### PR TITLE
Automate Qase 55 and 34; Windows nodepool update in GKE

### DIFF
--- a/cattle-config-provisioning.yaml
+++ b/cattle-config-provisioning.yaml
@@ -111,7 +111,7 @@ gkeClusterConfig:
       autoRepair: true
       autoUpgrade: true
     maxPodsConstraint: 110
-    name: default-pool
+    name: np
     version: 1.27.3-gke.100
   privateClusterConfig:
     enablePrivateEndpoint: false

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -478,7 +478,7 @@ func CreateGKEClusterOnGCloud(zone string, clusterName string, project string, k
 // AddNodePoolOnGCloud adds a nodepool to the GKE cluster via gcloud CLI
 func AddNodePoolOnGCloud(clusterName, zone, project, npName string, extraArgs ...string) error {
 	if npName == "" {
-		npName = namegen.AppendRandomString("default-pool")
+		npName = namegen.AppendRandomString("np")
 	}
 
 	fmt.Println("Adding nodepool to the GKE cluster ...")

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -389,6 +389,17 @@ func UpdateAutoScaling(cluster *management.Cluster, client *rancher.Client, enab
 	return cluster, nil
 }
 
+// UpdateCluster is a generic function to update a cluster
+func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFunc func(*management.Cluster)) (*management.Cluster, error) {
+	upgradedCluster := new(management.Cluster)
+	upgradedCluster.Name = cluster.Name
+	upgradedCluster.GKEConfig = cluster.GKEConfig
+
+	updateFunc(upgradedCluster)
+
+	return client.Management.Cluster.Update(cluster, &upgradedCluster)
+}
+
 // ListGKEAvailableVersions is a function to list and return only available GKE versions for a specific cluster.
 func ListGKEAvailableVersions(client *rancher.Client, clusterID string) ([]string, error) {
 	// kubernetesversions.ListGKEAvailableVersions expects cluster.Version.GitVersion to be available, which it is not sometimes, so we fetch the cluster again to ensure it has all the available data
@@ -467,7 +478,7 @@ func CreateGKEClusterOnGCloud(zone string, clusterName string, project string, k
 // AddNodePoolOnGCloud adds a nodepool to the GKE cluster via gcloud CLI
 func AddNodePoolOnGCloud(clusterName, zone, project, npName string, extraArgs ...string) error {
 	if npName == "" {
-		npName = namegen.AppendRandomString("np")
+		npName = namegen.AppendRandomString("default-pool")
 	}
 
 	fmt.Println("Adding nodepool to the GKE cluster ...")
@@ -483,7 +494,6 @@ func AddNodePoolOnGCloud(clusterName, zone, project, npName string, extraArgs ..
 	fmt.Println("Added nodepool to GKE cluster: ", clusterName)
 
 	return nil
-
 }
 
 // ClusterExistsOnGCloud gets a list of cluster based on the name filter and returns true if the cluster is in RUNNING or PROVISIONING state;

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -18,7 +18,7 @@ var _ = Describe("K8sChartSupportProvisioning", func() {
 	)
 	BeforeEach(func() {
 		var err error
-		cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project)
+		cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 1)
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())

--- a/hosted/gke/k8s_chart_support/upgrade/k8s_chart_support_provisioning_upgrade_test.go
+++ b/hosted/gke/k8s_chart_support/upgrade/k8s_chart_support_provisioning_upgrade_test.go
@@ -18,7 +18,7 @@ var _ = Describe("K8sChartSupportUpgradeProvisioning", func() {
 	)
 	BeforeEach(func() {
 		var err error
-		cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project)
+		cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 1)
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -56,7 +56,7 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
-				cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project)
+				cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 1)
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -89,7 +89,7 @@ var _ = Describe("P1Importing", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should not be able to update the only non-windows nodepool to windows", func() {
+		FIt("should not be able to update the only non-windows nodepool to windows", func() {
 			upgradedCluster := new(management.Cluster)
 			upgradedCluster.Name = cluster.Name
 			upgradedCluster.GKEConfig = cluster.GKEConfig
@@ -107,7 +107,7 @@ var _ = Describe("P1Importing", func() {
 		})
 	})
 
-	When("a cluster is created with at least 2 node pools", func() {
+	FWhen("a cluster is created with at least 2 node pools", func() {
 		var cluster *management.Cluster
 
 		BeforeEach(func() {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -89,7 +89,9 @@ var _ = Describe("P1Importing", func() {
 			Expect(err).To(BeNil())
 		})
 
-		FIt("should not be able to update the only non-windows nodepool to windows", func() {
+		It("should not be able to update the only non-windows nodepool to windows", func() {
+			testCaseID = 264
+
 			upgradedCluster := new(management.Cluster)
 			upgradedCluster.Name = cluster.Name
 			upgradedCluster.GKEConfig = cluster.GKEConfig
@@ -107,7 +109,7 @@ var _ = Describe("P1Importing", func() {
 		})
 	})
 
-	FWhen("a cluster is created with at least 2 node pools", func() {
+	When("a cluster is created with at least 2 node pools", func() {
 		var cluster *management.Cluster
 
 		BeforeEach(func() {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -89,7 +89,7 @@ var _ = Describe("P1Importing", func() {
 			Expect(err).To(BeNil())
 		})
 
-		FIt("should not be able to update the only non-windows nodepool to windows", func() {
+		It("should not be able to update the only non-windows nodepool to windows", func() {
 			upgradedCluster := new(management.Cluster)
 			upgradedCluster.Name = cluster.Name
 			upgradedCluster.GKEConfig = cluster.GKEConfig
@@ -107,7 +107,7 @@ var _ = Describe("P1Importing", func() {
 		})
 	})
 
-	FWhen("a cluster is created with at least 2 node pools", func() {
+	When("a cluster is created with at least 2 node pools", func() {
 		var cluster *management.Cluster
 
 		BeforeEach(func() {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -2,6 +2,7 @@ package p1_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -86,6 +87,74 @@ var _ = Describe("P1Importing", func() {
 			var err error
 			_, err = helper.AddNodePool(cluster, ctx.RancherAdminClient, 1, "WINDOWS_LTSC_CONTAINERD", true, true)
 			Expect(err).To(BeNil())
+		})
+
+		FIt("should not be able to update the only non-windows nodepool to windows", func() {
+			upgradedCluster := new(management.Cluster)
+			upgradedCluster.Name = cluster.Name
+			upgradedCluster.GKEConfig = cluster.GKEConfig
+
+			updateNodePoolsList := cluster.GKEConfig.NodePools
+			for i := 0; i < len(updateNodePoolsList); i++ {
+				updateNodePoolsList[i].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
+			}
+
+			upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+
+			_, err := ctx.RancherAdminClient.Management.Cluster.Update(cluster, &upgradedCluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("require at least one other Linux node pool"))
+		})
+	})
+
+	FWhen("a cluster is created with at least 2 node pools", func() {
+		var cluster *management.Cluster
+
+		BeforeEach(func() {
+			var err error
+			err = helper.CreateGKEClusterOnGCloud(zone, clusterName, project, k8sVersion)
+			Expect(err).To(BeNil())
+
+			err = helper.AddNodePoolOnGCloud(clusterName, zone, project, "")
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, zone, project)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
+			cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup && cluster != nil {
+				err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("For a given NodePool with a non-windows imageType, updating it to a windows imageType should fail", func() {
+			testCaseID = 55
+			upgradedCluster := new(management.Cluster)
+			upgradedCluster.Name = cluster.Name
+			upgradedCluster.GKEConfig = cluster.GKEConfig
+
+			updateNodePoolsList := cluster.GKEConfig.NodePools
+			updateNodePoolsList[0].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
+
+			upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+
+			cluster, err := ctx.RancherAdminClient.Management.Cluster.Update(cluster, &upgradedCluster)
+			Expect(err).To(BeNil())
+			Eventually(func() bool {
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "Node pools cannot be upgraded between Windows and non-Windows image families")
+			}, "30s", "2s").Should(BeTrue())
 		})
 	})
 

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -89,7 +89,7 @@ var _ = Describe("P1Importing", func() {
 			Expect(err).To(BeNil())
 		})
 
-		FIt("updating a cluster to all windows nodepool should fail", func() {
+		It("updating a cluster to all windows nodepool should fail", func() {
 			testCaseID = 264
 			_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
 				updateNodePoolsList := cluster.GKEConfig.NodePools
@@ -104,7 +104,7 @@ var _ = Describe("P1Importing", func() {
 		})
 	})
 
-	FWhen("a cluster is created with at least 2 node pools", func() {
+	When("a cluster is created with at least 2 node pools", func() {
 		var cluster *management.Cluster
 
 		BeforeEach(func() {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -89,7 +89,7 @@ var _ = Describe("P1Importing", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("updating a cluster to all windows nodepool should fail", func() {
+		FIt("updating a cluster to all windows nodepool should fail", func() {
 			testCaseID = 264
 			_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
 				updateNodePoolsList := cluster.GKEConfig.NodePools
@@ -104,7 +104,7 @@ var _ = Describe("P1Importing", func() {
 		})
 	})
 
-	When("a cluster is created with at least 2 node pools", func() {
+	FWhen("a cluster is created with at least 2 node pools", func() {
 		var cluster *management.Cluster
 
 		BeforeEach(func() {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -103,7 +103,7 @@ var _ = Describe("P1Importing", func() {
 
 			_, err := ctx.RancherAdminClient.Management.Cluster.Update(cluster, &upgradedCluster)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("require at least one other Linux node pool"))
+			Expect(err.Error()).To(ContainSubstring("at least 1 Linux node pool is required"))
 		})
 	})
 

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -196,7 +196,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 		})
 
-		FIt("should not be able to update the only non-windows nodepool to windows", func() {
+		It("should not be able to update the only non-windows nodepool to windows", func() {
 			upgradedCluster := new(management.Cluster)
 			upgradedCluster.Name = cluster.Name
 			upgradedCluster.GKEConfig = cluster.GKEConfig
@@ -214,7 +214,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	FWhen("creating a cluster with at least 2 nodepools", func() {
+	When("creating a cluster with at least 2 nodepools", func() {
 		BeforeEach(func() {
 			var err error
 			cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 2)

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -196,7 +196,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("updating a cluster to all windows nodepool should fail", func() {
+		FIt("updating a cluster to all windows nodepool should fail", func() {
 			testCaseID = 263
 
 			_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
@@ -212,7 +212,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	When("creating a cluster with at least 2 nodepools", func() {
+	FWhen("creating a cluster with at least 2 nodepools", func() {
 		BeforeEach(func() {
 			var err error
 			cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 2)

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -196,7 +196,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 		})
 
-		FIt("updating a cluster to all windows nodepool should fail", func() {
+		It("updating a cluster to all windows nodepool should fail", func() {
 			testCaseID = 263
 
 			_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
@@ -212,7 +212,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	FWhen("creating a cluster with at least 2 nodepools", func() {
+	When("creating a cluster with at least 2 nodepools", func() {
 		BeforeEach(func() {
 			var err error
 			cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 2)

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -210,7 +210,7 @@ var _ = Describe("P1Provisioning", func() {
 
 			_, err := ctx.RancherAdminClient.Management.Cluster.Update(cluster, &upgradedCluster)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("require at least one other Linux node pool"))
+			Expect(err.Error()).To(ContainSubstring("at least 1 Linux node pool is required"))
 		})
 	})
 

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -196,20 +196,17 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should not be able to update the only non-windows nodepool to windows", func() {
+		It("updating a cluster to all windows nodepool should fail", func() {
 			testCaseID = 263
-			upgradedCluster := new(management.Cluster)
-			upgradedCluster.Name = cluster.Name
-			upgradedCluster.GKEConfig = cluster.GKEConfig
 
-			updateNodePoolsList := cluster.GKEConfig.NodePools
-			for i := 0; i < len(updateNodePoolsList); i++ {
-				updateNodePoolsList[i].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
-			}
+			_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
+				updateNodePoolsList := cluster.GKEConfig.NodePools
+				for i := 0; i < len(updateNodePoolsList); i++ {
+					updateNodePoolsList[i].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
+				}
 
-			upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
-
-			_, err := ctx.RancherAdminClient.Management.Cluster.Update(cluster, &upgradedCluster)
+				upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("at least 1 Linux node pool is required"))
 		})
@@ -233,19 +230,15 @@ var _ = Describe("P1Provisioning", func() {
 			}
 		})
 
-		It("For a given NodePool with a non-windows imageType, updating it to a windows imageType should fail", func() {
+		It("for a given NodePool with a non-windows imageType, updating it to a windows imageType should fail", func() {
 			testCaseID = 34
-			upgradedCluster := new(management.Cluster)
-			upgradedCluster.Name = cluster.Name
-			upgradedCluster.GKEConfig = cluster.GKEConfig
+			var err error
+			cluster, err = helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
+				updateNodePoolsList := cluster.GKEConfig.NodePools
+				updateNodePoolsList[0].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
 
-			updateNodePoolsList := cluster.GKEConfig.NodePools
-			updateNodePoolsList[0].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
-
-			upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
-
-			cluster, err := ctx.RancherAdminClient.Management.Cluster.Update(cluster, &upgradedCluster)
-			Expect(err).To(BeNil())
+				upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+			})
 
 			Eventually(func() bool {
 				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -196,7 +196,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should not be able to update the only non-windows nodepool to windows", func() {
+		FIt("should not be able to update the only non-windows nodepool to windows", func() {
 			upgradedCluster := new(management.Cluster)
 			upgradedCluster.Name = cluster.Name
 			upgradedCluster.GKEConfig = cluster.GKEConfig
@@ -214,7 +214,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	When("creating a cluster with at least 2 nodepools", func() {
+	FWhen("creating a cluster with at least 2 nodepools", func() {
 		BeforeEach(func() {
 			var err error
 			cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 2)

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -196,7 +196,8 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 		})
 
-		FIt("should not be able to update the only non-windows nodepool to windows", func() {
+		It("should not be able to update the only non-windows nodepool to windows", func() {
+			testCaseID = 263
 			upgradedCluster := new(management.Cluster)
 			upgradedCluster.Name = cluster.Name
 			upgradedCluster.GKEConfig = cluster.GKEConfig
@@ -214,7 +215,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	FWhen("creating a cluster with at least 2 nodepools", func() {
+	When("creating a cluster with at least 2 nodepools", func() {
 		BeforeEach(func() {
 			var err error
 			cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 2)

--- a/hosted/gke/support_matrix/support_matrix_provisioning_test.go
+++ b/hosted/gke/support_matrix/support_matrix_provisioning_test.go
@@ -40,7 +40,7 @@ var _ = Describe("SupportMatrixProvisioning", func() {
 			BeforeEach(func() {
 				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
-				cluster, err = helper.CreateGKEHostedCluster(ctx.StdUserClient, clusterName, ctx.CloudCred.ID, version, zone, project)
+				cluster, err = helper.CreateGKEHostedCluster(ctx.StdUserClient, clusterName, ctx.CloudCred.ID, version, zone, project, 1)
 				Expect(err).To(BeNil())
 				// Requires RancherAdminClient
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)


### PR DESCRIPTION
### What does this PR do?
1. Add `npSize` to CreateGKEHostedCluster to create nodepool with more than 1 np.
2. Add `AddNodePoolOnGCloud` to add nodepool via CLI.
3. Automate qase 55 and 34 - changing non-windows > windows should fail
4. Automate all windows np should fail.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - https://github.com/rancher/hosted-providers-e2e/actions/runs/10058907754, https://github.com/rancher/hosted-providers-e2e/actions/runs/10073527172/job/27847815539 (tests have passed, the action has failed because of programmatic focus)

### Special notes for your reviewer:
