### PR TITLE
Update dependabot.yml to ignore k8s.io related pkgs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    ignore:
+    # Ignore k8s.io/* as its upgraded manually.
+    - dependency-name: "k8s.io/apimachinery"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    - dependency-name: "k8s.io/api"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    - dependency-name: "github.com/rancher/client-go"


### PR DESCRIPTION
### What does this PR do?
This change will only do patch updates. For e.g. updating v0.27.9 -> v0.27.10.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
