### PR TITLE
[CI]: Setup Rancher behind proxy in CI

### DIFF
--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -44,8 +44,13 @@ To use crust-gather; do the following:
 Ref: https://github.com/crust-gather/crust-gather
 EOF
 
+# Move back to logs dir
+cd ..
 
-docker exec squid_proxy cat /var/log/squid/access.log > ../logs/squid.log
-
+# Check if proxy has been implemented then fetch proxy logs
+if [[ $RANCHER_BEHIND_PROXY = true ]]; then
+  mkdir -p -m 755 proxy-logs
+  docker cp squid_proxy:/var/log/squid/access.log ../proxy-logs/squid.log
+fi
 # Done!
 exit 0

--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -45,5 +45,7 @@ Ref: https://github.com/crust-gather/crust-gather
 EOF
 
 
+docker exec squid_proxy cat /var/log/squid/access.log > ../logs/squid.log
+
 # Done!
 exit 0

--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -50,7 +50,8 @@ cd ..
 # Check if proxy has been implemented then fetch proxy logs
 if [[ $RANCHER_BEHIND_PROXY = true ]]; then
   mkdir -p -m 755 proxy-logs
-  docker cp squid_proxy:/var/log/squid/access.log ../proxy-logs/squid.log
+  cd proxy-logs
+  docker cp squid_proxy:/var/log/squid/access.log ./squid-access.log
 fi
 # Done!
 exit 0

--- a/.github/scripts/squid.conf
+++ b/.github/scripts/squid.conf
@@ -1,0 +1,82 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
+acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
+acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
+acl localnet src fc00::/7       # RFC 4193 local private network range
+acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl SSL_ports port 6443
+acl SSL_ports port 22
+acl SSL_ports port 2376
+
+acl Safe_ports port 22      # ssh
+acl Safe_ports port 2376    # docker port
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl Safe_ports port 6443        # k8s
+acl CONNECT method CONNECT
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access allow all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/cache/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/cache/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320
+
+debug_options ALL,1 11,3 20,3

--- a/.github/scripts/squid.conf
+++ b/.github/scripts/squid.conf
@@ -59,7 +59,7 @@ http_access deny manager
 http_access allow localnet
 http_access allow localhost
 
-# And finally deny all other access to this proxy
+# And finally -deny- allow all other access to this proxy
 http_access allow all
 
 # Squid normally listens to port 3128

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -45,6 +45,10 @@ on:
         type: string
         required: true
         default: p0_provisioning/p0_import
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
 
 jobs:
   aks-e2e:
@@ -61,3 +65,4 @@ jobs:
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
+      proxy: ${{ inputs.proxy == true }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -45,6 +45,10 @@ on:
         type: string
         required: true
         default: p0_provisioning/p0_import
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
 
 jobs:
   eks-e2e:
@@ -61,3 +65,4 @@ jobs:
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
+      proxy: ${{ inputs.proxy == true }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -45,6 +45,10 @@ on:
         type: string
         required: true
         default: p0_provisioning/p0_import
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
 
 jobs:
   gke-e2e:
@@ -61,3 +65,4 @@ jobs:
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
+      proxy: ${{ inputs.proxy == true }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -147,7 +147,7 @@ jobs:
       - name: Install Proxy
         if: ${{ inputs.rancher_installed == 'hostname/password' && inputs.proxy == true }}
         run: |
-          docker run -d --name squid_proxy -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
+          docker run -d --name squid_proxy -v $(pwd)/.github/scripts/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
       - name: Install K3s / Helm / Rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,6 +39,9 @@ on:
       downstream_cluster_cleanup:
         description: Cleanup downstream clusters after test
         type: boolean
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -141,7 +144,10 @@ jobs:
             echo RANCHER_HOSTNAME=${{ steps.runner-ip.outputs.PUBLIC_IP }}.sslip.io >> $GITHUB_ENV
             echo RANCHER_PASSWORD=${{ secrets.RANCHER_PASSWORD }} >> $GITHUB_ENV
           fi
-
+      - name: Install Proxy
+        if: ${{ inputs.rancher_installed == 'hostname/password' && inputs.proxy == true }}
+        run: |
+          docker run -d --name squid_proxy -v $(pwd)/tests/assets/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
       - name: Install K3s / Helm / Rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
         env:
@@ -154,6 +160,8 @@ jobs:
         run: |
           if [ ${{ inputs.operator_nightly_chart }} == true ]; then
             make prepare-e2e-ci-rancher-hosted-nightly-chart
+          if [ ${{ inputs.proxy }} == true ]; then
+            make prepare-e2e-ci-rancher-behind-proxy
           else
             make prepare-e2e-ci-rancher
           fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -148,6 +148,7 @@ jobs:
         if: ${{ inputs.rancher_installed == 'hostname/password' && inputs.proxy == true }}
         run: |
           docker run -d --name squid_proxy -v $(pwd)/.github/scripts/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
+
       - name: Install K3s / Helm / Rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
         env:
@@ -160,7 +161,7 @@ jobs:
         run: |
           if [ ${{ inputs.operator_nightly_chart }} == true ]; then
             make prepare-e2e-ci-rancher-hosted-nightly-chart
-          if [ ${{ inputs.proxy }} == true ]; then
+          elif [ ${{ inputs.proxy }} == true ]; then
             make prepare-e2e-ci-rancher-behind-proxy
           else
             make prepare-e2e-ci-rancher

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -144,10 +144,17 @@ jobs:
             echo RANCHER_HOSTNAME=${{ steps.runner-ip.outputs.PUBLIC_IP }}.sslip.io >> $GITHUB_ENV
             echo RANCHER_PASSWORD=${{ secrets.RANCHER_PASSWORD }} >> $GITHUB_ENV
           fi
+
       - name: Install Proxy
         if: ${{ inputs.rancher_installed == 'hostname/password' && inputs.proxy == true }}
         run: |
           docker run -d --name squid_proxy -v $(pwd)/.github/scripts/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
+          echo "PROXY_HOST=$(gcloud compute instances describe ${{ needs.create-runner.outputs.runner }} \
+            --format='get(networkInterfaces[0].networkIP)' --zone ${{ env.GCP_RUNNER_ZONE }}):3128" >> ${GITHUB_ENV}
+          echo "HTTP_PROXY=http://${PROXY_HOST}" >> ${GITHUB_ENV}
+          echo "HTTPS_PROXY=http://${PROXY_HOST}" >> ${GITHUB_ENV}
+          echo "NO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local" >> ${GITHUB_ENV}
+
 
       - name: Install K3s / Helm / Rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
@@ -158,6 +165,10 @@ jobs:
           RANCHER_VERSION: ${{ inputs.rancher_version }}
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
+          PROXY_HOST: ${{ env.PROXY_HOST }}
+          HTTP_PROXY: ${{ env.HTTP_PROXY }}
+          HTTPS_PROXY: ${{ env.HTTPS_PROXY }}
+          NO_PROXY: ${{ env.NO_PROXY }}
         run: |
           if [ ${{ inputs.operator_nightly_chart }} == true ]; then
             make prepare-e2e-ci-rancher-hosted-nightly-chart

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -151,10 +151,6 @@ jobs:
           docker run -d --name squid_proxy -v $(pwd)/.github/scripts/squid.conf:/etc/squid/squid.conf -p 3128:3128 wernight/squid
           echo "PROXY_HOST=$(gcloud compute instances describe ${{ needs.create-runner.outputs.runner }} \
             --format='get(networkInterfaces[0].networkIP)' --zone ${{ env.GCP_RUNNER_ZONE }}):3128" >> ${GITHUB_ENV}
-          echo "HTTP_PROXY=http://${PROXY_HOST}" >> ${GITHUB_ENV}
-          echo "HTTPS_PROXY=http://${PROXY_HOST}" >> ${GITHUB_ENV}
-          echo "NO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local" >> ${GITHUB_ENV}
-
 
       - name: Install K3s / Helm / Rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
@@ -166,12 +162,13 @@ jobs:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           PROXY_HOST: ${{ env.PROXY_HOST }}
-          HTTP_PROXY: ${{ env.HTTP_PROXY }}
-          HTTPS_PROXY: ${{ env.HTTPS_PROXY }}
-          NO_PROXY: ${{ env.NO_PROXY }}
         run: |
           if [ ${{ inputs.operator_nightly_chart }} == true ]; then
-            make prepare-e2e-ci-rancher-hosted-nightly-chart
+            if [ ${{ inputs.proxy }} == true ]; then
+              make prepare-e2e-ci-rancher-hosted-nightly-chart-behind-proxy
+            else
+              make prepare-e2e-ci-rancher-hosted-nightly-chart
+            fi
           elif [ ${{ inputs.proxy }} == true ]; then
             make prepare-e2e-ci-rancher-behind-proxy
           else
@@ -342,6 +339,7 @@ jobs:
       - name: Collect logs
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+          RANCHER_BEHIND_PROXY: ${{ inputs.proxy == true }}
         if: ${{ !cancelled() }}
         run: |
           chmod +x ${{ env.RANCHER_LOG_COLLECTOR }}

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,8 @@ install-k3s: ## Install K3s with default options; installed on the local machine
 	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"
 
 install-k3s-behind-proxy:
-	cat <<'EOF' | sudo tee /etc/default/k3s > /dev/null
-	HTTP_PROXY=http://${PROXY_HOST}
-	HTTPS_PROXY=https://${PROXY_HOST}
-	NO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
-	EOF
+	echo -e 'HTTP_PROXY=http://${PROXY_HOST}\nHTTPS_PROXY=https://${PROXY_HOST}\nNO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local' > k3s
+	sudo mv k3s /etc/default/k3s
 	curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} sh -s - --write-kubeconfig-mode 644
 	## Wait for K3s to start
 	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ BUILD_DATE= $(shell date +'%Y%m%d')
 install-k3s: ## Install K3s with default options; installed on the local machine
 	curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} sh -s - --write-kubeconfig-mode 644
 	## Wait for K3s to start
-	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"
+	timeout 2m bash -c "until kubectl get pod -A 2>/dev/null | grep -Eq 'Running|Completed'; do sleep 1; done"
 
 install-k3s-behind-proxy:
 	curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} sh -s - --write-kubeconfig-mode 644
 	## Wait for K3s to start
