### PR TITLE
Use new GCP template based on openSUSE 15.6

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -17,7 +17,7 @@ on:
         default: v1.27.9+k3s1
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2
         type: string
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
@@ -55,7 +55,7 @@ jobs:
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
       tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_importing' }}
       destroy_runner: ${{ inputs.destroy_runner == true }}
-      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -17,7 +17,7 @@ on:
         default: v1.27.9+k3s1
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2
         type: string
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
@@ -54,8 +54,8 @@ jobs:
       k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
       tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_importing' }}
-      destroy_runner: ${{ inputs.destroy_runner ==true }}
-      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
+      destroy_runner: ${{ inputs.destroy_runner == true }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -17,7 +17,7 @@ on:
         default: v1.27.9+k3s1
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2
         type: string
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
@@ -54,8 +54,8 @@ jobs:
       k3s_version: ${{ inputs.k3s_version || 'v1.27.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true }}
       tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_importing' }}
-      destroy_runner: ${{ inputs.destroy_runner ==true }}
-      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v1' }}
+      destroy_runner: ${{ inputs.destroy_runner == true }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,9 +105,17 @@ jobs:
   installation-and-e2e-tests:
     runs-on: ${{ needs.create-runner.outputs.uuid }}
     needs: create-runner
+    env:
+      # For some reason the go doesn't link by default against system libresolv library
+      CGO_LDFLAGS: -O2 -g -lresolv
     outputs:
       PUBLIC_IP: ${{ steps.runner-ip.outputs.PUBLIC_IP }}
     steps:
+      - name: Add /usr/local/bin into PATH
+        run: |
+          echo "/usr/local/bin/" >> ${GITHUB_PATH}
+          echo 'Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"' | sudo tee /etc/sudoers.d/0-custom_secure_path
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
### What does this PR do?
followup for https://github.com/rancher/hosted-providers-e2e/pull/123

Bumping GCP template to openSUSE 15.6 on `release/v2.8 branch`

Testrun for GKE p0_provisioning here https://github.com/rancher/hosted-providers-e2e/actions/runs/9792091101
