### PR TITLE
Fix for chart support tests

### DIFF
--- a/hosted/aks/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -112,6 +112,10 @@ func commonchecks(client *rancher.Client, cluster *management.Cluster) {
 			helpers.WaitUntilOperatorChartInstallation(originalChartVersion, "", 0)
 		})
 
+		By("ensuring that rancher is up", func() {
+			helpers.CheckRancherPods(false)
+		})
+
 		err = clusters.WaitClusterToBeUpgraded(client, cluster.ID)
 		Expect(err).To(BeNil())
 		// Check if the desired config has been applied in Rancher

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -114,6 +114,10 @@ func commonChartSupport(client *rancher.Client, cluster *management.Cluster) {
 			helpers.WaitUntilOperatorChartInstallation(originalChartVersion, "", 0)
 		})
 
+		By("ensuring that rancher is up", func() {
+			helpers.CheckRancherPods(false)
+		})
+
 		err = clusters.WaitClusterToBeUpgraded(client, cluster.ID)
 		Expect(err).To(BeNil())
 		Eventually(func() int {

--- a/hosted/helpers/helper_rancher.go
+++ b/hosted/helpers/helper_rancher.go
@@ -58,16 +58,22 @@ func DeployRancherManager(fullVersion string, checkPods bool) {
 	Expect(err).To(BeNil())
 
 	if checkPods {
-		// Wait for all pods to be started
-		checkList := [][]string{
-			{CattleSystemNS, "app=rancher"},
-			{"cattle-fleet-local-system", "app=fleet-agent"},
-			{CattleSystemNS, "app=rancher-webhook"},
-		}
-		Eventually(func() error {
-			return rancherhelper.CheckPod(kubectl.New(), checkList)
-		}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		CheckRancherPods(true)
+	}
+}
 
+func CheckRancherPods(wait bool) {
+	// Wait for all pods to be started
+	checkList := [][]string{
+		{CattleSystemNS, "app=rancher"},
+		{"cattle-fleet-system", "app=fleet-controller"},
+		{CattleSystemNS, "app=rancher-webhook"},
+	}
+	Eventually(func() error {
+		return rancherhelper.CheckPod(kubectl.New(), checkList)
+	}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+
+	if wait {
 		// A bit dirty be better to wait a little here for all to be correctly started
 		time.Sleep(2 * time.Minute)
 	}


### PR DESCRIPTION
### What does this PR do?
Adds a check to ensure Rancher API is available after chart is re-installed to latest version

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #117 

### Checklist:
- [x] GitHub Actions
[AKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/9567909734), [EKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/9576500166), [GKE](https://github.com/rancher/hosted-providers-e2e/actions/runs/9565279217)

