### PR TITLE
Use operator nightly charts for CI run

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -39,6 +39,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        type: string
 
 jobs:
   aks-e2e:
@@ -54,4 +58,4 @@ jobs:
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
-
+      runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -14,6 +14,11 @@ on:
         required: true
         type: string
         default: v1.26.10+k3s1
+      operator_nightly_chart:
+        description: Install hosted-provider nightly chart
+        default: true
+        required: true
+        type: boolean
       run_p0_provisioning_tests:
         required: true
         default: true
@@ -34,10 +39,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      runner_template:
-        description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
-        type: string
 
 jobs:
   aks-e2e:
@@ -47,9 +48,10 @@ jobs:
       hosted_provider: aks
       rancher_version: ${{ inputs.rancher_version }}
       k3s_version: ${{ inputs.k3s_version }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
       run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true }}
       run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template }}
+

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -14,6 +14,11 @@ on:
         required: true
         type: string
         default: v1.26.10+k3s1
+      operator_nightly_chart:
+        description: Install hosted-provider nightly chart
+        default: true
+        required: true
+        type: boolean
       run_p0_provisioning_tests:
         required: true
         default: true
@@ -34,10 +39,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      runner_template:
-        description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
-        type: string
 
 jobs:
   eks-e2e:
@@ -47,9 +48,10 @@ jobs:
       hosted_provider: eks
       rancher_version: ${{ inputs.rancher_version }}
       k3s_version: ${{ inputs.k3s_version }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
       run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true }}
       run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template }}
+

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -39,6 +39,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        type: string
 
 jobs:
   eks-e2e:
@@ -54,4 +58,5 @@ jobs:
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
+      runner_template: ${{ inputs.runner_template }}
 

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -40,6 +40,10 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        type: string
 
 jobs:
   gke-e2e:
@@ -55,4 +59,4 @@ jobs:
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
-
+      runner_template: ${{ inputs.runner_template }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -14,6 +14,12 @@ on:
         required: true
         type: string
         default: v1.26.10+k3s1
+      operator_nightly_chart:
+        description: Install hosted-provider nightly chart
+        # Until https://github.com/rancher/gke-operator/issues/137 is fixed
+        default: false
+        required: true
+        type: boolean
       run_p0_provisioning_tests:
         required: true
         default: true
@@ -34,10 +40,6 @@ on:
         description: Destroy the auto-generated self-hosted runner
         default: true
         type: boolean
-      runner_template:
-        description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
-        type: string
 
 jobs:
   gke-e2e:
@@ -47,9 +49,10 @@ jobs:
       hosted_provider: gke
       rancher_version: ${{ inputs.rancher_version }}
       k3s_version: ${{ inputs.k3s_version }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart == false }}
       run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true }}
       run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template }}
+

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,10 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
+      operator_nightly_chart:
+        description: Install hosted-provider nightly chart
+        required: true
+        type: boolean
       run_p0_provisioning_tests:
         required: true
         type: boolean
@@ -114,7 +118,11 @@ jobs:
           RANCHER_VERSION: ${{ inputs.rancher_version }}
           RANCHER_HOSTNAME: ${{steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
         run: |
-          make prepare-e2e-ci-rancher
+          if [ ${{ github.event.inputs.operator_nightly_chart }} == 'true' ]; then
+            make prepare-e2e-ci-rancher-hosted-nightly-chart
+          else
+            make prepare-e2e-ci-rancher
+          fi
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v1


### PR DESCRIPTION
### What does this PR do?
Added an option to run tests on operator nightly charts (default true)

### Checklist:
- [x] Squashed commits into logical changes
- [x] GitHub Actions
With nightly chart - https://github.com/rancher/hosted-providers-e2e/actions/runs/7385110621/job/20089259358
Without nightly chart - https://github.com/rancher/hosted-providers-e2e/actions/runs/7385864856/job/20091431266