### PR TITLE
Update all the workflow input with GCP Zone and move to geolocalized instance template

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -43,10 +43,7 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
-      zone:
-        description: GCP zone to host the runner
-        default: asia-south2-c
-        type: string
+
 jobs:
   aks-e2e:
     uses: ./.github/workflows/main.yaml
@@ -62,4 +59,3 @@ jobs:
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
       runner_template: ${{ inputs.runner_template }}
-      zone: ${{inputs.zone}}

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -45,7 +45,7 @@ on:
         type: string
       zone:
         description: GCP zone to host the runner
-        default: us-west1-b
+        default: asia-south2-c
         type: string
 jobs:
   aks-e2e:

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -41,7 +41,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
       zone:
         description: GCP zone to host the runner

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -43,7 +43,10 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
         type: string
-
+      zone:
+        description: GCP zone to host the runner
+        default: us-west1-b
+        type: string
 jobs:
   aks-e2e:
     uses: ./.github/workflows/main.yaml
@@ -59,3 +62,4 @@ jobs:
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
       runner_template: ${{ inputs.runner_template }}
+      zone: ${{inputs.zone}}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -43,10 +43,7 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
-      zone:
-        description: GCP zone to host the runner
-        default: asia-south2-c
-        type: string
+
 jobs:
   eks-e2e:
     uses: ./.github/workflows/main.yaml
@@ -62,4 +59,3 @@ jobs:
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
       runner_template: ${{ inputs.runner_template }}
-      zone: ${{inputs.zone}}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -41,11 +41,11 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
       zone:
         description: GCP zone to host the runner
-        default: us-west1-b
+        default: asia-south2-c
         type: string
 jobs:
   eks-e2e:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -43,7 +43,10 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
         type: string
-
+      zone:
+        description: GCP zone to host the runner
+        default: us-west1-b
+        type: string
 jobs:
   eks-e2e:
     uses: ./.github/workflows/main.yaml
@@ -59,4 +62,4 @@ jobs:
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
       runner_template: ${{ inputs.runner_template }}
-
+      zone: ${{inputs.zone}}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -42,11 +42,11 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
       zone:
         description: GCP zone to host the runner
-        default: us-west1-b
+        default: asia-south2-c
         type: string
 jobs:
   gke-e2e:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -44,10 +44,7 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
-      zone:
-        description: GCP zone to host the runner
-        default: asia-south2-c
-        type: string
+
 jobs:
   gke-e2e:
     uses: ./.github/workflows/main.yaml
@@ -63,4 +60,3 @@ jobs:
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
       runner_template: ${{ inputs.runner_template }}
-      zone: ${{inputs.zone}}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -44,7 +44,10 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
         type: string
-
+      zone:
+        description: GCP zone to host the runner
+        default: us-west1-b
+        type: string
 jobs:
   gke-e2e:
     uses: ./.github/workflows/main.yaml
@@ -60,3 +63,4 @@ jobs:
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
       runner_template: ${{ inputs.runner_template }}
+      zone: ${{inputs.zone}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,9 +84,10 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Create runner
         run: |
+          REGION=echo "${{ inputs.zone }}" | sed 's/-[abcdef]$//'
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --zone ${{ inputs.zone }} \
-            --source-instance-template ${{ inputs.runner_template }} &> /dev/null
+            --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }} &> /dev/null
       - name: Allow traffic
         run: |
           gcloud compute instances add-tags ${{ steps.generator.outputs.runner }} \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,11 +37,11 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-x86-64-template-n2-highmem-32-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
       zone:
         description: GCP zone to host the runner
-        default: us-west1-b
+        default: asia-south2-c
         type: string
 
 env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Create runner
         run: |
-          REGION=${{ inputs.zone }} | sed 's/-[abcdef]$//'
+          REGION=$(echo ${{ inputs.zone }} | sed 's/-[abcdef]$//')
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --zone ${{ inputs.zone }} \
             --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Create runner
         run: |