-	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"
-	echo -e 'HTTP_PROXY=http://${PROXY_HOST}\nHTTPS_PROXY=https://${PROXY_HOST}\nNO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local' > k3s
+	timeout 2m bash -c "until kubectl get pod -A 2>/dev/null | grep -Eq 'Running|Completed'; do sleep 1; done"
+	echo "HTTP_PROXY=http://${PROXY_HOST}\nHTTPS_PROXY=https://${PROXY_HOST}\nNO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local" > k3s
 	sudo mv k3s /etc/default/k3s
 
 install-helm: ## Install Helm on the local machine
@@ -32,7 +32,7 @@ install-cert-manager: ## Install cert-manager via Helm on the k8s cluster
 		--set extraArgs[0]=--enable-certificate-owner-ref=true
 	kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
 
-installl-cert-manager-behind-proxy:
+install-cert-manager-behind-proxy:
 	kubectl create namespace cert-manager
 	helm repo add jetstack https://charts.jetstack.io
 	helm repo update
@@ -79,7 +79,7 @@ install-rancher-hosted-nightly-chart: ## Install Rancher via Helm with hosted pr
 	helm install ${PROVIDER}-operator-crds  oci://ttl.sh/${PROVIDER}-operator/rancher-${PROVIDER}-operator-crd --version ${BUILD_DATE}
 	helm install ${PROVIDER}-operator oci://ttl.sh/${PROVIDER}-operator/rancher-${PROVIDER}-operator --version ${BUILD_DATE} --namespace cattle-system
 
-install-rancher-behind-proxy:
+install-rancher-behind-proxy:  ## Setup Rancher behind proxy on the local machine
 	helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 	helm repo update
 	helm install rancher --devel rancher-latest/rancher \
@@ -92,8 +92,36 @@ install-rancher-behind-proxy:
 		--set replicas=1 \
 		--set rancherImageTag=v${RANCHER_VERSION} \
 		--set proxy=http://${PROXY_HOST} \
+		--set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local \
 		--wait
 	kubectl rollout status deployment rancher -n cattle-system --timeout=300s
+
+install-rancher-hosted-nightly-chart-behind-proxy:  ## Setup Rancher with nightly hosted provider charts behind proxy on the local machine
+	helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+	helm repo update
+	helm install rancher --devel rancher-latest/rancher \
+		--namespace cattle-system \
+		--create-namespace \
+		--version ${RANCHER_VERSION} \
+		--set global.cattle.psp.enabled=false \
+		--set hostname=${RANCHER_HOSTNAME} \
+		--set bootstrapPassword=${RANCHER_PASSWORD} \
+		--set replicas=1 \
+		--set rancherImageTag=v${RANCHER_VERSION} \
+		--set proxy=http://${PROXY_HOST} \
+		--set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local \
+		--set 'extraEnv[0].name=CATTLE_SKIP_HOSTED_CLUSTER_CHART_INSTALLATION' \
+		--set-string 'extraEnv[0].value=true' \
+		--wait
+	kubectl rollout status deployment rancher -n cattle-system --timeout=300s
+	helm install ${PROVIDER}-operator-crds  oci://ttl.sh/${PROVIDER}-operator/rancher-${PROVIDER}-operator-crd --version ${BUILD_DATE} \
+		--set proxy=http://${PROXY_HOST} \
+		--set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
+	helm install ${PROVIDER}-operator oci://ttl.sh/${PROVIDER}-operator/rancher-${PROVIDER}-operator --version ${BUILD_DATE} \
+ 		--namespace cattle-system \
+ 		--set proxy=http://${PROXY_HOST} \
+		--set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
+
 
 deps: ## Install the Go dependencies
 	go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
@@ -102,7 +130,8 @@ deps: ## Install the Go dependencies
 
 prepare-e2e-ci-rancher-hosted-nightly-chart: install-k3s install-helm install-cert-manager install-rancher-hosted-nightly-chart ## Setup Rancher with nightly hosted provider charts on the local machine
 prepare-e2e-ci-rancher: install-k3s install-helm install-cert-manager install-rancher ## Setup Rancher on the local machine
-prepare-e2e-ci-rancher-behind-proxy: install-k3s-behind-proxy install-helm install-cert-manager install-rancher-behind-proxy ## Setup Rancher behind proxy on the local machine
+prepare-e2e-ci-rancher-behind-proxy: install-k3s-behind-proxy install-helm install-cert-manager-behind-proxy install-rancher-behind-proxy ## Setup Rancher behind proxy on the local machine
+prepare-e2e-ci-rancher-hosted-nightly-chart-behind-proxy: install-k3s-behind-proxy install-helm install-cert-manager-behind-proxy install-rancher-hosted-nightly-chart-behind-proxy ## Setup Rancher with nightly hosted provider charts behind proxy on the local machine
 
 e2e-import-tests: deps	## Run the 'P0Import' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Import" ./hosted/${PROVIDER}/p0/

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,16 @@ install-k3s: ## Install K3s with default options; installed on the local machine
 	## Wait for K3s to start
 	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"
 
+install-k3s-behind-proxy:
+	cat <<'EOF' | sudo tee /etc/default/k3s > /dev/null
+	HTTP_PROXY=http://${PROXY_HOST}
+	HTTPS_PROXY=https://${PROXY_HOST}
+	NO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+	EOF
+	curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} sh -s - --write-kubeconfig-mode 644
+	## Wait for K3s to start
+	timeout 2m bash -c "until ! kubectl get pod -A 2>/dev/null | grep -Eq 'ContainerCreating|CrashLoopBackOff'; do sleep 1; done"
+
 install-helm: ## Install Helm on the local machine
 	curl --silent --location https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar xz -C .
 	sudo mv linux-amd64/helm /usr/local/bin
@@ -23,6 +33,19 @@ install-cert-manager: ## Install cert-manager via Helm on the k8s cluster
 	helm install cert-manager --namespace cert-manager jetstack/cert-manager \
 		--set installCRDs=true \
 		--set extraArgs[0]=--enable-certificate-owner-ref=true
+	kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
+
+installl-cert-manager-behind-proxy:
+	kubectl create namespace cert-manager
+	helm repo add jetstack https://charts.jetstack.io
+	helm repo update
+	helm install cert-manager --namespace cert-manager jetstack/cert-manager \
+		--set installCRDs=true \
+		--set extraArgs[0]=--enable-certificate-owner-ref=true \
+		--set http_proxy=http://${PROXY_HOST} \
+		--set https_proxy=https://${PROXY_HOST} \
+		--set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
+
 	kubectl rollout status deployment cert-manager -n cert-manager --timeout=120s
 
 install-rancher: ## Install Rancher via Helm on the k8s cluster
@@ -71,7 +94,7 @@ install-rancher-behind-proxy:
 		--set bootstrapPassword=${RANCHER_PASSWORD} \
 		--set replicas=1 \
 		--set rancherImageTag=v${RANCHER_VERSION} \
-		--set proxy=http://172.17.0.1:3128 \
+		--set proxy=http://${PROXY_HOST} \
         --set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local \
 		--wait
 	kubectl rollout status deployment rancher -n cattle-system --timeout=300s
@@ -83,7 +106,7 @@ deps: ## Install the Go dependencies
 
 prepare-e2e-ci-rancher-hosted-nightly-chart: install-k3s install-helm install-cert-manager install-rancher-hosted-nightly-chart ## Setup Rancher with nightly hosted provider charts on the local machine
 prepare-e2e-ci-rancher: install-k3s install-helm install-cert-manager install-rancher ## Setup Rancher on the local machine
-prepare-e2e-ci-rancher-behind-proxy: install-k3s install-helm install-cert-manager install-rancher-behind-proxy ## Setup Rancher behind proxy on the local machine
+prepare-e2e-ci-rancher-behind-proxy: install-k3s-behind-proxy install-helm installl-cert-manager-behind-proxy install-rancher-behind-proxy ## Setup Rancher behind proxy on the local machine
 
 e2e-import-tests: deps	## Run the 'P0Import' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Import" ./hosted/${PROVIDER}/p0/


### PR DESCRIPTION
### What does this PR do?
This PRs adds steps to install rancher behind proxy for automation tests using [Squid proxy](https://www.squid-cache.org/). 

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #128 

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [nightly charts] https://github.com/rancher/hosted-providers-e2e/actions/runs/10488976030/job/29052577727, [regular] https://github.com/rancher/hosted-providers-e2e/actions/runs/10488978931

### Special notes for your reviewer:
These changes are copied from/implemented using rancher/elemental CI. Check the logs to know if requests went through proxy.

TODO: Add a doc to setup Rancher behind proxy.