### PR TITLE
Add K8s chart support tests for GKE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,13 @@ e2e-support-matrix-importing-tests: deps ## Run the 'SupportMatrixImporting' tes
 e2e-support-matrix-provisioning-tests: deps ## Run the 'SupportMatrixProvisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SupportMatrixProvisioning" ./hosted/${PROVIDER}/support_matrix/
 
+e2e-k8s-chart-support-importing-tests: deps ## Run the 'K8sChartSupportImport' test suite for a given ${PROVIDER}
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportImport" ./hosted/${PROVIDER}/k8s_chart_support/
+
+e2e-k8s-chart-support-provisioning-tests: deps ## Run the 'K8sChartSupportProvisioning' test suite for a given ${PROVIDER}
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportProvisioning" ./hosted/${PROVIDER}/k8s_chart_support/
+
+
 clean-k3s:	## Uninstall k3s cluster
 	/usr/local/bin/k3s-uninstall.sh
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ Following are the common environment variables that need to be exported for runn
 3. CATTLE_TEST_CONFIG: Config file containing cluster and cloud credential information, for e.g. cattle-config-provisioning.yaml and cattle-config-import.yaml in the root directory.
 4. PROVIDER: Type of the hosted provider you want to test. Acceptable values - gke, eks, aks
 5. DOWNSTREAM_KUBERNETES_VERSION (optional): Downstream cluster Kubernetes version to test. If the env var is not provided, the value is obtained from the config, if even that is not available, it uses a provider specific default value.
+6. DOWNSTREAM_CLUSTER_CLEANUP (optional): If set to true, downstream cluster will be deleted. Default: false. 
 
-To run GKE:
+#### To run K8s Chart support test cases:
+1. KUBECONFIG: Upstream K8s' Kubeconfig file; usually it is k3s.yaml.
+2. RANCHER_UPGRADE_VERSION: Rancher version to test upgrade. This version can be in the following formats: 2.8.2, 2.8.2-rc3, devel/2.8-head
+3. K8S_UPGRADE_MINOR_VERSION: K8s version to test. This value does not have to be exact, just the X.Y version. For e.g. 1.28. The complete version value will be fetched during the test.
+4. RANCHER_VERSION: Base rancher version to begin with. Since chart support tests are basically upgrade scenarios, the base version should be a released version, if it is an unreleased version such as 2.8-head, the test will fail. This version can be in the following formats: 2.8.2, 2.8.2-rc3, devel/2.8-head
+5. RANCHER_CHANNEL (Optional): Acceptable values: latest (default), alpha, stable, prime
+
+Note: These are E2E tests, so rancher (version=`RANCHER_VERSION`) will be installed by the test.
+
+#### To run GKE:
 1. GCP_CREDENTIALS - a Service Account with a JSON private key and provide the JSON here. These IAM roles are required:
    - Compute Engine: Compute Viewer (roles/compute.viewer)
    - Project: Viewer (roles/viewer)
@@ -25,12 +35,12 @@ To run GKE:
 2. GKE_PROJECT_ID - Name of the Google Cloud Project
 3. GKE_ZONE - Zone in which GKE must be provisioned (default: 'asia-south2-c'). This environment variable takes precedence over the config file variable.
 
-To run EKS:
+#### To run EKS:
 1. AWS_ACCESS_KEY_ID - AWS Access Key
 2. AWS_SECRET_ACCESS_KEY - AWS Secret Key
 3. EKS_REGION - Region in which EKS must be provisioned (default: 'ap-south-1'). This environment variable takes precedence over the config file variable.
 
-To run AKS:
+#### To run AKS:
 1. AKS_CLIENT_ID - Azure Client ID [Check Microsoft Entra ID to create or fetch value from an existing one](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)
 2. AKS_CLIENT_SECRET - Azure Client Secret [Check Microsoft Entra ID to create or fetch value from an existing one](https://learn.microsoft.com/en-us/entra/identity-platform/howto-create-service-principal-portal)
 3. AKS_SUBSCRIPTION_ID - Azure Subscription ID (In this case it is similar to a Google Cloud Project, but the value is an ID). [Check Azure Subscriptions](https://learn.microsoft.com/en-us/microsoft-365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings?view=o365-worldwide#subscriptions)

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/epinio/epinio v1.10.0
 	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/onsi/gomega v1.31.1
 	github.com/pkg/errors v0.9.1
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240226095724-c65cbe829176
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
-	github.com/rancher/shepherd v0.0.0-20240205165058-79095d1622f8
+	github.com/rancher/shepherd v0.0.0-20240301183025-4979762558e1
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/apimachinery v0.27.9
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
@@ -19,8 +21,8 @@ require (
 	github.com/antihax/optional v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.322 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bramvdbogaerde/go-scp v1.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/creasty/defaults v1.5.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -73,6 +75,8 @@ require (
 	go.qase.io/client v0.0.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.24.0 // indirect
+	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
@@ -95,6 +99,7 @@ require (
 	k8s.io/kube-aggregator v0.27.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20230530175149-33f04d5d6b58 // indirect
 	k8s.io/kubernetes v1.27.6 // indirect
+	libvirt.org/libvirt-go-xml v7.4.0+incompatible // indirect
 	sigs.k8s.io/cli-utils v0.27.0 // indirect
 	sigs.k8s.io/cluster-api v1.5.0 // indirect
 	sigs.k8s.io/controller-runtime v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,7 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/aws/aws-sdk-go v1.44.322 h1:7JfwifGRGQMHd99PvfXqxBaZsjuRaOF6e3X9zRx2uYo=
 github.com/aws/aws-sdk-go v1.44.322/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -85,6 +86,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/bramvdbogaerde/go-scp v1.2.1 h1:BKTqrqXiQYovrDlfuVFaEGz0r4Ou6EED8L7jCXw6Buw=
+github.com/bramvdbogaerde/go-scp v1.2.1/go.mod h1:s4ZldBoRAOgUg8IrRP2Urmq5qqd2yPXQTPshACY8vQ0=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
@@ -580,6 +583,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240226095724-c65cbe829176 h1:okW6rEvLaCuh6E1L5CMdmr2Pb8JSHyGj5uOKWZvYic0=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20240226095724-c65cbe829176/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/aks-operator v1.2.0 h1:cNB84j23Ng7GUkqIt8I1TUfkpPdA5SQ2uyosPNJM5G4=
@@ -604,8 +609,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20230915232223-a9ea4ce4a5ba h1:GTSOFe
 github.com/rancher/rancher/pkg/apis v0.0.0-20230915232223-a9ea4ce4a5ba/go.mod h1:CygL4GxLAJpxMRpqImc8+wH4zW+0kNVYW+nb0IsJ04A=
 github.com/rancher/rke v1.5.0 h1:M/YryKnBs7IwzMGA2kh1EiypVQkme6o9KSg0hlllQa4=
 github.com/rancher/rke v1.5.0/go.mod h1:wZaVWzW46OTuGvyxgRHXGUyJ/QP0zOkKESO9hBOwTaY=
-github.com/rancher/shepherd v0.0.0-20240205165058-79095d1622f8 h1:uAEdiG4Spsx3DMFcFRTlPX2pfNy7/uvquWhtcCnxIWA=
-github.com/rancher/shepherd v0.0.0-20240205165058-79095d1622f8/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
+github.com/rancher/shepherd v0.0.0-20240301183025-4979762558e1 h1:dNpsxcHNnQnxTGNuDD4Sj12jzXs+QDWqVA2Kj6dkV10=
+github.com/rancher/shepherd v0.0.0-20240301183025-4979762558e1/go.mod h1:pggo0NvlbxaplK5cwiTSp7AixbGrGWbz6CC710biulI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007 h1:ru+mqGnxMmKeU0Q3XIDxkARvInDIqT1hH2amTcsjxI4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20210727200656-10b094e30007/go.mod h1:Ja346o44aTPWADc/5Jm93+KgctT6KtftuOosgz0F2AM=
 github.com/rancher/wrangler v0.6.1/go.mod h1:L4HtjPeX8iqLgsxfJgz+JjKMcX2q3qbRXSeTlC/CSd4=
@@ -746,6 +751,7 @@ go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
+go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -761,8 +767,11 @@ golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
+golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
+golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -965,6 +974,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1316,6 +1326,8 @@ k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20230209194617-a36077c30491/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106 h1:EObNQ3TW2D+WptiYXlApGNLVy0zm/JIBVY9i+M4wpAU=
 k8s.io/utils v0.0.0-20230505201702-9f6742963106/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+libvirt.org/libvirt-go-xml v7.4.0+incompatible h1:NaCRjbtz//xuTZOp1nDHbe0eu5BQlhIy5PPuc09EWtU=
+libvirt.org/libvirt-go-xml v7.4.0+incompatible/go.mod h1:FL+H1+hKNWDdkKQGGS4sGCZJ3pGWcjt6VbxZvPlQJkY=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
@@ -1,0 +1,58 @@
+package k8s_chart_support_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters/gke"
+	"github.com/rancher/shepherd/pkg/config"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/gke/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("K8sChartSupportImport", func() {
+	var (
+		cluster *management.Cluster
+	)
+
+	BeforeEach(func() {
+		err := helper.CreateGKEClusterOnGCloud(zone, clusterName, project, k8sVersion)
+		Expect(err).To(BeNil())
+
+		gkeConfig := new(helper.ImportClusterConfig)
+		config.LoadAndUpdateConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig, func() {
+			gkeConfig.ProjectID = project
+			gkeConfig.Zone = zone
+			labels := helper.GetLabels()
+			gkeConfig.Labels = &labels
+			for _, np := range gkeConfig.NodePools {
+				np.Version = &k8sVersion
+			}
+		})
+		cluster, err = helper.ImportGKEHostedCluster(ctx.RancherClient, clusterName, ctx.CloudCred.ID, false, false, false, false, map[string]string{})
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)
+		Expect(err).To(BeNil())
+		// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
+		cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
+	})
+
+	AfterEach(func() {
+		if ctx.ClusterCleanup {
+			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherClient)
+			Expect(err).To(BeNil())
+			err = helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
+			Expect(err).To(BeNil())
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
+
+	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func() {
+		commonChartSupportUpgrade(&ctx, cluster, clusterName, rancherUpgradedVersion, helpers.RancherHostname, k8sUpgradedMinorVersion)
+	})
+
+})

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
@@ -54,5 +54,6 @@ var _ = Describe("K8sChartSupportImport", func() {
 	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func() {
 		commonChartSupportUpgrade(&ctx, cluster, clusterName, rancherUpgradedVersion, helpers.RancherHostname, k8sUpgradedMinorVersion)
 	})
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
 
 })

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -1,0 +1,54 @@
+package k8s_chart_support_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters/gke"
+	"github.com/rancher/shepherd/pkg/config"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/gke/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("K8sChartSupportProvisioning", func() {
+
+	var (
+		cluster *management.Cluster
+	)
+	BeforeEach(func() {
+		gkeConfig := new(management.GKEClusterConfigSpec)
+		config.LoadAndUpdateConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig, func() {
+			gkeConfig.ProjectID = project
+			gkeConfig.Zone = zone
+			labels := helper.GetLabels()
+			gkeConfig.Labels = &labels
+			gkeConfig.KubernetesVersion = &k8sVersion
+			for _, np := range gkeConfig.NodePools {
+				np.Version = &k8sVersion
+			}
+		})
+
+		var err error
+		cluster, err = gke.CreateGKEHostedCluster(ctx.RancherClient, clusterName, ctx.CloudCred.ID, false, false, false, false, map[string]string{})
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)
+		Expect(err).To(BeNil())
+	})
+
+	AfterEach(func() {
+		if ctx.ClusterCleanup {
+			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherClient)
+			Expect(err).To(BeNil())
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
+
+	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func() {
+		commonChartSupportUpgrade(&ctx, cluster, clusterName, rancherUpgradedVersion, helpers.RancherHostname, k8sUpgradedMinorVersion)
+	})
+
+})

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -50,5 +50,6 @@ var _ = Describe("K8sChartSupportProvisioning", func() {
 	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func() {
 		commonChartSupportUpgrade(&ctx, cluster, clusterName, rancherUpgradedVersion, helpers.RancherHostname, k8sUpgradedMinorVersion)
 	})
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
 
 })

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -1,0 +1,257 @@
+package k8s_chart_support_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	nodestat "github.com/rancher/shepherd/extensions/nodes"
+	"github.com/rancher/shepherd/extensions/pipeline"
+	"github.com/rancher/shepherd/extensions/workloads/pods"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/gke/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var (
+	ctx                     helpers.Context
+	clusterName             string
+	k8sVersion              string
+	zone                    = helpers.GetGKEZone()
+	project                 = helpers.GetGKEProjectID()
+	rancherVersion          = os.Getenv("RANCHER_VERSION")
+	rancherUpgradedVersion  = os.Getenv("RANCHER_UPGRADE_VERSION")
+	kubeconfig              = os.Getenv("KUBECONFIG")
+	k8sUpgradedMinorVersion = os.Getenv("K8S_UPGRADE_MINOR_VERSION")
+)
+
+func TestK8sChartSupport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8sChartSupport Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(rancherVersion).ToNot(BeEmpty())
+	// For upgrade tests, the rancher version should not be an unreleased version (for e.g. 2.8-head)
+	Expect(rancherVersion).ToNot(ContainSubstring("head"))
+
+	Expect(rancherUpgradedVersion).ToNot(BeEmpty())
+	Expect(k8sUpgradedMinorVersion).ToNot(BeEmpty())
+	Expect(kubeconfig).ToNot(BeEmpty())
+
+	By("Adding the necessary chart repos", func() {
+		err := kubectl.RunHelmBinaryWithCustomErr("repo", "add", catalog.RancherChartRepo, "https://charts.rancher.io")
+		Expect(err).To(BeNil())
+		err = kubectl.RunHelmBinaryWithCustomErr("repo", "add", fmt.Sprintf("rancher-%s", helpers.RancherChannel), fmt.Sprintf("https://releases.rancher.com/server-charts/%s", helpers.RancherChannel))
+		Expect(err).To(BeNil())
+	})
+
+	By(fmt.Sprintf("Installing Rancher Manager v%s", rancherVersion), func() {
+		helpers.DeployRancherManager(rancherVersion, true)
+	})
+
+})
+
+var _ = BeforeEach(func() {
+	var err error
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
+	Expect(err).To(BeNil())
+	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+
+	k8sVersion, err = helper.DefaultGKE(ctx.RancherClient, project, ctx.CloudCred.ID, zone, "")
+	Expect(err).To(BeNil())
+	GinkgoLogr.Info(fmt.Sprintf("Using GKE version %s", k8sVersion))
+
+})
+
+var _ = AfterEach(func() {
+	// The test must restore the env to its original state, so we install rancher back to its original version and uninstall the operator charts
+	By(fmt.Sprintf("Installing Rancher back to its original version %s", rancherVersion), func() {
+		helpers.DeployRancherManager(rancherVersion, true)
+	})
+
+	By("Uninstalling the existing operator charts", func() {
+		charts := helpers.ListOperatorChart()
+		for _, chart := range charts {
+			args := []string{"uninstall", chart.Name, "--namespace", helpers.CattleSystemNS}
+			err := kubectl.RunHelmBinaryWithCustomErr(args...)
+			Expect(err).To(BeNil())
+		}
+	})
+})
+
+// commonChartSupportUpgrade runs the common checks required for testing chart support
+func commonChartSupportUpgrade(ctx *helpers.Context, cluster *management.Cluster, clusterName, rancherUpgradedVersion, hostname, k8sUpgradedVersion string) {
+	By("checking cluster name is same", func() {
+		Expect(cluster.Name).To(BeEquivalentTo(clusterName))
+	})
+
+	By("checking service account token secret", func() {
+		success, err := clusters.CheckServiceAccountTokenSecret(ctx.RancherClient, clusterName)
+		Expect(err).To(BeNil())
+		Expect(success).To(BeTrue())
+	})
+
+	By("checking all management nodes are ready", func() {
+		err := nodestat.AllManagementNodeReady(ctx.RancherClient, cluster.ID, helpers.Timeout)
+		Expect(err).To(BeNil())
+	})
+
+	By("checking all pods are ready", func() {
+		podErrors := pods.StatusPods(ctx.RancherClient, cluster.ID)
+		Expect(podErrors).To(BeEmpty())
+	})
+
+	var oldChartVersion string
+	By("checking the chart version", func() {
+		oldCharts := helpers.ListOperatorChart()
+		oldChartVersion = oldCharts[0].DerivedVersion
+		Expect(oldChartVersion).ToNot(BeEmpty())
+	})
+
+	By("upgrading rancher", func() {
+		helpers.DeployRancherManager(rancherUpgradedVersion, true)
+
+		By("regenerating the token and initiating a new rancher client", func() {
+			//	regenerate the tokens and initiate a new rancher client
+			rancherConfig := new(rancher.Config)
+			config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+			token, err := pipeline.CreateAdminToken(helpers.RancherPassword, rancherConfig)
+			Expect(err).To(BeNil())
+
+			config.LoadAndUpdateConfig(rancher.ConfigurationFileKey, rancherConfig, func() {
+				rancherConfig.AdminToken = token
+			})
+			rancherClient, err := rancher.NewClient(rancherConfig.AdminToken, ctx.Session)
+			Expect(err).To(BeNil())
+			ctx.RancherClient = rancherClient
+
+			setting := new(management.Setting)
+			resp, err := rancherClient.Management.Setting.ByID("server-url")
+			Expect(err).To(BeNil())
+
+			setting.Source = "env"
+			setting.Value = fmt.Sprintf("https://%s", hostname)
+			resp, err = rancherClient.Management.Setting.Update(resp, setting)
+			Expect(err).To(BeNil())
+
+			var isConnected bool
+			isConnected, err = ctx.RancherClient.IsConnected()
+			Expect(err).To(BeNil())
+			Expect(isConnected).To(BeTrue())
+		})
+	})
+
+	By("making sure the local cluster is ready", func() {
+		localClusterID := "local"
+		By("checking all management nodes are ready", func() {
+			err := nodestat.AllManagementNodeReady(ctx.RancherClient, localClusterID, helpers.Timeout)
+			Expect(err).To(BeNil())
+		})
+
+		By("checking all pods are ready", func() {
+			podErrors := pods.StatusPods(ctx.RancherClient, localClusterID)
+			Expect(podErrors).To(BeEmpty())
+		})
+	})
+
+	var newChartVersion string
+	By("checking the chart version and validating it is > the old version", func() {
+
+		Eventually(func() int {
+			charts := helpers.ListOperatorChart()
+			newChartVersion = charts[0].DerivedVersion
+			return helpers.VersionCompare(newChartVersion, oldChartVersion)
+		}, tools.SetTimeout(1*time.Minute), 5*time.Second).Should(BeNumerically("==", 1))
+
+	})
+
+	By(fmt.Sprintf("fetching a list of available k8s versions and ensuring v%s is present in the list and upgrading the cluster to it", k8sUpgradedVersion), func() {
+		versions, err := helper.ListGKEAvailableVersions(ctx.RancherClient, cluster.ID)
+		Expect(err).To(BeNil())
+		latestVersion := versions[len(versions)-1]
+		Expect(latestVersion).To(ContainSubstring(k8sUpgradedVersion))
+		Expect(helpers.VersionCompare(latestVersion, cluster.Version.GitVersion)).To(BeNumerically("==", 1))
+
+		cluster, err = helper.UpgradeKubernetesVersion(cluster, &latestVersion, ctx.RancherClient, true)
+		Expect(err).To(BeNil())
+		err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
+		Expect(err).To(BeNil())
+		Expect(*cluster.GKEConfig.KubernetesVersion).To(BeEquivalentTo(latestVersion))
+		for _, np := range cluster.GKEConfig.NodePools {
+			Expect(*np.Version).To(BeEquivalentTo(latestVersion))
+		}
+	})
+
+	By("downgrading the chart version", func() {
+		newCharts := helpers.ListOperatorChart()
+		for _, chart := range newCharts {
+			err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart.Name, fmt.Sprintf("%s/%s", catalog.RancherChartRepo, chart.Name), "--namespace", helpers.CattleSystemNS, "--version", oldChartVersion, "--wait")
+			Expect(err).To(BeNil())
+		}
+		// wait until the downgraded chart version is same as the old version
+		Eventually(func() int {
+			charts := helpers.ListOperatorChart()
+			downgradedChartVersion := charts[0].DerivedVersion
+			return helpers.VersionCompare(downgradedChartVersion, oldChartVersion)
+		}, tools.SetTimeout(1*time.Minute), 5*time.Second).Should(BeNumerically("==", 0))
+
+	})
+
+	By("making a change to the cluster to validate functionality after chart downgrade", func() {
+		initialNodeCount := *cluster.GKEConfig.NodePools[0].InitialNodeCount
+		var err error
+		cluster, err = helper.ScaleNodePool(cluster, ctx.RancherClient, initialNodeCount+1)
+		Expect(err).To(BeNil())
+		err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
+		Expect(err).To(BeNil())
+		for i := range cluster.GKEConfig.NodePools {
+			Expect(*cluster.GKEConfig.NodePools[i].InitialNodeCount).To(BeNumerically(">", initialNodeCount))
+		}
+	})
+
+	By("uninstalling the operator chart", func() {
+		charts := helpers.ListOperatorChart()
+		for _, chart := range charts {
+			args := []string{"uninstall", chart.Name, "--namespace", helpers.CattleSystemNS}
+			err := kubectl.RunHelmBinaryWithCustomErr(args...)
+			Expect(err).To(BeNil())
+		}
+	})
+
+	By("making a change(adding a nodepool) to the cluster to re-install the operator and validating it is re-installed to the latest version", func() {
+		currentNodePoolNumber := len(cluster.GKEConfig.NodePools)
+		var err error
+		cluster, err = helper.AddNodePool(cluster, 1, ctx.RancherClient)
+		Expect(err).To(BeNil())
+
+		By("ensuring that the chart is re-installed to the latest version", func() {
+			Eventually(func() int {
+				charts := helpers.ListOperatorChart()
+				if len(charts) == 0 {
+					return 10
+				}
+				reinstalledChartVersion := charts[0].DerivedVersion
+				return helpers.VersionCompare(reinstalledChartVersion, newChartVersion)
+			}, tools.SetTimeout(1*time.Minute), 5*time.Second).Should(BeNumerically("==", 0))
+
+		})
+
+		err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
+		Expect(err).To(BeNil())
+		Expect(len(cluster.GKEConfig.NodePools)).To(BeNumerically("==", currentNodePoolNumber+1))
+	})
+
+}

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -123,6 +123,12 @@ func commonChartSupportUpgrade(ctx *helpers.Context, cluster *management.Cluster
 	By("upgrading rancher", func() {
 		helpers.DeployRancherManager(rancherUpgradedVersion, true)
 
+		By("ensuring operator pods are also up", func() {
+			Eventually(func() error {
+				return kubectl.New().WaitForNamespaceWithPod(helpers.CattleSystemNS, fmt.Sprintf("ke.cattle.io/operator=%s", helpers.Provider))
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		})
+
 		By("regenerating the token and initiating a new rancher client", func() {
 			//	regenerate the tokens and initiate a new rancher client
 			rancherConfig := new(rancher.Config)

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -119,6 +119,10 @@ var _ = Describe("P0Provisioning", func() {
 				err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
 				Expect(err).To(BeNil())
 				Expect(len(cluster.GKEConfig.NodePools)).To(BeNumerically("==", currentNodePoolNumber+1))
+				for _, np := range cluster.GKEConfig.NodePools {
+					// qase: HIGHLANDER-35
+					Expect(np.Version).To(BeEquivalentTo(cluster.GKEConfig.KubernetesVersion))
+				}
 			})
 			By("deleting the nodepool", func() {
 				var err error

--- a/hosted/helpers/helper_rancher.go
+++ b/hosted/helpers/helper_rancher.go
@@ -92,7 +92,6 @@ func DeployRancherManager(fullVersion string, checkPods bool) {
 			{CattleSystemNS, "app=rancher"},
 			{"cattle-fleet-local-system", "app=fleet-agent"},
 			{CattleSystemNS, "app=rancher-webhook"},
-			{CattleSystemNS, fmt.Sprintf("ke.cattle.io/operator=%s", Provider)},
 		}
 		Eventually(func() error {
 			return rancherhelper.CheckPod(kubectl.New(), checkList)

--- a/hosted/helpers/helper_rancher.go
+++ b/hosted/helpers/helper_rancher.go
@@ -1,0 +1,104 @@
+package helpers
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	rancherhelper "github.com/rancher-sandbox/ele-testhelpers/rancher"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+)
+
+// GetRancherVersion returns the rancher version information as RancherVersionInfo
+// Sample Response from /rancherversion API endpoint:
+// 2.8-head {"Version":"6aae4eeee","GitCommit":"6aae4eeee","RancherPrime":"false"}
+// 2.8.2 {"Version":"v2.8.2","GitCommit":"2f7113dc3","RancherPrime":"false"}
+func GetRancherVersion() (versionInfo RancherVersionInfo) {
+	url := fmt.Sprintf("%s://%s/rancherversion", "https", RancherHostname)
+	httpClient := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	response, err := httpClient.Get(url)
+	Expect(err).To(BeNil())
+	defer func() {
+		_ = response.Body.Close()
+	}()
+
+	var bodyBytes []byte
+	bodyBytes, err = io.ReadAll(response.Body)
+	Expect(err).To(BeNil())
+	err = json.Unmarshal(bodyBytes, &versionInfo)
+	Expect(err).To(BeNil())
+
+	if versionInfo.Version == versionInfo.GitCommit {
+		versionInfo.Devel = true
+	}
+	return
+}
+
+// DeployRancherManager deploys Rancher. If checkPods is true, it waits until all the necessary pods are running
+// fullVersion: devel/2.8, 2.8.2, 2.8.1-rc3
+func DeployRancherManager(fullVersion string, checkPods bool) {
+	channelName := "rancher-" + RancherChannel
+
+	var version, headVersion string
+	versionSplit := strings.Split(fullVersion, "/")
+	version = versionSplit[0]
+	if len(versionSplit) == 2 {
+		headVersion = versionSplit[1]
+	}
+
+	// Set flags for Rancher Manager installation
+	flags := []string{
+		"upgrade", "--install", "rancher", channelName + "/rancher",
+		"--namespace", CattleSystemNS,
+		"--create-namespace",
+		"--set", "hostname=" + RancherHostname,
+		"--set", "bootstrapPassword=" + RancherPassword,
+		"--set", "replicas=1",
+		"--set", "global.cattle.psp.enabled=false",
+		"--wait",
+	}
+
+	// Set specified version if needed
+	if version != "" && version != "latest" {
+		if version == "devel" {
+			flags = append(flags,
+				"--devel",
+				"--set", "rancherImageTag=v"+headVersion+"-head",
+			)
+		} else if strings.Contains(version, "-rc") {
+			flags = append(flags,
+				"--devel",
+				"--version", version,
+			)
+		} else {
+			flags = append(flags, "--version", version)
+		}
+	}
+
+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Deploying rancher: %v", flags))
+	err := kubectl.RunHelmBinaryWithCustomErr(flags...)
+	Expect(err).To(BeNil())
+
+	if checkPods {
+		// Wait for all pods to be started
+		checkList := [][]string{
+			{CattleSystemNS, "app=rancher"},
+			{"cattle-fleet-local-system", "app=fleet-agent"},
+			{CattleSystemNS, "app=rancher-webhook"},
+			{CattleSystemNS, fmt.Sprintf("ke.cattle.io/operator=%s", Provider)},
+		}
+		Eventually(func() error {
+			return rancherhelper.CheckPod(kubectl.New(), checkList)
+		}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+
+		// A bit dirty be better to wait a little here for all to be correctly started
+		time.Sleep(2 * time.Minute)
+	}
+}

--- a/hosted/helpers/structs.go
+++ b/hosted/helpers/structs.go
@@ -1,0 +1,51 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/pkg/session"
+)
+
+const (
+	Timeout        = 30 * time.Minute
+	CattleSystemNS = "cattle-system"
+)
+
+var (
+	RancherPassword = os.Getenv("RANCHER_PASSWORD")
+	RancherHostname = os.Getenv("RANCHER_HOSTNAME")
+	RancherChannel  = func() string {
+		if channel := os.Getenv("RANCHER_CHANNEL"); channel != "" {
+			return channel
+		} else {
+			return "latest"
+		}
+	}()
+	Provider          = os.Getenv("PROVIDER")
+	ClusterNamePrefix = fmt.Sprintf("%shostcluster-hp", Provider)
+)
+
+type HelmChart struct {
+	Name           string `json:"name"`
+	Chart          string `json:"chart"`
+	AppVersion     string `json:"app_version"`
+	DerivedVersion string `json:"version"`
+}
+
+type Context struct {
+	CloudCred      *cloudcredentials.CloudCredential
+	RancherClient  *rancher.Client
+	Session        *session.Session
+	ClusterCleanup bool
+}
+
+type RancherVersionInfo struct {
+	Version      string
+	GitCommit    string
+	RancherPrime string
+	Devel        bool
+}


### PR DESCRIPTION
### What does this PR do?
This PR adds tests for k8s chart support test for GKE.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes part of #49 

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
Env Vars to use:
```
CATTLE_TEST_CONFIG=github.com/rancher/hosted-providers-e2e/cattle-config-import.yaml
GCP_CREDENTIALS=<gcp_creds>
GKE_PROJECT_ID=<gcp-project>
GKE_ZONE=us-central1-c
KUBECONFIG=/etc/k3s/k3s.yaml
K8S_UPGRADE_MINOR_VERSION=1.28
PROVIDER=gke
RANCHER_HOSTNAME=hostname
RANCHER_PASSWORD=adminadmin
RANCHER_UPGRADE_VERSION=devel/2.8
RANCHER_VERSION=2.8.2
```