### PR TITLE
Fix AKS cluster config issue

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/aks"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -190,7 +191,7 @@ func ImportAKSHostedCluster(client *rancher.Client, displayName, cloudCredential
 
 func AksHostClusterConfig(displayName, cloudCredentialID string) *management.AKSClusterConfigSpec {
 	var aksClusterConfig ImportClusterConfig
-	config.LoadConfig("aksClusterConfig", &aksClusterConfig)
+	config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &aksClusterConfig)
 
 	return &management.AKSClusterConfigSpec{
 		AzureCredentialSecret: cloudCredentialID,
@@ -203,7 +204,7 @@ func AksHostClusterConfig(displayName, cloudCredentialID string) *management.AKS
 
 func AksHostNodeConfig() []management.AKSNodePool {
 	var nodeConfig management.AKSClusterConfigSpec
-	config.LoadConfig("aksClusterConfig", &nodeConfig)
+	config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &nodeConfig)
 
 	return nodeConfig.NodePools
 }

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/eks"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
@@ -169,7 +170,7 @@ func ImportEKSHostedCluster(client *rancher.Client, displayName, cloudCredential
 
 func EksHostClusterConfig(displayName, cloudCredentialID string) *management.EKSClusterConfigSpec {
 	var eksClusterConfig ImportClusterConfig
-	config.LoadConfig("eksClusterConfig", &eksClusterConfig)
+	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
 
 	return &management.EKSClusterConfigSpec{
 		AmazonCredentialSecret: cloudCredentialID,
@@ -180,8 +181,9 @@ func EksHostClusterConfig(displayName, cloudCredentialID string) *management.EKS
 }
 
 func EksHostNodeConfig() []management.NodeGroup {
+	// TODO(pvala): should eks.ClusterConfig be used instead
 	var nodeConfig management.EKSClusterConfigSpec
-	config.LoadConfig("eksClusterConfig", &nodeConfig)
+	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &nodeConfig)
 
 	return nodeConfig.NodeGroups
 }

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/gke"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -178,7 +179,7 @@ func ImportGKEHostedCluster(client *rancher.Client, displayName, cloudCredential
 
 func GkeHostClusterConfig(displayName, cloudCredentialID string) *management.GKEClusterConfigSpec {
 	var gkeClusterConfig ImportClusterConfig
-	config.LoadConfig("gkeClusterConfig", &gkeClusterConfig)
+	config.LoadConfig(gke.GKEClusterConfigConfigurationFileKey, &gkeClusterConfig)
 
 	return &management.GKEClusterConfigSpec{
 		GoogleCredentialSecret: cloudCredentialID,
@@ -190,8 +191,9 @@ func GkeHostClusterConfig(displayName, cloudCredentialID string) *management.GKE
 }
 
 func GkeHostNodeConfig() []management.GKENodePoolConfig {
+	// TODO(pvala): Should gke.ClusterConfig be used instead
 	var nodeConfig management.GKEClusterConfigSpec
-	config.LoadConfig("gkeClusterConfig", &nodeConfig)
+	config.LoadConfig(gke.GKEClusterConfigConfigurationFileKey, &nodeConfig)
 
 	return nodeConfig.NodePools
 }


### PR DESCRIPTION
### What does this PR do?
This PR fixes issues introduced in PR #19, one of which was the inability to create AKS cluster where it failed to read the nodecount.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
Verified this locally, the aks cluster is created.