### PR TITLE
Fix the invalid AKS cluster config key and GH action input for scheduled workflows

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -15,7 +15,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.26.10+k3s1
+        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
@@ -52,12 +52,12 @@ jobs:
     secrets: inherit
     with:
       hosted_provider: aks
-      rancher_version: ${{ inputs.rancher_version }}
-      k3s_version: ${{ inputs.k3s_version }}
-      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
-      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true }}
-      run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true }}
+      rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || github.event_name == 'schedule' && true }}
+      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || github.event_name == 'schedule' && true }}
+      run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true || github.event_name == 'schedule' && true }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
-      destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template }}
+      destroy_runner: ${{ inputs.destroy_runner == true || github.event_name == 'schedule' && true }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -15,7 +15,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.26.10+k3s1
+        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
@@ -52,12 +52,12 @@ jobs:
     secrets: inherit
     with:
       hosted_provider: eks
-      rancher_version: ${{ inputs.rancher_version }}
-      k3s_version: ${{ inputs.k3s_version }}
-      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
-      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true }}
-      run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true }}
+      rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || github.event_name == 'schedule' && true }}
+      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || github.event_name == 'schedule' && true }}
+      run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true || github.event_name == 'schedule' && true }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
-      destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template }}
+      destroy_runner: ${{ inputs.destroy_runner == true || github.event_name == 'schedule' && true }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -15,7 +15,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.26.10+k3s1
+        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         # Until https://github.com/rancher/gke-operator/issues/137 is fixed
@@ -53,12 +53,12 @@ jobs:
     secrets: inherit
     with:
       hosted_provider: gke
-      rancher_version: ${{ inputs.rancher_version }}
-      k3s_version: ${{ inputs.k3s_version }}
+      rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == false }}
-      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true }}
-      run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true }}
+      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || github.event_name == 'schedule' && true }}
+      run_p0_importing_tests: ${{ inputs.run_p0_imorting_tests == true || github.event_name == 'schedule' && true }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true }}
-      destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template }}
+      destroy_runner: ${{ inputs.destroy_runner == true || github.event_name == 'schedule' && true }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,7 +37,7 @@ on:
         type: boolean
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
+        required: true
         type: string
 
 env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -135,7 +135,7 @@ jobs:
           pip install azure-cli
             
       - name: Login to Azure
-        uses: azure/login@v1
+        uses: azure/login@v1.5.1
         with:
           creds: '{"clientId":"${{ env.AKS_CLIENT_ID }}","clientSecret":"${{ env.AKS_CLIENT_SECRET }}","subscriptionId":"${{ env.AKS_SUBSCRIPTION_ID }}","tenantId":"${{ env.AKS_TENANT_ID }}"}'
 

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/aks"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -190,7 +191,7 @@ func ImportAKSHostedCluster(client *rancher.Client, displayName, cloudCredential
 
 func AksHostClusterConfig(displayName, cloudCredentialID string) *management.AKSClusterConfigSpec {
 	var aksClusterConfig ImportClusterConfig
-	config.LoadConfig("aksClusterConfig", &aksClusterConfig)
+	config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &aksClusterConfig)
 
 	return &management.AKSClusterConfigSpec{
 		AzureCredentialSecret: cloudCredentialID,
@@ -203,7 +204,7 @@ func AksHostClusterConfig(displayName, cloudCredentialID string) *management.AKS
 
 func AksHostNodeConfig() []management.AKSNodePool {
 	var nodeConfig management.AKSClusterConfigSpec
-	config.LoadConfig("aksClusterConfig", &nodeConfig)
+	config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, &nodeConfig)
 
 	return nodeConfig.NodePools
 }

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/eks"
 
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
 	management "github.com/rancher/rancher/tests/framework/clients/rancher/generated/management/v3"
@@ -169,7 +170,7 @@ func ImportEKSHostedCluster(client *rancher.Client, displayName, cloudCredential
 
 func EksHostClusterConfig(displayName, cloudCredentialID string) *management.EKSClusterConfigSpec {
 	var eksClusterConfig ImportClusterConfig
-	config.LoadConfig("eksClusterConfig", &eksClusterConfig)
+	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
 
 	return &management.EKSClusterConfigSpec{
 		AmazonCredentialSecret: cloudCredentialID,
@@ -180,8 +181,9 @@ func EksHostClusterConfig(displayName, cloudCredentialID string) *management.EKS
 }
 
 func EksHostNodeConfig() []management.NodeGroup {
+	// TODO(pvala): should eks.ClusterConfig be used instead
 	var nodeConfig management.EKSClusterConfigSpec
-	config.LoadConfig("eksClusterConfig", &nodeConfig)
+	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &nodeConfig)
 
 	return nodeConfig.NodeGroups
 }

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"github.com/rancher/rancher/tests/framework/extensions/clusters/gke"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/rancher/rancher/tests/framework/clients/rancher"
@@ -178,7 +179,7 @@ func ImportGKEHostedCluster(client *rancher.Client, displayName, cloudCredential
 
 func GkeHostClusterConfig(displayName, cloudCredentialID string) *management.GKEClusterConfigSpec {
 	var gkeClusterConfig ImportClusterConfig
-	config.LoadConfig("gkeClusterConfig", &gkeClusterConfig)
+	config.LoadConfig(gke.GKEClusterConfigConfigurationFileKey, &gkeClusterConfig)
 
 	return &management.GKEClusterConfigSpec{
 		GoogleCredentialSecret: cloudCredentialID,
@@ -190,8 +191,9 @@ func GkeHostClusterConfig(displayName, cloudCredentialID string) *management.GKE
 }
 
 func GkeHostNodeConfig() []management.GKENodePoolConfig {
+	// TODO(pvala): Should gke.ClusterConfig be used instead
 	var nodeConfig management.GKEClusterConfigSpec
-	config.LoadConfig("gkeClusterConfig", &nodeConfig)
+	config.LoadConfig(gke.GKEClusterConfigConfigurationFileKey, &nodeConfig)
 
 	return nodeConfig.NodePools
 }


### PR DESCRIPTION
### What does this PR do?
This PR fixes:
1. Replace invalid `azureClusterConfig` with constant from aks and replace other strings with their respective constants. Ref: 571014f56380418caaadd5e6c28fb5f154111f0e
2. Replace the `management.*ConfigSpec` with provider specific Configs. Ref: 571014f56380418caaadd5e6c28fb5f154111f0e
3. Pass valid GH action input for scheduled workflow. 046aca9f14cb75df64c4a5460eaad7a8a1684461

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
