### PR TITLE
WIP: Modify GH action steps to be executed if the job is not cancelled and add prefix to dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    commit-message:
+      # Prefix all commit messages with "[docker] " (no colon, but a trailing whitespace)
+      prefix: "[GHA] "
   - package-ecosystem: "gomod"
+    commit-message:
+      # Prefix all commit messages with "[docker] " (no colon, but a trailing whitespace)
+      prefix: "[Go] "
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -121,10 +121,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get Runner IP
+        if: ${{ !cancelled }}
         id: runner-ip
         run: echo "PUBLIC_IP=$(curl -s ifconfig.co)" >> "$GITHUB_OUTPUT"
 
       - name: Set Rancher hostname / password
+        if: ${{ !cancelled }}
         run: |
           if [ ${{ inputs.rancher_installed }} != 'hostname/password' ]; then
             echo RANCHER_HOSTNAME="$(echo ${{ inputs.rancher_installed }} | cut -d'/' -f1)" >> ${GITHUB_ENV}
@@ -135,7 +137,7 @@ jobs:
           fi
 
       - name: Install K3s / Helm / Rancher
-        if: ${{ inputs.rancher_installed == 'hostname/password' }}
+        if: ${{ !cancelled && inputs.rancher_installed == 'hostname/password' }}
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           HELM_VERSION: 3.13.1
@@ -151,24 +153,29 @@ jobs:
           fi
 
       - name: Authenticate to GCP
+        if: ${{ !cancelled }}
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       - name: Setup gcloud
+        if: ${{ !cancelled }}
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Install Azure cli
+        if: ${{ !cancelled }}
         run: |
           sudo zypper clean --all
           sudo zypper install -y azure-cli
           pip install azure-cli
             
       - name: Login to Azure
+        if: ${{ !cancelled }}
         uses: azure/login@v2.0.0
         with:
           creds: '{"clientId":"${{ env.AKS_CLIENT_ID }}","clientSecret":"${{ env.AKS_CLIENT_SECRET }}","subscriptionId":"${{ env.AKS_SUBSCRIPTION_ID }}","tenantId":"${{ env.AKS_TENANT_ID }}"}'
 
       - name: Install EKSCTL
+        if: ${{ !cancelled }}
         run: |
           # Better to always use the latest eksctl binary to avoid API version issue
           EKSCTL_GH=https://github.com/weaveworks/eksctl/releases/latest/download
@@ -177,6 +184,7 @@ jobs:
           sudo mv eksctl /usr/local/bin
             
       - name: Configure AWS credentials
+        if: ${{ !cancelled }}
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
@@ -184,11 +192,13 @@ jobs:
           aws-region: ${{ env.EKS_REGION }}
 
       - name: Install Go
+        if:  ${{ !cancelled }}
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Create/Export Qase Run
+        if: ${{ !cancelled }}
         id: qase
         run: |
           # Define and export URL of GH test run in Qase run description
@@ -205,7 +215,7 @@ jobs:
           echo -e "Exported values:\nQASE_RUN_ID=${ID}\nQASE_RUN_DESCRIPTION=${QASE_RUN_DESCRIPTION}\nQASE_RUN_NAME=${QASE_RUN_NAME}"
 
       - name: Provisioning cluster tests
-        if:  ${{ inputs.run_p0_provisioning_tests == true }}
+        if:  ${{ !cancelled && inputs.run_p0_provisioning_tests == true }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}


### PR DESCRIPTION
### What does this PR do?
1. Modify GH action steps to run if they are not cancelled. This way, if a certain plugin (for e.g. Azure errored out, the other plugins would still be installed.)
2. Add prefix to dependabot commit messages.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
