### PR TITLE
Fix Imported GKE and EKS not getting deleted on user interrupt

### DIFF
--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -155,7 +155,7 @@ func CreateEKSClusterOnAWS(eks_region string, clusterName string, k8sVersion str
 func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
 
 	fmt.Println("Deleting EKS cluster ...")
-	args := []string{"delete", "cluster", "--region=" + eks_region, "--name=" + clusterName}
+	args := []string{"delete", "cluster", "--region=" + eks_region, "--name=" + clusterName, "--disable-nodegroup-eviction"}
 	fmt.Printf("Running command: eksctl %v\n", args)
 	out, err := proc.RunW("eksctl", args...)
 	if err != nil {

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -163,10 +163,10 @@ func CreateGKEClusterOnGCloud(zone string, clusterName string, project string, k
 }
 
 // Complete cleanup steps for Google GKE
-func DeleteGKEClusterOnGCloud(zone string, clusterName string) error {
+func DeleteGKEClusterOnGCloud(zone, project, clusterName string) error {
 
 	fmt.Println("Deleting GKE cluster ...")
-	args := []string{"container", "clusters", "delete", clusterName, "--zone", zone, "--quiet"}
+	args := []string{"container", "clusters", "delete", clusterName, "--zone", zone, "--quiet", "--project", project}
 	fmt.Printf("Running command: gcloud %v\n", args)
 	out, err := proc.RunW("gcloud", args...)
 	if err != nil {

--- a/hosted/gke/p0/p0_importing_test.go
+++ b/hosted/gke/p0/p0_importing_test.go
@@ -41,7 +41,7 @@ var _ = Describe("P0Importing", func() {
 		AfterEach(func() {
 			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherClient)
 			Expect(err).To(BeNil())
-			err = helper.DeleteGKEClusterOnGCloud(zone, clusterName)
+			err = helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
 			Expect(err).To(BeNil())
 		})
 

--- a/hosted/gke/support_matrix/support_matrix_importing_test.go
+++ b/hosted/gke/support_matrix/support_matrix_importing_test.go
@@ -49,7 +49,7 @@ var _ = Describe("SupportMatrixImporting", func() {
 			AfterEach(func() {
 				err := helper.DeleteGKEHostCluster(cluster, ctx.RancherClient)
 				Expect(err).To(BeNil())
-				err = helper.DeleteGKEClusterOnGCloud(zone, clusterName)
+				err = helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
 				Expect(err).To(BeNil())
 			})
 			It("should successfully import the cluster", func() {


### PR DESCRIPTION
### What does this PR do?
This PR attempts to fix GKE and EKS not getting deleted on user interrupt.

This PR also adds a `--project` flag to GKE deletion, this ensures when running the test locally with a multi project setup, correct project is used.
I faced this issue locally, where my `gcloud` was configured to use project-2, but since my test config used `project-1`, the test created GKE on `project-1`. While deleting GKE, the `gcloud` used `project-2` because we did not explicitly pass a project, and since it did not find the resource to delete, the test failed.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)
    1. [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7639263489)

### Special notes for your reviewer:
