### PR TITLE
Update GH action plugins to fix Node.js 16 deprecation warnings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -73,11 +73,11 @@ jobs:
           echo "uuid=${UUID//-}" >> ${GITHUB_OUTPUT}
           echo "runner=${GH_REPO//\//-}-ci-${UUID//-}" >> ${GITHUB_OUTPUT}
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
       - name: Create runner
         run: |
           REGION=$(echo ${{ env.GCP_RUNNER_ZONE }} | sed 's/-[abcdef]$//')
@@ -123,11 +123,11 @@ jobs:
           fi
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Install Azure cli
         run: |
@@ -155,7 +155,7 @@ jobs:
           aws-region: ${{ env.EKS_REGION }}
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -199,7 +199,7 @@ jobs:
 
       - name: Upload cluster logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: support-logs
           path: ${{ github.workspace }}/logs/*
@@ -214,11 +214,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
       - name: Delete PAT token secret
         run: |
           gcloud --quiet secrets delete PAT_TOKEN_${{ needs.create-runner.outputs.uuid }}


### PR DESCRIPTION
### What does this PR do?
1. Update GH actions: google-github-actions/auth, google-github-actions/setup-gcloud to v2 to fix warnings related to nodejs16.
2. Update GH action: azure/login to v1 since https://github.com/Azure/login/issues/403 has been fixed.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #45 

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)
    1. [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7709027588)
    2. [GKE-E2E-2](https://github.com/rancher/hosted-providers-e2e/actions/runs/7710091749)
    3. [GKE-E2E-3](https://github.com/rancher/hosted-providers-e2e/actions/runs/7722722175) - this job has failed but there are no Node.js 16 warnings from any actions except azure/login (see: https://github.com/Azure/login/issues/413)

### Special notes for your reviewer:
