### PR TITLE
Fix GKE tests when upgrading a major version and add custom workflow run-name to all the workflows

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
+run-name: AKS ${{ inputs.downstream_k8s_version }} on Rancher v${{ inputs.rancher_version }} deployed on ${{ inputs.k3s_version}}
 
 on:
   schedule:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
+run-name: EKS ${{ inputs.downstream_k8s_version }} on Rancher v${{ inputs.rancher_version }} deployed on ${{ inputs.k3s_version}}
 
 on:
   schedule:

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
+run-name: GKE ${{ inputs.downstream_k8s_version }} on Rancher v${{ inputs.rancher_version }} deployed on ${{ inputs.k3s_version}}
 
 on:
   schedule:
@@ -48,6 +49,7 @@ on:
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
         default: 1.27.3-gke.100
+
 jobs:
   gke-e2e:
     uses: ./.github/workflows/main.yaml

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -2,9 +2,11 @@ package helper
 
 import (
 	"fmt"
-	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+
 	"github.com/rancher/shepherd/extensions/clusters/gke"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/epinio/epinio/acceptance/helpers/proc"
@@ -65,7 +67,7 @@ func AddNodePool(cluster *management.Cluster, increaseBy int, client *rancher.Cl
 		for _, np := range nodeConfig {
 			newNodepool := management.GKENodePoolConfig{
 				InitialNodeCount:  np.InitialNodeCount,
-				Version:           np.Version,
+				Version:           cluster.GKEConfig.KubernetesVersion,
 				Config:            np.Config,
 				Autoscaling:       np.Autoscaling,
 				Management:        np.Management,


### PR DESCRIPTION
### What does this PR do?
1. Fix GKE tests that failed when upgrading from one major version to another, for e.g v1.26.8-gke.200 -> v1.27.3-gke.100. Ref: [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7812352834/job/21309263401)
```
time="2024-02-07T09:58:19Z" level=info msg="ClusterID: c-dwrfx, Message: [googleapi: Error 400: Node version \"1.27.3-gke.100\" must not have a greater minor version than master version \"1.26.8-gke.200\".\nDetails:\n[\n  ***\n    \"@type\": \"type.googleapis.com/google.rpc.RequestInfo\",\n    \"requestId\": \"0xe424a128d6e3269e\"\n  ***\n]\n, badRequest], Error: true, State: updating, Transitioning: false"
   ```
2. Add custom workflow run-name to all the workflows to easily identify which downstream, rancher and upstream versions were using for a specific run instead of looking into inputs.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)
   1. [1][GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7814499314)
   2. [2][GKE 1.26.8-gke.200 on Rancher v2.7.11-head deployed on v1.26.13-rc2+k3s1](https://github.com/rancher/hosted-providers-e2e/actions/runs/7827761537)

### Special notes for your reviewer:
