### PR TITLE
Add ability to run tests on available Rancher Manager

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,6 +1,5 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
-run-name: AKS ${{ inputs.downstream_k8s_version }} on Rancher v${{ inputs.rancher_version }} deployed on ${{ inputs.k3s_version}}
 
 on:
   schedule:
@@ -12,11 +11,6 @@ on:
         required: true
         type: string
         default: 2.8-head
-      k3s_version:
-        description: k3s version of local cluster
-        required: true
-        type: string
-        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
@@ -49,6 +43,10 @@ on:
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
         default: 1.26.6
+      rancher:
+        description: Rancher hostname/password if already installed
+        default: ''
+        type: string
 
 jobs:
   aks-e2e:
@@ -57,12 +55,13 @@ jobs:
     with:
       hosted_provider: aks
       rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
+      k3s_version: 'v1.27.9+k3s1'
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || (github.event_name == 'schedule' && true) }}
       run_p0_importing_tests: ${{ inputs.run_p0_importing_tests == true || (github.event_name == 'schedule' && true) }}
       run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true || (github.event_name == 'schedule' && false) }}
       run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true || (github.event_name == 'schedule' && false) }}
-      destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
+      destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.26.6' }}
+      rancher: ${{ inputs.rancher || '' }}

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
+run-name: AKS ${{ inputs.downstream_k8s_version || '1.26.6' }} on Rancher v${{ inputs.rancher_version || '2.8-head' }} deployed on ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
 
 on:
   schedule:
@@ -11,26 +12,15 @@ on:
         required: true
         type: string
         default: 2.8-head
+      k3s_version:
+        description: k3s version of local cluster
+        required: true
+        type: string
+        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
         required: true
-        type: boolean
-      run_p0_provisioning_tests:
-        required: true
-        default: true
-        type: boolean
-      run_p0_importing_tests:
-        required: true
-        default: true
-        type: boolean
-      run_support_matrix_provisioning_tests:
-        required: true
-        default: false
-        type: boolean
-      run_support_matrix_importing_tests:
-        required: true
-        default: false
         type: boolean
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -45,8 +35,13 @@ on:
         default: 1.26.6
       rancher_installed:
         description: Rancher details if already installed
-        default: '<hostname/password>'
+        default: 'hostname/password'
         type: string
+      tests_to_run:
+        description: Tests to run (p0_provisioning/p0_importing/support_matrix_provisioning/support_matrix_importing)
+        type: string
+        required: true
+        default: p0_provisioning/p0_importing
 
 jobs:
   aks-e2e:
@@ -55,14 +50,13 @@ jobs:
     with:
       hosted_provider: aks
       rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
-      k3s_version: 'v1.27.9+k3s1'
+      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || (github.event_name == 'schedule' && true) }}
-      run_p0_importing_tests: ${{ inputs.run_p0_importing_tests == true || (github.event_name == 'schedule' && true) }}
-      run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true || (github.event_name == 'schedule' && false) }}
-      run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true || (github.event_name == 'schedule' && false) }}
+      run_p0_provisioning_tests: ${{ contains(inputs.tests_to_run, 'p0_provisioning') || (github.event_name == 'schedule' && true) }}
+      run_p0_importing_tests: ${{ contains(inputs.tests_to_run, 'p0_importing') || (github.event_name == 'schedule' && true) }}
+      run_support_matrix_provisioning_tests: ${{ contains(inputs.tests_to_run, 'support_matrix_provisioning') || (github.event_name == 'schedule' && false) }}
+      run_support_matrix_importing_tests: ${{ contains(inputs.tests_to_run, 'support_matrix_importing') || (github.event_name == 'schedule' && false) }}
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.26.6' }}
-      rancher_installed: ${{ inputs.rancher_installed || '<hostname/password>' }}
-
+      rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -43,9 +43,9 @@ on:
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
         default: 1.26.6
-      rancher:
-        description: Rancher hostname/password if already installed
-        default: ''
+      rancher_installed:
+        description: Rancher details if already installed
+        default: '<hostname/password>'
         type: string
 
 jobs:
