### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -34,6 +34,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        type: string
 
 jobs:
   aks-e2e:
@@ -48,3 +52,4 @@ jobs:
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
+      runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -34,6 +34,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        type: string
 
 jobs:
   eks-e2e:
@@ -48,3 +52,4 @@ jobs:
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
+      runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -34,6 +34,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        type: string
 
 jobs:
   gke-e2e:
@@ -48,3 +52,4 @@ jobs:
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
+      runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,7 @@ jobs:
           echo -n ${{ github.repository }} \
             | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --data-file=-
 
-  installation:
+  installation-and-e2e-tests:
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     needs: create-runner
     outputs:
@@ -115,7 +115,14 @@ jobs:
           RANCHER_HOSTNAME: ${{steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
         run: |
           make prepare-e2e-ci-rancher
-            
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Install Azure cli
         run: |
           sudo zypper install -y azure-cli
@@ -140,107 +147,47 @@ jobs:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.EKS_REGION }}
-            
-  provisioning-tests:
-    if: ${{ github.event.inputs.run_p0_provisioning_tests == 'true' }}
-    needs: [create-runner, installation]
-    runs-on: ${{ needs.create-runner.outputs.uuid }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-            
+
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
 
       - name: Provisioning cluster tests
+        if:  ${{ github.event.inputs.run_p0_provisioning_tests == 'true' }}
         env:
-          RANCHER_HOSTNAME: ${{ needs.installation.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
         run: |
           make e2e-provisioning-tests
-            
-  importing-tests:
-    if: ${{ github.event.inputs.run_p0_importing_tests == 'true' }}
-    needs: [create-runner, installation]
-    runs-on: ${{ needs.create-runner.outputs.uuid }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-            
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-
-      - name: Authenticate to GCP
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ env.GCP_CREDENTIALS }}'
-                
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
 
       - name: Importing cluster tests
+        if: ${{ github.event.inputs.run_p0_importing_tests == 'true' }}
         env:
-          RANCHER_HOSTNAME: ${{ needs.installation.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
         run: |
           make e2e-import-tests
-            
-  support-matrix-provisioning-tests:
-    if: ${{ github.event.inputs.run_support_matrix_provisioning_tests == 'true' }}
-    needs: [create-runner, installation]
-    runs-on: ${{ needs.create-runner.outputs.uuid }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-            
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
 
       - name: Support matrix provisioning tests
+        if: ${{ github.event.inputs.run_support_matrix_provisioning_tests == 'true' }}
         env:
-          RANCHER_HOSTNAME: ${{ needs.installation.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
         run: |
           make e2e-support-matrix-provisioning-tests
 
-  support-matrix-importing-tests:
-    if: ${{ github.event.inputs.run_support_matrix_importing_tests == 'true' }}
-    needs: [create-runner, installation]
-    runs-on: ${{ needs.create-runner.outputs.uuid }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-            
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: go.mod
-
-      - name: Authenticate to GCP
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: '${{ env.GCP_CREDENTIALS }}'
-                  
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Support matrix importing tests
+        if: ${{ github.event.inputs.run_support_matrix_importing_tests == 'true' }}
         env:
-          RANCHER_HOSTNAME: ${{ needs.installation.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
         run: |
           make e2e-support-matrix-importing-tests
 
-
   delete-runner:
     if: ${{ always() && inputs.destroy_runner == true }}
-    needs: [create-runner, installation, provisioning-tests, importing-tests, support-matrix-provisioning-tests, support-matrix-importing-tests]
+    needs: [create-runner, installation-and-e2e-tests]
     runs-on: ubuntu-latest
     steps:
       # actions/checkout MUST come before auth


### PR DESCRIPTION
[GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7356019159)
[EKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7356018018)
[AKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7356016741)

All the above runs were triggered simultaneously, EKS-E2E failed.

Things that can be improved here is:
1. None of the 4 test steps must be dependent on each other, if one fails the others should continue to run.
2. The possibility to run all the 4 tests in parallel.