### PR TITLE
Fix default k8s version used for tests

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -428,6 +428,11 @@ func defaultAKS(client *rancher.Client, cloudCredentialID, region string, forUpg
 	// For upgrade tests, it returns a variant of the second-highest minor version
 	for i := len(versions) - 1; i >= 0; i-- {
 		version := versions[i]
+		// If UI maxValue not yet supported by operator
+		if !strings.Contains(version, maxValue) {
+			maxValue = versions[len(versions)-1]
+		}
+
 		if forUpgrade {
 			if result := helpers.VersionCompare(version, maxValue); result == -1 {
 				return version, nil

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -316,7 +316,8 @@ func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
 	_ = os.Setenv("KUBECONFIG", downstreamKubeconfig)
 
 	fmt.Println("Deleting EKS cluster ...")
-	args := []string{"delete", "cluster", "--region=" + eks_region, "--name=" + clusterName, "--wait", "--force"}
+	// TODO: Fix and wait for cluster deletion
+	args := []string{"delete", "cluster", "--region=" + eks_region, "--name=" + clusterName, "--disable-nodegroup-eviction"}
 	fmt.Printf("Running command: eksctl %v\n", args)
 	out, err := proc.RunW("eksctl", args...)
 	if err != nil {
@@ -343,6 +344,11 @@ func defaultEKS(client *rancher.Client, forUpgrade bool) (defaultEKS string, err
 
 	for i := 0; i < len(versions); i++ {
 		version := versions[i]
+		// If UI maxValue not yet supported by operator
+		if !strings.Contains(version, maxValue) {
+			maxValue = versions[0]
+		}
+
 		if forUpgrade {
 			if result := helpers.VersionCompare(version, maxValue); result == -1 {
 				return version, nil

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -71,10 +71,9 @@ var _ = ReportAfterEach(func(report SpecReport) {
 func p0upgradeK8sVersionChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
 
-	versions, err := helper.ListEKSAvailableVersions(client, cluster.ID)
+	// Default version is highest supported version
+	upgradeToVersion, err := helper.GetK8sVersion(client, false)
 	Expect(err).To(BeNil())
-	Expect(versions).ToNot(BeEmpty())
-	upgradeToVersion := versions[0]
 	GinkgoLogr.Info(fmt.Sprintf("Upgrading cluster to EKS version %s", upgradeToVersion))
 
 	By("upgrading the ControlPlane", func() {

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -523,9 +523,10 @@ func GetK8sVersion(client *rancher.Client, projectID, cloudCredentialID, zone, r
 		return "", err
 	}
 
-	maxValue := helpers.HighestK8sMinorVersionSupportedByUI(client)
+	// defaultValue has highest supported minorVersion
+	defaultValue, _ := defaultGKE(client, projectID, cloudCredentialID, zone, region)
 	for _, v := range allVariants {
-		if comparator := helpers.VersionCompare(v, maxValue); comparator == -1 {
+		if comparator := helpers.VersionCompare(v, defaultValue); comparator == -1 {
 			return v, nil
 		}
 	}

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -76,12 +76,8 @@ func p0upgradeK8sVersionChecks(cluster *management.Cluster, client *rancher.Clie
 	upgradeToVersion := versions[0]
 	GinkgoLogr.Info(fmt.Sprintf("Upgrading cluster to GKE version %s", upgradeToVersion))
 
+	// TODO: v2.9 Check - NodePool getting upgraded by default
 	By("upgrading the ControlPlane", func() {
-		cluster, err = helper.UpgradeKubernetesVersion(cluster, upgradeToVersion, client, false, true, true)
-		Expect(err).To(BeNil())
-	})
-
-	By("upgrading the NodePools", func() {
 		cluster, err = helper.UpgradeKubernetesVersion(cluster, upgradeToVersion, client, true, true, true)
 		Expect(err).To(BeNil())
 	})


### PR DESCRIPTION
### What does this PR do?
Fixes issue where _ui-k8s-default-version-range_ is updated, but operator not yet supports that k8s version
For eg. ui-k8s-default-version-range <=v1.30.x", operator highest supported version <=1.29

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes:
- Part of https://github.com/rancher/hosted-providers-e2e/issues/117
- Failing CI P0 jobs

### Checklist:
- [x] GitHub Actions
[AKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/9546464074), [EKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/9550218118), [GKE](https://github.com/rancher/hosted-providers-e2e/actions/runs/9550649412)