-          REGION=echo "${{ inputs.zone }}" | sed 's/-[abcdef]$//'
+          REGION=${{ inputs.zone }} | sed 's/-[abcdef]$//'
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --zone ${{ inputs.zone }} \
             --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }} &> /dev/null

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -87,7 +87,7 @@ jobs:
           REGION=${{ inputs.zone }} | sed 's/-[abcdef]$//'
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --zone ${{ inputs.zone }} \
-            --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }} &> /dev/null
+            --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }}
       - name: Allow traffic
         run: |
           gcloud compute instances add-tags ${{ steps.generator.outputs.runner }} \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,10 +39,6 @@ on:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
         type: string
-      zone:
-        description: GCP zone to host the runner
-        default: asia-south2-c
-        type: string
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -57,7 +53,7 @@ env:
   PROVIDER: ${{ inputs.hosted_provider }}
   RANCHER_PASSWORD: rancherpassword
   RANCHER_LOG_COLLECTOR: ${{ github.workspace }}/.github/scripts/collect-rancher-logs.sh
-        
+  GCP_RUNNER_ZONE: asia-south2-c
 jobs:
   create-runner:
     runs-on: ubuntu-latest
@@ -84,14 +80,14 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Create runner
         run: |
-          REGION=$(echo ${{ inputs.zone }} | sed 's/-[abcdef]$//')
+          REGION=$(echo ${{ env.GCP_RUNNER_ZONE }} | sed 's/-[abcdef]$//')
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
-            --zone ${{ inputs.zone }} \
+            --zone ${{ env.GCP_RUNNER_ZONE }} \
             --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }}
       - name: Allow traffic
         run: |
           gcloud compute instances add-tags ${{ steps.generator.outputs.runner }} \
-            --tags http-server,https-server --zone ${{ inputs.zone }}
+            --tags http-server,https-server --zone ${{ env.GCP_RUNNER_ZONE }}
       - name: Create GCP secrets
         run: |
           echo -n ${{ secrets.PAT_TOKEN }} \
@@ -230,4 +226,4 @@ jobs:
         run: |
           gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \
             --delete-disks all \
-            --zone ${{ inputs.zone }}
+            --zone ${{ env.GCP_RUNNER_ZONE }}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,32 @@ To run AKS:
 Run `make help` to know about other targets.
 
 ### Example
+**GKE Provisioning Tests**
 ```shell
-PROVIDER=gke RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/config make e2e-provisioning-tests
+GKE_PROJECT_ID=some-project GCP_CREDENTIALS=<credentials-json> PROVIDER=gke RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com RANCHER_PASSWORD=admin123 CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/cattle-config-provisioning.yaml make e2e-provisioning-tests
+```
+
+**GKE Import Tests**
+```shell
+GKE_PROJECT_ID=some-project GCP_CREDENTIALS=<credentials-json> PROVIDER=gke RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com RANCHER_PASSWORD=admin123 CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/cattle-config-import.yaml make e2e-import-tests
+```
+
+**EKS Provisioning Tests**
+```shell
+EKS_REGION=ap-south-1 AWS_ACCESS_KEY_ID=<key-id> AWS_SECRET_ACCESS_KEY=<key> PROVIDER=eks RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com RANCHER_PASSWORD=admin123 CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/cattle-config-provisioning.yaml make e2e-provisioning-tests
+```
+
+**EKS Import Tests**
+```shell
+EKS_REGION=ap-south-1 AWS_ACCESS_KEY_ID=<key-id> AWS_SECRET_ACCESS_KEY=<key> PROVIDER=eks RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com RANCHER_PASSWORD=admin123 CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/cattle-config-import.yaml make e2e-import-tests
+```
+
+**AKS Provisioning Tests**
+```shell
+AKS_REGION=centralindia AKS_CLIENT_ID=<client-id> AKS_CLIENT_SECRET=<secret> AKS_SUBSCRIPTION_ID=<subscription-id> PROVIDER=aks RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com RANCHER_PASSWORD=admin123 CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/cattle-config-provisioning.yaml make e2e-provisioning-tests
+```
+
+**AKS Import Tests**
+```shell
+AKS_REGION=centralindia AKS_CLIENT_ID=<client-id> AKS_CLIENT_SECRET=<secret> AKS_SUBSCRIPTION_ID=<subscription-id> PROVIDER=aks RANCHER_HOSTNAME=ec2-1-2-3-4.ap-south-1.compute.amazonaws.com RANCHER_PASSWORD=admin123 CATTLE_TEST_CONFIG=/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/gke/cattle-config-import.yaml make e2e-import-tests
 ```

