### PR TITLE
Use default k8s version provided by GKE

### DIFF
--- a/cattle-config-import.yaml
+++ b/cattle-config-import.yaml
@@ -63,7 +63,7 @@ gkeClusterConfig:
       autoRepair: true
       autoUpgrade: true
     maxPodsConstraint: 110
-    version: 1.27.4-gke.900
+    version: 1.27.3-gke.100
 googleCredentials:
 rancher:
   cleanup: false

--- a/cattle-config-provisioning.yaml
+++ b/cattle-config-provisioning.yaml
@@ -73,7 +73,7 @@ gkeClusterConfig:
     servicesSecondaryRangeName: ""
     subnetworkName: ""
     useIpAliases: true
-  kubernetesVersion: 1.27.4-gke.900
+  kubernetesVersion: 1.27.3-gke.100
   labels:
     owner: hosted-provider-ci
   locations: []
@@ -113,7 +113,7 @@ gkeClusterConfig:
       autoUpgrade: true
     maxPodsConstraint: 110
     name: default-pool
-    version: 1.27.4-gke.900
+    version: 1.27.3-gke.100
   privateClusterConfig:
     enablePrivateEndpoint: false
     enablePrivateNodes: false

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	k8sVersion = "1.27.4-gke.900"
+	k8sVersion = "1.27.3-gke.100"
 	increaseBy = 1
 )
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes GKE tests failing due to unavailable version. Currently we use `1.27.4-gke.900` which has become unavailable.

![Screenshot from 2024-01-31 15-03-02](https://github.com/rancher/hosted-providers-e2e/assets/11015077/af865c62-6903-40e1-9793-40c2a0e86a30)

Excerpt of gke-operator pod logs:
```yaml
time="2024-01-31T07:51:01Z" level=error msg="error syncing 'cattle-global-data/c-hgflj': handler gke-controller: googleapi: Error 400: Master version \"1.27.4-gke.900\" is unsupported.\nDetails:\n[\n  {\n    \"@type\": \"type.googleapis.com/google.rpc.RequestInfo\",\n    \"requestId\": \"0x80de9c07e8bffe0a\"\n  }\n]\n, badRequest, requeuing"
```

Failing Action: https://github.com/rancher/hosted-providers-e2e/actions/runs/7721123412/job/21047171556
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)
    1. [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7723967956)

### Special notes for your reviewer:
