### PR TITLE
Add Qase IDs for K8s Chart Support tests and cleanup code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Following are the common environment variables that need to be exported for runn
 2. RANCHER_PASSWORD - Admin Password for login. We currently only test with 'admin' user.
 3. CATTLE_TEST_CONFIG: Config file containing cluster and cloud credential information, for e.g. cattle-config-provisioning.yaml and cattle-config-import.yaml in the root directory.
 4. PROVIDER: Type of the hosted provider you want to test. Acceptable values - gke, eks, aks
-5. DOWNSTREAM_KUBERNETES_VERSION (optional): Downstream cluster Kubernetes version to test. If the env var is not provided, the value is obtained from the config, if even that is not available, it uses a provider specific default value.
+5. DOWNSTREAM_KUBERNETES_VERSION (optional): Downstream cluster Kubernetes version to test. If the env var is not provided, it uses a provider specific default value.
 6. DOWNSTREAM_CLUSTER_CLEANUP (optional): If set to true, downstream cluster will be deleted. Default: false. 
 
 #### To run K8s Chart support test cases:

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -333,3 +333,13 @@ func getUIK8sDefaultVersionRange(client *rancher.Client) (value string, err erro
 	return
 
 }
+
+// GetK8sVersion returns the k8s version to be used by the test;
+// this value can either be envvar DOWNSTREAM_KUBERNETES_VERSION or the default UI value returned by DefaultAKS.
+func GetK8sVersion(client *rancher.Client, cloudCredentialID, region string) (string, error) {
+	k8sVersion := os.Getenv("DOWNSTREAM_KUBERNETES_VERSION")
+	if k8sVersion != "" {
+		return k8sVersion, nil
+	}
+	return DefaultAKS(client, cloudCredentialID, region)
+}

--- a/hosted/aks/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_import_test.go
@@ -47,8 +47,10 @@ var _ = Describe("K8sChartSupportImport", func() {
 	})
 
 	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", helpers.K8sUpgradedMinorVersion, helpers.RancherUpgradeVersion), func() {
+		testCaseID = 322 // Report to Qase
 		commonchecks(&ctx, cluster, clusterName, helpers.RancherUpgradeVersion, helpers.RancherHostname, helpers.K8sUpgradedMinorVersion)
 	})
-	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
+
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func(){ testCaseID = 323 // Report to Qase})
 
 })

--- a/hosted/aks/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -44,8 +44,10 @@ var _ = Describe("K8sChartSupportProvisioning", func() {
 	})
 
 	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", helpers.K8sUpgradedMinorVersion, helpers.RancherUpgradeVersion), func() {
+		testCaseID = 320 // Report to Qase
 		commonchecks(&ctx, cluster, clusterName, helpers.RancherUpgradeVersion, helpers.RancherHostname, helpers.K8sUpgradedMinorVersion)
 	})
-	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
+
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func(){ testCaseID = 321 // Report to Qase})
 
 })

--- a/hosted/aks/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	. "github.com/rancher-sandbox/qase-ginkgo"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -26,6 +27,7 @@ import (
 var (
 	ctx                     helpers.Context
 	clusterName, k8sVersion string
+	testCaseID              int64
 	location                = helpers.GetAKSLocation()
 )
 
@@ -83,6 +85,16 @@ var _ = AfterEach(func() {
 			Expect(err).To(BeNil())
 		}
 	})
+})
+
+var _ = ReportBeforeEach(func(report SpecReport) {
+	// Reset case ID
+	testCaseID = -1
+})
+
+var _ = ReportAfterEach(func(report SpecReport) {
+	// Add result in Qase if asked
+	Qase(testCaseID, report)
 })
 
 func commonchecks(ctx *helpers.Context, cluster *management.Cluster, clusterName, rancherUpgradedVersion, hostname, k8sUpgradedVersion string) {

--- a/hosted/aks/p0/p0_suite_test.go
+++ b/hosted/aks/p0/p0_suite_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/rancher-sandbox/qase-ginkgo"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
+	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
@@ -30,11 +31,10 @@ const (
 )
 
 var (
-	ctx         helpers.Context
-	clusterName string
-	testCaseID  int64
-	location    = helpers.GetAKSLocation()
-	k8sVersion  = helpers.GetK8sVersion("aks")
+	ctx                     helpers.Context
+	clusterName, k8sVersion string
+	testCaseID              int64
+	location                = helpers.GetAKSLocation()
 )
 
 func TestP0(t *testing.T) {
@@ -44,9 +44,11 @@ func TestP0(t *testing.T) {
 
 var _ = BeforeEach(func() {
 	var err error
-	ctx, err = helpers.CommonBeforeSuite("aks")
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
 	Expect(err).To(BeNil())
-	clusterName = namegen.AppendRandomString("akshostcluster")
+	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+	k8sVersion, err = helper.GetK8sVersion(ctx.RancherClient, ctx.CloudCred.ID, location)
+	Expect(err).To(BeNil())
 })
 
 var _ = ReportBeforeEach(func(report SpecReport) {

--- a/hosted/aks/support_matrix/support_matrix_importing_test.go
+++ b/hosted/aks/support_matrix/support_matrix_importing_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportMatrixImporting", func() {
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {
-				clusterName = namegen.AppendRandomString("akshostcluster")
+				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
 				err = helper.CreateAKSClusterOnAzure(location, clusterName, version, "1")
 				Expect(err).To(BeNil())

--- a/hosted/aks/support_matrix/support_matrix_provisioning_test.go
+++ b/hosted/aks/support_matrix/support_matrix_provisioning_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportMatrixProvisioning", func() {
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {
-				clusterName = namegen.AppendRandomString("akshostcluster")
+				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
 				aksConfig := new(aks.ClusterConfig)
 				config.LoadAndUpdateConfig(aks.AKSClusterConfigConfigurationFileKey, aksConfig, func() {

--- a/hosted/aks/support_matrix/support_matrix_suite_test.go
+++ b/hosted/aks/support_matrix/support_matrix_suite_test.go
@@ -35,7 +35,7 @@ var (
 func TestSupportMatrix(t *testing.T) {
 	RegisterFailHandler(Fail)
 	var err error
-	ctx, err = helpers.CommonBeforeSuite("aks")
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
 	Expect(err).To(BeNil())
 	availableVersionList, err = helper.ListSingleVariantAKSAvailableVersions(ctx.RancherClient, ctx.CloudCred.ID, location)
 	Expect(err).To(BeNil())

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -235,3 +235,13 @@ func DefaultEKS(client *rancher.Client) (defaultEKS string, err error) {
 	}
 	return versions[1], nil
 }
+
+// GetK8sVersion returns the k8s version to be used by the test;
+// this value can either be envvar DOWNSTREAM_KUBERNETES_VERSION or the default UI value returned by DefaultEKS.
+func GetK8sVersion(client *rancher.Client) (string, error) {
+	k8sVersion := os.Getenv("DOWNSTREAM_KUBERNETES_VERSION")
+	if k8sVersion != "" {
+		return k8sVersion, nil
+	}
+	return DefaultEKS(client)
+}

--- a/hosted/eks/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/eks/k8s_chart_support/k8s_chart_support_import_test.go
@@ -47,7 +47,9 @@ var _ = Describe("K8sChartSupportImport", func() {
 		}
 	})
 	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", helpers.K8sUpgradedMinorVersion, helpers.RancherUpgradeVersion), func() {
+		testCaseID = 318 // Report to Qase
+
 		commonchecks(&ctx, cluster, clusterName, helpers.RancherUpgradeVersion, helpers.RancherHostname, helpers.K8sUpgradedMinorVersion)
 	})
-	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func(){ testCaseID = 319 // Report to Qase})
 })

--- a/hosted/eks/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/eks/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -38,8 +38,9 @@ var _ = Describe("K8sChartSupportProvisioning", func() {
 		}
 	})
 	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", helpers.K8sUpgradedMinorVersion, helpers.RancherUpgradeVersion), func() {
+		testCaseID = 316
 		commonchecks(&ctx, cluster, clusterName, helpers.RancherUpgradeVersion, helpers.RancherHostname, helpers.K8sUpgradedMinorVersion)
 	})
-	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func(){ testCaseID = 317})
 
 })

--- a/hosted/eks/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/eks/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	. "github.com/rancher-sandbox/qase-ginkgo"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -24,10 +25,10 @@ import (
 )
 
 var (
-	ctx         helpers.Context
-	clusterName string
-	region      = helpers.GetEKSRegion()
-	k8sVersion  string
+	ctx                     helpers.Context
+	clusterName, k8sVersion string
+	region                  = helpers.GetEKSRegion()
+	testCaseID              int64
 )
 
 func TestK8sChartSupport(t *testing.T) {
@@ -85,6 +86,16 @@ var _ = AfterEach(func() {
 			Expect(err).To(BeNil())
 		}
 	})
+})
+
+var _ = ReportBeforeEach(func(report SpecReport) {
+	// Reset case ID
+	testCaseID = -1
+})
+
+var _ = ReportAfterEach(func(report SpecReport) {
+	// Add result in Qase if asked
+	Qase(testCaseID, report)
 })
 
 func commonchecks(ctx *helpers.Context, cluster *management.Cluster, clusterName, rancherUpgradedVersion, hostname, k8sUpgradedVersion string) {

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
+	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
@@ -31,11 +32,10 @@ const (
 )
 
 var (
-	ctx         helpers.Context
-	clusterName string
-	testCaseID  int64
-	region      = helpers.GetEKSRegion()
-	k8sVersion  = helpers.GetK8sVersion("eks")
+	ctx                     helpers.Context
+	k8sVersion, clusterName string
+	testCaseID              int64
+	region                  = helpers.GetEKSRegion()
 )
 
 func TestP0(t *testing.T) {
@@ -45,9 +45,11 @@ func TestP0(t *testing.T) {
 
 var _ = BeforeEach(func() {
 	var err error
-	ctx, err = helpers.CommonBeforeSuite("eks")
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
 	Expect(err).To(BeNil())
-	clusterName = namegen.AppendRandomString("ekshostcluster")
+	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+	k8sVersion, err = helper.GetK8sVersion(ctx.RancherClient)
+	Expect(err).To(BeNil())
 })
 
 var _ = ReportBeforeEach(func(report SpecReport) {

--- a/hosted/eks/support_matrix/support_matrix_importing_test.go
+++ b/hosted/eks/support_matrix/support_matrix_importing_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportMatrixImporting", func() {
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {
-				clusterName = namegen.AppendRandomString("ekshostcluster")
+				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
 				err = helper.CreateEKSClusterOnAWS(region, clusterName, version, "1")
 				Expect(err).To(BeNil())

--- a/hosted/eks/support_matrix/support_matrix_provisioning_test.go
+++ b/hosted/eks/support_matrix/support_matrix_provisioning_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportMatrixProvisioning", func() {
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {
-				clusterName = namegen.AppendRandomString("ekshostcluster")
+				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				eksConfig := new(eks.ClusterConfig)
 				config.LoadAndUpdateConfig(eks.EKSClusterConfigConfigurationFileKey, eksConfig, func() {
 					eksConfig.Region = region

--- a/hosted/eks/support_matrix/support_matrix_suite_test.go
+++ b/hosted/eks/support_matrix/support_matrix_suite_test.go
@@ -36,7 +36,7 @@ var (
 func TestSupportMatrix(t *testing.T) {
 	RegisterFailHandler(Fail)
 	var err error
-	ctx, err = helpers.CommonBeforeSuite("eks")
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
 	Expect(err).To(BeNil())
 	availableVersionList, err = kubernetesversions.ListEKSAllVersions(ctx.RancherClient)
 	Expect(err).To(BeNil())

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -284,3 +284,13 @@ func DefaultGKE(client *rancher.Client, projectID, cloudCredentialID, zone, regi
 
 	return
 }
+
+// GetK8sVersion returns the k8s version to be used by the test;
+// this value can either be envvar DOWNSTREAM_KUBERNETES_VERSION or the default UI value returned by DefaultGKE.
+func GetK8sVersion(client *rancher.Client, projectID, cloudCredentialID, zone, region string) (string, error) {
+	k8sVersion := os.Getenv("DOWNSTREAM_KUBERNETES_VERSION")
+	if k8sVersion != "" {
+		return k8sVersion, nil
+	}
+	return DefaultGKE(client, projectID, cloudCredentialID, zone, region)
+}

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
@@ -51,9 +51,10 @@ var _ = Describe("K8sChartSupportImport", func() {
 		}
 	})
 
-	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func() {
-		commonChartSupportUpgrade(&ctx, cluster, clusterName, rancherUpgradedVersion, helpers.RancherHostname, k8sUpgradedMinorVersion)
+	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", helpers.K8sUpgradedMinorVersion, helpers.RancherUpgradeVersion), func() {
+		testCaseID = 314 // Report to Qase
+		commonChartSupportUpgrade(&ctx, cluster, clusterName, helpers.RancherUpgradeVersion, helpers.RancherHostname, helpers.K8sUpgradedMinorVersion)
 	})
-	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
 
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support importing on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func(){ testCaseID = 315 // Report to Qase})
 })

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -47,9 +47,10 @@ var _ = Describe("K8sChartSupportProvisioning", func() {
 		}
 	})
 
-	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func() {
-		commonChartSupportUpgrade(&ctx, cluster, clusterName, rancherUpgradedVersion, helpers.RancherHostname, k8sUpgradedMinorVersion)
+	It(fmt.Sprintf("should successfully test k8s %s chart support on rancher %s", helpers.K8sUpgradedMinorVersion, helpers.RancherUpgradeVersion), func() {
+		testCaseID = 312 // Report to Qase
+		commonChartSupportUpgrade(&ctx, cluster, clusterName, helpers.RancherUpgradeVersion, helpers.RancherHostname, helpers.K8sUpgradedMinorVersion)
 	})
-	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion)
+	//	TODO: Automate It(fmt.Sprintf("should successfully test k8s %s chart support provisioning on upgraded rancher %s", k8sUpgradedMinorVersion, rancherUpgradedVersion), func(){ testCaseID = 313 // Report to Qase})
 
 })

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -23,6 +23,7 @@ import (
 
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
+	"github.com/rancher/hosted-providers-e2e/hosted/gke/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
@@ -31,12 +32,11 @@ const (
 )
 
 var (
-	ctx         helpers.Context
-	clusterName string
-	testCaseID  int64
-	zone        = helpers.GetGKEZone()
-	project     = helpers.GetGKEProjectID()
-	k8sVersion  = helpers.GetK8sVersion("gke")
+	ctx                     helpers.Context
+	clusterName, k8sVersion string
+	testCaseID              int64
+	zone                    = helpers.GetGKEZone()
+	project                 = helpers.GetGKEProjectID()
 )
 
 func TestP0(t *testing.T) {
@@ -46,9 +46,11 @@ func TestP0(t *testing.T) {
 
 var _ = BeforeEach(func() {
 	var err error
-	ctx, err = helpers.CommonBeforeSuite("gke")
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
 	Expect(err).To(BeNil())
-	clusterName = namegen.AppendRandomString("gkehostcluster")
+	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+	k8sVersion, err = helper.GetK8sVersion(ctx.RancherClient, project, ctx.CloudCred.ID, zone, "")
+	Expect(err).To(BeNil())
 })
 
 var _ = ReportBeforeEach(func(report SpecReport) {

--- a/hosted/gke/support_matrix/support_matrix_importing_test.go
+++ b/hosted/gke/support_matrix/support_matrix_importing_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportMatrixImporting", func() {
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {
-				clusterName = namegen.AppendRandomString("gkehostcluster")
+				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
 				gkeConfig := new(management.GKEClusterConfigSpec)
 				config.LoadAndUpdateConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig, func() {

--- a/hosted/gke/support_matrix/support_matrix_provisioning_test.go
+++ b/hosted/gke/support_matrix/support_matrix_provisioning_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportMatrixProvisioning", func() {
 				cluster     *management.Cluster
 			)
 			BeforeEach(func() {
-				clusterName = namegen.AppendRandomString("gkehostcluster")
+				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
 				gkeConfig := new(management.GKEClusterConfigSpec)
 				config.LoadAndUpdateConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig, func() {

--- a/hosted/gke/support_matrix/support_matrix_suite_test.go
+++ b/hosted/gke/support_matrix/support_matrix_suite_test.go
@@ -36,7 +36,7 @@ var (
 func TestSupportMatrix(t *testing.T) {
 	RegisterFailHandler(Fail)
 	var err error
-	ctx, err = helpers.CommonBeforeSuite("gke")
+	ctx, err = helpers.CommonBeforeSuite(helpers.Provider)
 	Expect(err).To(BeNil())
 	availableVersionList, err = helper.ListSingleVariantGKEAvailableVersions(ctx.RancherClient, project, ctx.CloudCred.ID, zone, "")
 	Expect(err).To(BeNil())

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -11,9 +11,6 @@ import (
 	"github.com/blang/semver"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
-	"github.com/rancher/shepherd/extensions/clusters/aks"
-	"github.com/rancher/shepherd/extensions/clusters/eks"
-	"github.com/rancher/shepherd/extensions/clusters/gke"
 	"github.com/rancher/shepherd/extensions/pipeline"
 
 	. "github.com/onsi/gomega"
@@ -196,41 +193,6 @@ func GetCommonMetadataLabels() map[string]string {
 		"owner":          "hosted-providers-qa-ci-" + testuser.Username,
 		"testfilenumber": filename,
 	}
-}
-
-func GetK8sVersion(provider string) string {
-	k8sVersion := os.Getenv("DOWNSTREAM_KUBERNETES_VERSION")
-	if k8sVersion != "" {
-		return k8sVersion
-	}
-	switch provider {
-	case "gke":
-		gkeConfig := new(management.GKEClusterConfigSpec)
-		config.LoadConfig(gke.GKEClusterConfigConfigurationFileKey, gkeConfig)
-		if gkeConfig.KubernetesVersion != nil {
-			k8sVersion = *gkeConfig.KubernetesVersion
-		} else {
-			k8sVersion = "1.27.3-gke.100"
-		}
-	case "eks":
-		eksConfig := new(management.EKSClusterConfigSpec)
-		config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, eksConfig)
-		if eksConfig.KubernetesVersion != nil {
-			k8sVersion = *eksConfig.KubernetesVersion
-		} else {
-			k8sVersion = "1.26"
-
-		}
-	case "aks":
-		aksConfig := new(management.AKSClusterConfigSpec)
-		config.LoadConfig(aks.AKSClusterConfigConfigurationFileKey, aksConfig)
-		if aksConfig.KubernetesVersion != nil {
-			k8sVersion = *aksConfig.KubernetesVersion
-		} else {
-			k8sVersion = "1.26.10"
-		}
-	}
-	return k8sVersion
 }
 
 func ListOperatorChart() (operatorCharts []HelmChart) {


### PR DESCRIPTION
### What does this PR do?
This PR makes the following change:
1. Add Qase IDs to K8s Chart Support tests.
2. Cleanup code for GKE Chart support tests to use global variables for fetching rancher and k8s version instead.
3. Add cluster specific `GetK8sVersion` to use DOWNSTREAM_KUBERNETES_VERSION or `Default[EKS/AKS/GKE]` to fetch the k8s version.
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #52

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