--- a/README.md
+++ b/README.md
@@ -21,26 +21,27 @@ To run GKE:
    - Project: Viewer (roles/viewer)
    - Kubernetes Engine: Kubernetes Engine Admin (roles/container.admin)
    - Service Accounts: Service Account User (roles/iam.serviceAccountUser)
-
 2. GKE_PROJECT_ID - Name of the Google Cloud Project
+3. GKE_ZONE - Zone in which GKE must be provisioned (default: 'asia-south2-c'). This environment variable takes precedence over the config file variable.
 
 To run EKS:
 1. AWS_ACCESS_KEY_ID - AWS Access Key
 2. AWS_SECRET_ACCESS_KEY - AWS Secret Key
-3. EKS_REGION - Default Region (default: us-west-2)
+3. EKS_REGION - Region in which EKS must be provisioned (default: 'ap-south-1'). This environment variable takes precedence over the config file variable.
 
 To run AKS:
 1. AKS_CLIENT_ID - Azure Client ID [Check Microsoft Entra ID to create or fetch value from an existing one](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)
 2. AKS_CLIENT_SECRET - Azure Client Secret [Check Microsoft Entra ID to create or fetch value from an existing one](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)
 3. AKS_SUBSCRIPTION_ID - Azure Subscription ID (In this case it is similar to a Google Cloud Project, but the value is an ID). [Check Azure Subscriptions](https://learn.microsoft.com/en-us/microsoft-365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings?view=o365-worldwide#subscriptions)
+4. AKS_REGION - Region in which AKS must be provisioned (default: 'centralindia'). This environment variable takes precedence over the config file variable.
 
-
+**Note:** It is advisable that all the Hosted Provider cluster be provisioned in APAC region, this is because we want to geolocalize all the resources created by hosted provider.
 
 ### Makefile targets to run tests
-1. `make e2e-provisioning-tests` - Covers the _P0Provisioning_ test suite for a given ${PROVIDER}
-2. `make e2e-import-tests` - Covers the _P0Importing_ test suite for a given ${PROVIDER}
-3. `make e2e-support-matrix-importing-tests` - Covers the _SupportMatrixImporting_ test suite for a given ${PROVIDER}
-4. `make e2e-support-matrix-provisioning-tests` - Covers the _SupportMatrixProvisioning_ test suite for a given ${PROVIDER}
+1. `make e2e-provisioning-tests` - Covers the _P0Provisioning_ test suite for a given `${PROVIDER}`
+2. `make e2e-import-tests` - Covers the _P0Importing_ test suite for a given `${PROVIDER}`
+3. `make e2e-support-matrix-importing-tests` - Covers the _SupportMatrixImporting_ test suite for a given `${PROVIDER}`
+4. `make e2e-support-matrix-provisioning-tests` - Covers the _SupportMatrixProvisioning_ test suite for a given `${PROVIDER}`
 
 Run `make help` to know about other targets.
 

--- a/cattle-config-import.yaml
+++ b/cattle-config-import.yaml
@@ -42,7 +42,7 @@ eksClusterConfig:
   region: ca-central-1
 gkeClusterConfig:
   projectID: <project>
-  zone: us-central1-c
+  zone: asia-south2-c
   imported: true
   nodePools:
   - autoscaling: {}

--- a/cattle-config-import.yaml
+++ b/cattle-config-import.yaml
@@ -15,7 +15,7 @@ aksClusterConfig:
     osType: Linux
     vmSize: Standard_DS2_v2
   resourceGroup: ""
-  resourceLocation:  centralindia
+  resourceLocation: centralindia
 awsCredentials:
 azureCredentials:
   environment: AzurePublicCloud

--- a/cattle-config-import.yaml
+++ b/cattle-config-import.yaml
@@ -15,7 +15,7 @@ aksClusterConfig:
     osType: Linux
     vmSize: Standard_DS2_v2
   resourceGroup: ""
-  resourceLocation: eastus
+  resourceLocation:  centralindia
 awsCredentials:
 azureCredentials:
   environment: AzurePublicCloud
@@ -39,7 +39,7 @@ eksClusterConfig:
     subnets: []
     tags: {}
     userData: ""
-  region: ca-central-1
+  region: ap-south-1
 gkeClusterConfig:
   projectID: <project>
   zone: asia-south2-c

--- a/cattle-config-provisioning.yaml
+++ b/cattle-config-provisioning.yaml
@@ -21,8 +21,8 @@ aksClusterConfig:
     vmSize: Standard_DS2_v2
   privateCluster: false
   resourceGroup: ""
-  resourceLocation: eastus
-  tags: {}
+  resourceLocation: centralindia
+tags: {}
 awsCredentials:
 azureCredentials:
   environment: AzurePublicCloud

--- a/cattle-config-provisioning.yaml
+++ b/cattle-config-provisioning.yaml
@@ -51,7 +51,7 @@ eksClusterConfig:
   privateAccess: false
   publicAccess: true
   publicAccessSources: []
-  region: us-east-2
+  region: ap-south-1
   secretsEncryption: false
   securityGroups: []
   serviceRole: ""
@@ -120,7 +120,7 @@ gkeClusterConfig:
     masterIpv4CidrBlock: ""
   region: ""
   subnetwork: default
-  zone: us-central1-c
+  zone: asia-south2-c
   projectID: <project>
 googleCredentials:
 rancher:

--- a/hosted/aks/p0/p0_importing_test.go
+++ b/hosted/aks/p0/p0_importing_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 var _ = Describe("P0Importing", func() {
-
+	var (
+		location = helpers.GetAKSLocation()
+	)
 	When("a cluster is imported", func() {
 		var cluster *management.Cluster
 

--- a/hosted/aks/p0/p0_suite_test.go
+++ b/hosted/aks/p0/p0_suite_test.go
@@ -12,7 +12,7 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	location    = "centralindia"
+	location    = helpers.GetAKSLocation()
 	k8sVersion  = "1.26.6"
 	increaseBy  = 1
 )

--- a/hosted/aks/p0/p0_suite_test.go
+++ b/hosted/aks/p0/p0_suite_test.go
@@ -12,7 +12,7 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	location    = "eastus"
+	location    = "centralindia"
 	k8sVersion  = "1.26.6"
 	increaseBy  = 1
 )

--- a/hosted/aks/p0/p0_suite_test.go
+++ b/hosted/aks/p0/p0_suite_test.go
@@ -12,7 +12,6 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	location    = helpers.GetAKSLocation()
 	k8sVersion  = "1.26.6"
 	increaseBy  = 1
 )

--- a/hosted/aks/support_matrix/support_matrix_importing_test.go
+++ b/hosted/aks/support_matrix/support_matrix_importing_test.go
@@ -1,10 +1,9 @@
 package support_matrix_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"fmt"
 
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
@@ -26,7 +25,7 @@ var _ = Describe("SupportMatrixImporting", func() {
 		When(fmt.Sprintf("a cluster is created with kubernetes version %s", version), func() {
 			var (
 				clusterName string
-				location    = "eastus"
+				location    = "centralindia"
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {

--- a/hosted/aks/support_matrix/support_matrix_importing_test.go
+++ b/hosted/aks/support_matrix/support_matrix_importing_test.go
@@ -25,7 +25,6 @@ var _ = Describe("SupportMatrixImporting", func() {
 		When(fmt.Sprintf("a cluster is created with kubernetes version %s", version), func() {
 			var (
 				clusterName string
-				location    = "centralindia"
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {

--- a/hosted/aks/support_matrix/support_matrix_suite_test.go
+++ b/hosted/aks/support_matrix/support_matrix_suite_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	availableVersionList []string
 	ctx                  helpers.Context
+	location             = helpers.GetAKSLocation()
 )
 
 func TestSupportMatrix(t *testing.T) {
@@ -20,7 +21,7 @@ func TestSupportMatrix(t *testing.T) {
 	var err error
 	ctx, err = helpers.CommonBeforeSuite("aks")
 	Expect(err).To(BeNil())
-	availableVersionList, err = helper.ListSingleVariantAKSAvailableVersions(ctx.RancherClient, ctx.CloudCred.ID, "eastus")
+	availableVersionList, err = helper.ListSingleVariantAKSAvailableVersions(ctx.RancherClient, ctx.CloudCred.ID, location)
 	Expect(err).To(BeNil())
 	RunSpecs(t, "SupportMatrix Suite")
 }

--- a/hosted/eks/p0/p0_importing_test.go
+++ b/hosted/eks/p0/p0_importing_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 var _ = Describe("P0Importing", func() {
-	var cluster *management.Cluster
+	var (
+		cluster *management.Cluster
+		region  = helpers.GetEKSRegion()
+	)
 
 	When("a cluster is imported", func() {
 

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -1,7 +1,6 @@
 package p0_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,7 +12,7 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	region      = os.Getenv("EKS_REGION")
+	region      = helpers.GetEKSLocation()
 	k8sVersion  = "1.26"
 	increaseBy  = 1
 )

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -12,7 +12,6 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	region      = helpers.GetEKSLocation()
 	k8sVersion  = "1.26"
 	increaseBy  = 1
 )

--- a/hosted/eks/support_matrix/support_matrix_importing_test.go
+++ b/hosted/eks/support_matrix/support_matrix_importing_test.go
@@ -1,8 +1,6 @@
 package support_matrix_test
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -26,7 +24,6 @@ var _ = Describe("SupportMatrixImporting", func() {
 		When(fmt.Sprintf("a cluster is created with kubernetes version %s", version), func() {
 			var (
 				clusterName string
-				region      = os.Getenv("EKS_REGION")
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {

--- a/hosted/eks/support_matrix/support_matrix_suite_test.go
+++ b/hosted/eks/support_matrix/support_matrix_suite_test.go
@@ -13,7 +13,7 @@ import (
 var (
 	availableVersionList []string
 	ctx                  helpers.Context
-	region               = helpers.GetEKSLocation()
+	region               = helpers.GetEKSRegion()
 )
 
 func TestSupportMatrix(t *testing.T) {

--- a/hosted/eks/support_matrix/support_matrix_suite_test.go
+++ b/hosted/eks/support_matrix/support_matrix_suite_test.go
@@ -13,6 +13,7 @@ import (
 var (
 	availableVersionList []string
 	ctx                  helpers.Context
+	region               = helpers.GetEKSLocation()
 )
 
 func TestSupportMatrix(t *testing.T) {

--- a/hosted/gke/p0/p0_importing_test.go
+++ b/hosted/gke/p0/p0_importing_test.go
@@ -8,26 +8,23 @@ import (
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
-	"github.com/rancher/rancher/tests/framework/extensions/clusters/gke"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
-	"github.com/rancher/rancher/tests/framework/pkg/config"
 )
 
 var _ = Describe("P0Importing", func() {
+	var (
+		zone = helpers.GetGKEZone()
+	)
 
 	When("a cluster is created", func() {
 		var cluster *management.Cluster
 
 		BeforeEach(func() {
 			var err error
-			err = helper.CreateGKEClusterOnGCloud(zone, clusterName, project, k8sVersion)
+			err = helper.CreateGKEClusterOnGCloud(zone, clusterName, helpers.GetGKEProjectID(), k8sVersion)
 			Expect(err).To(BeNil())
 
-			gkeConfig := new(helper.ImportClusterConfig)
-			config.LoadAndUpdateConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig, func() {
-				gkeConfig.ProjectID = project
-			})
 			cluster, err = helper.ImportGKEHostedCluster(ctx.RancherClient, clusterName, ctx.CloudCred.ID, false, false, false, false, map[string]string{})
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -4,15 +4,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/rancher/hosted-providers-e2e/hosted/gke/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters"
 	"github.com/rancher/rancher/tests/framework/extensions/clusters/gke"
 	nodestat "github.com/rancher/rancher/tests/framework/extensions/nodes"
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
-	"github.com/rancher/rancher/tests/framework/pkg/config"
-
-	"github.com/rancher/hosted-providers-e2e/hosted/gke/helper"
-	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
 var _ = Describe("P0Provisioning", func() {
@@ -22,11 +20,6 @@ var _ = Describe("P0Provisioning", func() {
 
 		BeforeEach(func() {
 			var err error
-			gkeConfig := new(management.GKEClusterConfigSpec)
-			config.LoadAndUpdateConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig, func() {
-				gkeConfig.ProjectID = project
-			})
-
 			cluster, err = gke.CreateGKEHostedCluster(ctx.RancherClient, clusterName, ctx.CloudCred.ID, false, false, false, false, map[string]string{})
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -13,7 +13,7 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	zone        = "us-central1-c"
+	zone        = "asia-south2-c"
 	project     = os.Getenv("GKE_PROJECT_ID")
 	k8sVersion  = "1.27.4-gke.900"
 	increaseBy  = 1

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -1,7 +1,6 @@
 package p0_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,8 +12,6 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	zone        = helpers.GetGKEZone()
-	project     = os.Getenv("GKE_PROJECT_ID")
 	k8sVersion  = "1.27.4-gke.900"
 	increaseBy  = 1
 )

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -13,7 +13,7 @@ import (
 var (
 	ctx         helpers.Context
 	clusterName string
-	zone        = "asia-south2-c"
+	zone        = helpers.GetGKEZone()
 	project     = os.Getenv("GKE_PROJECT_ID")
 	k8sVersion  = "1.27.4-gke.900"
 	increaseBy  = 1

--- a/hosted/gke/support_matrix/support_matrix_importing_test.go
+++ b/hosted/gke/support_matrix/support_matrix_importing_test.go
@@ -1,8 +1,6 @@
 package support_matrix_test
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -29,8 +27,6 @@ var _ = Describe("SupportMatrixImporting", func() {
 			var (
 				clusterName string
 				cluster     *management.Cluster
-				project     = os.Getenv("GKE_PROJECT_ID")
-				zone        = "asia-south2-c"
 			)
 			BeforeEach(func() {
 				clusterName = namegen.AppendRandomString("gkehostcluster")

--- a/hosted/gke/support_matrix/support_matrix_importing_test.go
+++ b/hosted/gke/support_matrix/support_matrix_importing_test.go
@@ -30,7 +30,7 @@ var _ = Describe("SupportMatrixImporting", func() {
 				clusterName string
 				cluster     *management.Cluster
 				project     = os.Getenv("GKE_PROJECT_ID")
-				zone        = "us-central1-c"
+				zone        = "asia-south2-c"
 			)
 			BeforeEach(func() {
 				clusterName = namegen.AppendRandomString("gkehostcluster")

--- a/hosted/gke/support_matrix/support_matrix_provisioning_test.go
+++ b/hosted/gke/support_matrix/support_matrix_provisioning_test.go
@@ -1,8 +1,6 @@
 package support_matrix_test
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -31,7 +29,6 @@ var _ = Describe("SupportMatrixProvisioning", func() {
 			var (
 				clusterName string
 				cluster     *management.Cluster
-				project     = os.Getenv("GKE_PROJECT_ID")
 			)
 			BeforeEach(func() {
 				clusterName = namegen.AppendRandomString("gkehostcluster")

--- a/hosted/gke/support_matrix/support_matrix_suite_test.go
+++ b/hosted/gke/support_matrix/support_matrix_suite_test.go
@@ -16,6 +16,7 @@ var (
 	availableVersionList []string
 	ctx                  helpers.Context
 	project              = os.Getenv("GKE_PROJECT_ID")
+	zone                 = helpers.GetGKEZone()
 )
 
 func TestSupportMatrix(t *testing.T) {
@@ -23,7 +24,7 @@ func TestSupportMatrix(t *testing.T) {
 	var err error
 	ctx, err = helpers.CommonBeforeSuite("gke")
 	Expect(err).To(BeNil())
-	availableVersionList, err = helper.ListSingleVariantGKEAvailableVersions(ctx.RancherClient, project, ctx.CloudCred.ID, "", "us-central1")
+	availableVersionList, err = helper.ListSingleVariantGKEAvailableVersions(ctx.RancherClient, project, ctx.CloudCred.ID, zone, "")
 	Expect(err).To(BeNil())
 	RunSpecs(t, "SupportMatrix Suite")
 }


### PR DESCRIPTION
### What does this PR do?
This PR adds GCP Zone for running runner in the hosted providers workflow templates so that it is easier to test geolocalized templates and have an option to instantiate the runner in any other region.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)
       ~1. https://github.com/rancher/hosted-providers-e2e/actions/runs/7395629941/job/20119191235~
       ~2. [EKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7395954958)~
       ~3. [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7395952783)~
    1. [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7446950908)
    2. [EKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7446949481)
    3. [AKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7446947195)


### Special notes for your reviewer:
