### PR TITLE
Re-add --version to rancher helm installation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ install-rancher: ## Install Rancher via Helm on the k8s cluster
 	helm install rancher --devel rancher-latest/rancher \
 		--namespace cattle-system \
 		--create-namespace \
+		--version ${RANCHER_VERSION} \
 		--set global.cattle.psp.enabled=false \
 		--set hostname=${RANCHER_HOSTNAME} \
 		--set bootstrapPassword=${RANCHER_PASSWORD} \
@@ -44,6 +45,7 @@ install-rancher-hosted-nightly-chart: ## Install Rancher via Helm with hosted pr
 	helm repo update
 	helm install rancher --devel rancher-latest/rancher \
 		--namespace cattle-system \
+		--version ${RANCHER_VERSION} \
 		--create-namespace \
 		--set global.cattle.psp.enabled=false \
 		--set hostname=${RANCHER_HOSTNAME} \


### PR DESCRIPTION
### What does this PR do?
Re-add --version to rancher helm installation command. If this is not passed, the latest version is taken which I am not sure is correct. So if we want to test `v2.7-head` and we provide `--set rancherImageTag=v2.7.11-head` but no `--version=v2.7.10`, then `v2.8.2` is used which does not seem right.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
```
helm install rancher rancher-latest/rancher --namespace cattle-system --set rancherImageTag=v2.7.11-head --set hostname=<hostname> --set global.cattle.psp.enabled=false --set bootstrapPassword=adminadmin --create-namespace --wait
```
1. Navigate to local cluster --> Apps --> Installed Apps
2. Check the Rancher version
![image (1)](https://github.com/rancher/hosted-providers-e2e/assets/11015077/d81c9712-73f4-4d2f-bf0d-32a99cf66a10)