@@ -64,4 +64,5 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.26.6' }}
-      rancher: ${{ inputs.rancher || '' }}
+      rancher_installed: ${{ inputs.rancher_installed || '<hostname/password>' }}
+

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,6 +1,5 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
-run-name: EKS ${{ inputs.downstream_k8s_version }} on Rancher v${{ inputs.rancher_version }} deployed on ${{ inputs.k3s_version}}
 
 on:
   schedule:

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -11,11 +11,6 @@ on:
         required: true
         type: string
         default: 2.8-head
-      k3s_version:
-        description: k3s version of local cluster
-        required: true
-        type: string
-        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
@@ -48,6 +43,11 @@ on:
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
         default: 1.26
+      rancher_installed:
+        description: Rancher details if already installed
+        default: '<hostname/password>'
+        type: string
+
 jobs:
   eks-e2e:
     uses: ./.github/workflows/main.yaml
@@ -55,7 +55,7 @@ jobs:
     with:
       hosted_provider: eks
       rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
+      k3s_version: 'v1.27.9+k3s1'
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || (github.event_name == 'schedule' && true) }}
       run_p0_importing_tests: ${{ inputs.run_p0_importing_tests == true || (github.event_name == 'schedule' && true) }}
@@ -64,3 +64,4 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.26' }}
+      rancher_installed: ${{ inputs.rancher_installed || '<hostname/password>' }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
+run-name: EKS ${{ inputs.downstream_k8s_version || '1.26' }} on Rancher v${{ inputs.rancher_version || '2.8-head' }} deployed on ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
 
 on:
   schedule:
@@ -11,26 +12,15 @@ on:
         required: true
         type: string
         default: 2.8-head
+      k3s_version:
+        description: k3s version of local cluster
+        required: true
+        type: string
+        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
         required: true
-        type: boolean
-      run_p0_provisioning_tests:
-        required: true
-        default: true
-        type: boolean
-      run_p0_importing_tests:
-        required: true
-        default: true
-        type: boolean
-      run_support_matrix_provisioning_tests:
-        required: true
-        default: false
-        type: boolean
-      run_support_matrix_importing_tests:
-        required: true
-        default: false
         type: boolean
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -45,8 +35,13 @@ on:
         default: 1.26
       rancher_installed:
         description: Rancher details if already installed
-        default: '<hostname/password>'
+        default: 'hostname/password'
         type: string
+      tests_to_run:
+        description: Tests to run (p0_provisioning/p0_importing/support_matrix_provisioning/support_matrix_importing)
+        type: string
+        required: true
+        default: p0_provisioning/p0_importing
 
 jobs:
   eks-e2e:
@@ -55,13 +50,13 @@ jobs:
     with:
       hosted_provider: eks
       rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
-      k3s_version: 'v1.27.9+k3s1'
+      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || (github.event_name == 'schedule' && true) }}
-      run_p0_importing_tests: ${{ inputs.run_p0_importing_tests == true || (github.event_name == 'schedule' && true) }}
-      run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true || (github.event_name == 'schedule' && false) }}
-      run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true || (github.event_name == 'schedule' && false) }}
+      run_p0_provisioning_tests: ${{ contains(inputs.tests_to_run, 'p0_provisioning') || (github.event_name == 'schedule' && true) }}
+      run_p0_importing_tests: ${{ contains(inputs.tests_to_run, 'p0_importing') || (github.event_name == 'schedule' && true) }}
+      run_support_matrix_provisioning_tests: ${{ contains(inputs.tests_to_run, 'support_matrix_provisioning') || (github.event_name == 'schedule' && false) }}
+      run_support_matrix_importing_tests: ${{ contains(inputs.tests_to_run, 'support_matrix_importing') || (github.event_name == 'schedule' && false) }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.26' }}
-      rancher_installed: ${{ inputs.rancher_installed || '<hostname/password>' }}
+      rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,5 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
+run-name: GKE ${{ inputs.downstream_k8s_version || '1.27.3-gke.100' }} on Rancher v${{ inputs.rancher_version || '2.8-head' }} deployed on ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
 
 on:
   schedule:
@@ -11,26 +12,15 @@ on:
         required: true
         type: string
         default: 2.8-head
+      k3s_version:
+        description: k3s version of local cluster
+        required: true
+        type: string
+        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
         required: true
-        type: boolean
-      run_p0_provisioning_tests:
-        required: true
-        default: true
-        type: boolean
-      run_p0_importing_tests:
-        required: true
-        default: true
-        type: boolean
-      run_support_matrix_provisioning_tests:
-        required: true
-        default: false
-        type: boolean
-      run_support_matrix_importing_tests:
-        required: true
-        default: false
         type: boolean
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
@@ -45,8 +35,13 @@ on:
         default: 1.27.3-gke.100
       rancher_installed:
         description: Rancher details if already installed
-        default: '<hostname/password>'
+        default: 'hostname/password'
         type: string
+      tests_to_run:
+        description: Tests to run (p0_provisioning/p0_importing/support_matrix_provisioning/support_matrix_importing)
+        type: string
+        required: true
+        default: p0_provisioning/p0_importing
 
 jobs:
   gke-e2e:
@@ -55,13 +50,13 @@ jobs:
     with:
       hosted_provider: gke
       rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
-      k3s_version: 'v1.27.9+k3s1'
+      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || (github.event_name == 'schedule' && true) }}
-      run_p0_importing_tests: ${{ inputs.run_p0_importing_tests == true || (github.event_name == 'schedule' && true) }}
-      run_support_matrix_provisioning_tests: ${{ inputs.run_support_matrix_provisioning_tests == true || (github.event_name == 'schedule' && false) }}
-      run_support_matrix_importing_tests: ${{ inputs.run_support_matrix_importing_tests == true || (github.event_name == 'schedule' && false) }}
+      run_p0_provisioning_tests: ${{ contains(inputs.tests_to_run, 'p0_provisioning') || (github.event_name == 'schedule' && true) }}
+      run_p0_importing_tests: ${{ contains(inputs.tests_to_run, 'p0_importing') || (github.event_name == 'schedule' && true) }}
+      run_support_matrix_provisioning_tests: ${{ contains(inputs.tests_to_run, 'support_matrix_provisioning') || (github.event_name == 'schedule' && false) }}
+      run_support_matrix_importing_tests: ${{ contains(inputs.tests_to_run, 'support_matrix_importing') || (github.event_name == 'schedule' && false) }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.27.3-gke.100' }}
-      rancher_installed: ${{ inputs.rancher_installed || '<hostname/password>' }}
+      rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -11,11 +11,6 @@ on:
         required: true
         type: string
         default: 2.8-head
-      k3s_version:
-        description: k3s version of local cluster
-        required: true
-        type: string
-        default: v1.27.9+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: true
@@ -48,6 +43,10 @@ on:
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
         default: 1.27.3-gke.100
+      rancher_installed:
+        description: Rancher details if already installed
+        default: '<hostname/password>'
+        type: string
 
 jobs:
   gke-e2e:
@@ -56,7 +55,7 @@ jobs:
     with:
       hosted_provider: gke
       rancher_version: ${{ inputs.rancher_version || '2.8-head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
+      k3s_version: 'v1.27.9+k3s1'
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       run_p0_provisioning_tests: ${{ inputs.run_p0_provisioning_tests == true || (github.event_name == 'schedule' && true) }}
       run_p0_importing_tests: ${{ inputs.run_p0_importing_tests == true || (github.event_name == 'schedule' && true) }}
@@ -65,3 +64,4 @@ jobs:
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
       downstream_k8s_version: ${{ inputs.downstream_k8s_version || '1.27.3-gke.100' }}
+      rancher_installed: ${{ inputs.rancher_installed || '<hostname/password>' }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,6 +1,5 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
-run-name: GKE ${{ inputs.downstream_k8s_version }} on Rancher v${{ inputs.rancher_version }} deployed on ${{ inputs.k3s_version}}
 
 on:
   schedule:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set Rancher hostname / password
         run: |
-          if [ ${{ inputs.rancher_installed }} != '<hostname/password>' ]; then
+          if [ ${{ inputs.rancher_installed }} != 'hostname/password' ]; then
             echo RANCHER_HOSTNAME="$(echo ${{ inputs.rancher_installed }} | cut -d'/' -f1)" >> ${GITHUB_ENV}
             echo RANCHER_PASSWORD="$(echo ${{ inputs.rancher_installed }} | cut -d'/' -f2)" >> ${GITHUB_ENV}
           else
@@ -126,7 +126,7 @@ jobs:
           fi
 
       - name: Install K3s / Helm / Rancher
-        if: ${{ inputs.rancher_installed == '<hostname/password>' }}
+        if: ${{ inputs.rancher_installed == 'hostname/password' }}
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.13.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,9 @@ on:
         description: Install hosted-provider nightly chart
         required: true
         type: boolean
+      rancher:
+        description: Rancher hostname/password if already installed
+        type: string
       run_p0_provisioning_tests:
         required: true
         type: boolean
@@ -41,6 +44,7 @@ on:
         type: string
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
+        default: ''
         type: string
 
 env:
@@ -111,14 +115,25 @@ jobs:
       - name: Get Runner IP
         id: runner-ip
         run: echo "PUBLIC_IP=$(curl -s ifconfig.co)" >> "$GITHUB_OUTPUT"
-            
+
+      - name: Set Rancher hostname / password
+        run: |
+          if [ ${{ inputs.rancher }} != '' ]; then
+            echo RANCHER_HOSTNAME="$(echo ${{ inputs.rancher }} | cut -d'/' -f1)" >> ${GITHUB_ENV}
+            echo RANCHER_PASSWORD="$(echo ${{ inputs.rancher }} | cut -d'/' -f2)" >> ${GITHUB_ENV}
+          else
+            echo RANCHER_HOSTNAME=${{ steps.runner-ip.outputs.PUBLIC_IP }}.sslip.io >> $GITHUB_ENV
+            echo RANCHER_PASSWORD=${{ secrets.RANCHER_PASSWORD }} >> $GITHUB_ENV
+          fi
+
       - name: Install K3s / Helm / Rancher
+        if: ${{ inputs.rancher == '' }}
         env:
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.13.1
           K3S_VERSION: ${{ inputs.k3s_version }}
           RANCHER_VERSION: ${{ inputs.rancher_version }}
-          RANCHER_HOSTNAME: ${{steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
+          RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
         run: |
           if [ ${{ inputs.operator_nightly_chart }} == true ]; then
             make prepare-e2e-ci-rancher-hosted-nightly-chart
@@ -167,7 +182,8 @@ jobs:
       - name: Provisioning cluster tests
         if:  ${{ inputs.run_p0_provisioning_tests == true }}
         env:
-          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
+          RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
         run: |
           make e2e-provisioning-tests
@@ -175,7 +191,8 @@ jobs:
       - name: Importing cluster tests
         if: ${{ !cancelled() && inputs.run_p0_importing_tests == true }}
         env:
-          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
+          RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
         run: |
           make e2e-import-tests
@@ -183,7 +200,8 @@ jobs:
       - name: Support matrix provisioning tests
         if: ${{ !cancelled() && inputs.run_support_matrix_provisioning_tests == true }}
         env:
-          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
+          RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
         run: |
           make e2e-support-matrix-provisioning-tests
@@ -191,7 +209,8 @@ jobs:
       - name: Support matrix importing tests
         if: ${{ !cancelled() && inputs.run_support_matrix_importing_tests == true }}
         env:
-          RANCHER_HOSTNAME: ${{ steps.runner-ip.outputs.PUBLIC_IP}}.sslip.io
+          RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
+          RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
         run: |
           make e2e-support-matrix-importing-tests
@@ -209,6 +228,15 @@ jobs:
           name: support-logs
           path: ${{ github.workspace }}/logs/*
           if-no-files-found: ignore
+
+      - name: Add summary
+        if: ${{ always() }}
+        run: |
+          # Add summary
+          echo "## General information" >> ${GITHUB_STEP_SUMMARY}
+          echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "K3s on Rancher Manager: ${{ inputs.k3s_version }}" >> ${GITHUB_STEP_SUMMARY}
+          echo "Downstream ${{ inputs.hosted_provider }} version: ${{ inputs.downstream_k8s_version }}" >> ${GITHUB_STEP_SUMMARY}
 
   delete-runner:
     if: ${{ always() && inputs.destroy_runner == true }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,8 +20,8 @@ on:
         description: Install hosted-provider nightly chart
         required: true
         type: boolean
-      rancher:
-        description: Rancher hostname/password if already installed
+      rancher_installed:
+        description: Rancher details if already installed
         type: string
       run_p0_provisioning_tests:
         required: true
@@ -44,7 +44,6 @@ on:
         type: string
       downstream_k8s_version:
         description: Downstream cluster K8s version to test
-        default: ''
         type: string
 
 env:
@@ -118,17 +117,18 @@ jobs:
 
       - name: Set Rancher hostname / password
         run: |
-          if [ ${{ inputs.rancher }} != '' ]; then
-            echo RANCHER_HOSTNAME="$(echo ${{ inputs.rancher }} | cut -d'/' -f1)" >> ${GITHUB_ENV}
-            echo RANCHER_PASSWORD="$(echo ${{ inputs.rancher }} | cut -d'/' -f2)" >> ${GITHUB_ENV}
+          if [ ${{ inputs.rancher_installed }} != '<hostname/password>' ]; then
+            echo RANCHER_HOSTNAME="$(echo ${{ inputs.rancher_installed }} | cut -d'/' -f1)" >> ${GITHUB_ENV}
+            echo RANCHER_PASSWORD="$(echo ${{ inputs.rancher_installed }} | cut -d'/' -f2)" >> ${GITHUB_ENV}
           else
             echo RANCHER_HOSTNAME=${{ steps.runner-ip.outputs.PUBLIC_IP }}.sslip.io >> $GITHUB_ENV
             echo RANCHER_PASSWORD=${{ secrets.RANCHER_PASSWORD }} >> $GITHUB_ENV
           fi
 
       - name: Install K3s / Helm / Rancher
-        if: ${{ inputs.rancher == '' }}
+        if: ${{ inputs.rancher_installed == '<hostname/password>' }}
         env:
+          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.13.1
           K3S_VERSION: ${{ inputs.k3s_version }}
           RANCHER_VERSION: ${{ inputs.rancher_version }}

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters/aks"
 	"github.com/rancher/shepherd/extensions/clusters/eks"
 	"github.com/rancher/shepherd/extensions/clusters/gke"
+	"github.com/rancher/shepherd/extensions/pipeline"
 
 	. "github.com/onsi/gomega"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -21,7 +22,6 @@ import (
 	"github.com/rancher/shepherd/extensions/cloudcredentials/google"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
-	"github.com/rancher/shepherd/extensions/pipeline"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/shepherd/pkg/wait"


### PR DESCRIPTION
### What does this PR do?
- Adds support in framework to run tests on any available Rancher manager
- Changed job summary, as custom run-name was not working on scheduled jobs

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #62 

### Checklist:
- [x] Squashed commits into logical changes
- [x] GitHub Actions

Custom Rancher: 
[AKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7885120818) [EKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7886952272) [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7886292072)

CI Installed Rancher: 
[AKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7885883472) [EKS-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7886956678) [GKE-E2E](https://github.com/rancher/hosted-providers-e2e/actions/runs/7886294089)

### Special notes for your reviewer:
Since GHA has limitation of max 10 inputs for workflow_dispatch, disabled _k3s_version_ input as a tradeoff and uyse default k3s version. https://github.com/rancher/hosted-providers-e2e/actions/runs/7884132500