### PR TITLE
Rename importing references

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -41,10 +41,10 @@ on:
         default: 'hostname/password'
         type: string
       tests_to_run:
-        description: Tests to run (p0_provisioning/p0_importing/support_matrix_provisioning/support_matrix_importing/k8s_chart_support_provisioning/k8s_chart_support_importing)
+        description: Tests to run (p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import)
         type: string
         required: true
-        default: p0_provisioning/p0_importing
+        default: p0_provisioning/p0_import
 
 jobs:
   aks-e2e:
@@ -55,7 +55,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || '2.9-head' }}
       k3s_version: ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_importing' }}
+      tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_import' }}
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -41,10 +41,10 @@ on:
         default: 'hostname/password'
         type: string
       tests_to_run:
-        description: Tests to run (p0_provisioning/p0_importing/support_matrix_provisioning/support_matrix_importing/k8s_chart_support_provisioning/k8s_chart_support_importing)
+        description: Tests to run (p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import)
         type: string
         required: true
-        default: p0_provisioning/p0_importing
+        default: p0_provisioning/p0_import
 
 jobs:
   eks-e2e:
@@ -55,7 +55,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || '2.9-head' }}
       k3s_version: ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_importing' }}
+      tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_import' }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -41,10 +41,10 @@ on:
         default: 'hostname/password'
         type: string
       tests_to_run:
-        description: Tests to run (p0_provisioning/p0_importing/p1_provisioning/p1_importing/support_matrix_provisioning/support_matrix_importing/k8s_chart_support_provisioning/k8s_chart_support_importing/sync_provisioning/sync_importing)
+        description: Tests to run (p0_provisioning/p0_import/p1_provisioning/p1_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import/sync_provisioning/sync_import)
         type: string
         required: true
-        default: p0_provisioning/p0_importing
+        default: p0_provisioning/p0_import
 
 jobs:
   gke-e2e:
@@ -55,7 +55,7 @@ jobs:
       rancher_version: ${{ inputs.rancher_version || '2.9-head' }}
       k3s_version: ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_importing' }}
+      tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_import' }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -215,8 +215,8 @@ jobs:
         run: |
           make e2e-provisioning-tests
 
-      - name: Importing cluster tests
-        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'p0_importing') }}
+      - name: Import cluster tests
+        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'p0_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -235,8 +235,8 @@ jobs:
         run: |
           make e2e-p1-provisioning-tests
 
-      - name: Importing cluster P1 tests
-        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'p1_importing') }}
+      - name: Import cluster P1 tests
+        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'p1_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -255,15 +255,15 @@ jobs:
         run: |
           make e2e-support-matrix-provisioning-tests
 
-      - name: Support matrix importing tests
-        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'support_matrix_importing') }}
+      - name: Support matrix import tests
+        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'support_matrix_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
         run: |
-          make e2e-support-matrix-importing-tests
+          make e2e-support-matrix-import-tests
 
       - name: K8s Chart Support provisioning tests
         if: ${{ !cancelled() && contains(inputs.tests_to_run, 'k8s_chart_support_provisioning') }}
@@ -277,8 +277,8 @@ jobs:
         run: |
           make e2e-k8s-chart-support-provisioning-tests
 
-      - name: K8s Chart Support importing tests
-        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'k8s_chart_support_importing') }}
+      - name: K8s Chart Support import tests
+        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'k8s_chart_support_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -287,7 +287,7 @@ jobs:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           DOWNSTREAM_K8S_MINOR_VERSION: ${{ env.DOWNSTREAM_K8S_MINOR_VERSION }}
         run: |
-          make e2e-k8s-chart-support-importing-tests
+          make e2e-k8s-chart-support-import-tests
 
       - name: Sync provisioning tests
         if: ${{ !cancelled() && contains(inputs.tests_to_run, 'sync_provisioning') }}
@@ -300,8 +300,8 @@ jobs:
         run: |
           make e2e-sync-provisioning-tests
 
-      - name: Sync importing tests
-        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'sync_importing') }}
+      - name: Sync import tests
+        if: ${{ !cancelled() && contains(inputs.tests_to_run, 'sync_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -309,7 +309,7 @@ jobs:
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
           DOWNSTREAM_K8S_MINOR_VERSION: ${{ env.DOWNSTREAM_K8S_MINOR_VERSION }}
         run: |
-          make e2e-sync-importing-tests
+          make e2e-sync-import-tests
 
       - name: Finalize Qase Run and publish Results
         env:

--- a/Makefile
+++ b/Makefile
@@ -67,25 +67,25 @@ deps: ## Install the Go dependencies
 prepare-e2e-ci-rancher-hosted-nightly-chart: install-k3s install-helm install-cert-manager install-rancher-hosted-nightly-chart ## Setup Rancher with nightly hosted provider charts on the local machine
 prepare-e2e-ci-rancher: install-k3s install-helm install-cert-manager install-rancher ## Setup Rancher on the local machine
 
-e2e-import-tests: deps	## Run the 'P0Importing' test suite for a given ${PROVIDER}
-	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Importing" ./hosted/${PROVIDER}/p0/
+e2e-import-tests: deps	## Run the 'P0Import' test suite for a given ${PROVIDER}
+	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Import" ./hosted/${PROVIDER}/p0/
 
 e2e-provisioning-tests: deps ## Run the 'P0Provisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Provisioning" ./hosted/${PROVIDER}/p0/
 
-e2e-p1-import-tests: deps	## Run the 'P1Importing' test suite for a given ${PROVIDER}
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Importing" ./hosted/${PROVIDER}/p1/
+e2e-p1-import-tests: deps	## Run the 'P1Import' test suite for a given ${PROVIDER}
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Import" ./hosted/${PROVIDER}/p1/
 
 e2e-p1-provisioning-tests: deps ## Run the 'P1Provisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Provisioning" ./hosted/${PROVIDER}/p1/
 
 
 # Support Matrix test has not been parallelized for EKS because we hit resource limits when running it in parallel
-e2e-support-matrix-importing-tests: deps ## Run the 'SupportMatrixImporting' test suite for a given ${PROVIDER}
+e2e-support-matrix-import-tests: deps ## Run the 'SupportMatrixImport' test suite for a given ${PROVIDER}
 ifeq (${PROVIDER}, eks)
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SupportMatrixImporting" ./hosted/${PROVIDER}/support_matrix/
+	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SupportMatrixImport" ./hosted/${PROVIDER}/support_matrix/
 else
-	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SupportMatrixImporting" ./hosted/${PROVIDER}/support_matrix/
+	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SupportMatrixImport" ./hosted/${PROVIDER}/support_matrix/
 endif
 
 
@@ -98,13 +98,13 @@ endif
 
 
 
-e2e-k8s-chart-support-importing-tests-upgrade: deps ## Run the 'K8sChartSupportUpgradeImport' test suite for a given ${PROVIDER}
+e2e-k8s-chart-support-import-tests-upgrade: deps ## Run the 'K8sChartSupportUpgradeImport' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportUpgradeImport" ./hosted/${PROVIDER}/k8s_chart_support/upgrade
 
 e2e-k8s-chart-support-provisioning-tests-upgrade: deps ## Run the 'K8sChartSupportUpgradeProvisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportUpgradeProvisioning" ./hosted/${PROVIDER}/k8s_chart_support/upgrade
 
-e2e-k8s-chart-support-importing-tests: deps ## Run the 'K8sChartSupportImport' test suite for a given ${PROVIDER}
+e2e-k8s-chart-support-import-tests: deps ## Run the 'K8sChartSupportImport' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportImport" ./hosted/${PROVIDER}/k8s_chart_support
 
 e2e-k8s-chart-support-provisioning-tests: deps ## Run the 'K8sChartSupportProvisioning' test suite for a given ${PROVIDER}
@@ -113,7 +113,7 @@ e2e-k8s-chart-support-provisioning-tests: deps ## Run the 'K8sChartSupportProvis
 e2e-sync-provisioning-tests: deps ## Run "SyncProvisioning" test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SyncProvisioning" ./hosted/${PROVIDER}/p1
 
-e2e-sync-importing-tests: deps ## Run "SyncImport" test suite for a given ${PROVIDER}
+e2e-sync-import-tests: deps ## Run "SyncImport" test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SyncImport" ./hosted/${PROVIDER}/p1
 
 clean-k3s:	## Uninstall k3s cluster

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Note: These are E2E tests, so rancher (version=`RANCHER_VERSION`) will be instal
 
 ### Makefile targets to run tests
 1. `make e2e-provisioning-tests` - Covers the _P0Provisioning_ test suite for a given `${PROVIDER}`
-2. `make e2e-import-tests` - Covers the _P0Importing_ test suite for a given `${PROVIDER}`
-3. `make e2e-support-matrix-importing-tests` - Covers the _SupportMatrixImporting_ test suite for a given `${PROVIDER}`
+2. `make e2e-import-tests` - Covers the _P0Import_ test suite for a given `${PROVIDER}`
+3. `make e2e-support-matrix-import-tests` - Covers the _SupportMatrixImport_ test suite for a given `${PROVIDER}`
 4. `make e2e-support-matrix-provisioning-tests` - Covers the _SupportMatrixProvisioning_ test suite for a given `${PROVIDER}`
 5. `make e2e-k8s-chart-support-provisioning-tests` - Focuses on _K8sChartSupportProvisioning_ for a given `${PROVIDER}`
-6. `make e2e-k8s-chart-support-importing-tests` - Focuses on _K8sChartSupportImport_ for a given `${PROVIDER}`
-7. `make e2e-k8s-chart-support-importing-tests-upgrade` - Focuses on _K8sChartSupportUpgradeImport_ for a given `${PROVIDER}`
+6. `make e2e-k8s-chart-support-import-tests` - Focuses on _K8sChartSupportImport_ for a given `${PROVIDER}`
+7. `make e2e-k8s-chart-support-import-tests-upgrade` - Focuses on _K8sChartSupportUpgradeImport_ for a given `${PROVIDER}`
 8. `make e2e-k8s-chart-support-provisioning-tests-upgrade` - Focuses on _K8sChartSupportUpgradeProvisioning_ for a given `${PROVIDER}`
 
 Run `make help` to know about other targets.

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -1,8 +1,8 @@
 # Tests description for aks/p0
 
-## `p0_importing_test.go`
+## `p0_import_test.go`
 
-- **Describe:** P0Importing
+- **Describe:** P0Import
     - **It:** should successfully import the cluster & add, delete, scale nodepool
       -  **By:** checking cluster name is same
       -  **By:** checking service account token secret
@@ -36,9 +36,9 @@
 
 # Tests description for aks/support_matrix
 
-## `support_matrix_importing_test.go`
+## `support_matrix_import_test.go`
 
-- **Describe:** SupportMatrixImporting
+- **Describe:** SupportMatrixImport
     - **It:** should successfully import the cluster
       -  **By:** checking cluster name is same
       -  **By:** checking service account token secret
@@ -56,9 +56,9 @@
 
 # Tests description for eks/p0
 
-## `p0_importing_test.go`
+## `p0_import_test.go`
 
-- **Describe:** P0Importing
+- **Describe:** P0Import
     - **It:** should successfully import the cluster & add, delete, scale nodepool
       -  **By:** checking cluster name is same
       -  **By:** checking service account token secret
@@ -92,9 +92,9 @@
 
 # Tests description for eks/support_matrix
 
-## `support_matrix_importing_test.go`
+## `support_matrix_import_test.go`
 
-- **Describe:** SupportMatrixImporting
+- **Describe:** SupportMatrixImport
     - **It:** should successfully import the cluster
       -  **By:** checking cluster name is same
       -  **By:** checking service account token secret
@@ -112,9 +112,9 @@
 
 # Tests description for gke/p0
 
-## `p0_importing_test.go`
+## `p0_import_test.go`
 
-- **Describe:** P0Importing
+- **Describe:** P0Import
     - **It:** should successfully import the cluster & add, delete, scale nodepool
       -  **By:** checking cluster name is same
       -  **By:** checking service account token secret
@@ -147,9 +147,9 @@
 
 # Tests description for gke/support_matrix
 
-## `support_matrix_importing_test.go`
+## `support_matrix_import_test.go`
 
-- **Describe:** SupportMatrixImporting
+- **Describe:** SupportMatrixImport
     - **It:** should successfully import the cluster
       -  **By:** checking cluster name is same
       -  **By:** checking service account token secret

--- a/hosted/aks/support_matrix/support_matrix_import_test.go
+++ b/hosted/aks/support_matrix/support_matrix_import_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
-var _ = Describe("SupportMatrixImporting", func() {
+var _ = Describe("SupportMatrixImport", func() {
 
 	for _, version := range availableVersionList {
 		version := version

--- a/hosted/eks/support_matrix/support_matrix_import_test.go
+++ b/hosted/eks/support_matrix/support_matrix_import_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
-var _ = Describe("SupportMatrixImporting", func() {
+var _ = Describe("SupportMatrixImport", func() {
 
 	for _, version := range availableVersionList {
 		version := version

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -477,27 +477,6 @@ func CreateGKEClusterOnGCloud(zone string, clusterName string, project string, k
 	return nil
 }
 
-// AddNodePoolOnGCloud adds a nodepool to the GKE cluster via gcloud CLI
-func AddNodePoolOnGCloud(clusterName, zone, project, npName string, extraArgs ...string) error {
-	if npName == "" {
-		npName = namegen.AppendRandomString("np")
-	}
-
-	fmt.Println("Adding nodepool to the GKE cluster ...")
-	args := []string{"container", "node-pools", "create", npName, "--cluster", clusterName, "--project", project, "--zone", zone, "--num-nodes", "1"}
-
-	args = append(args, extraArgs...)
-	fmt.Printf("Running command: gcloud %v\n", args)
-	out, err := proc.RunW("gcloud", args...)
-	if err != nil {
-		return errors.Wrap(err, "Failed to add nodepool to the cluster: "+out)
-	}
-
-	fmt.Println("Added nodepool to GKE cluster: ", clusterName)
-
-	return nil
-}
-
 // ClusterExistsOnGCloud gets a list of cluster based on the name filter and returns true if the cluster is in RUNNING or PROVISIONING state;
 // it returns false if the cluster does not exist or is in STOPPING state.
 func ClusterExistsOnGCloud(clusterName, project, zone string) (bool, error) {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
-var _ = Describe("P1Importing", func() {
+var _ = Describe("P1Import", func() {
 
 	var _ = BeforeEach(func() {
 		var err error

--- a/hosted/gke/p1/sync_provisioning_test.go
+++ b/hosted/gke/p1/sync_provisioning_test.go
@@ -41,7 +41,7 @@ var _ = Describe("SyncProvisioning", func() {
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
-				cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project)
+				cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 1)
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())

--- a/hosted/gke/support_matrix/support_matrix_import_test.go
+++ b/hosted/gke/support_matrix/support_matrix_import_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
-var _ = Describe("SupportMatrixImporting", func() {
+var _ = Describe("SupportMatrixImport", func() {
 
 	for _, version := range availableVersionList {
 		version := version


### PR DESCRIPTION
### What does this PR do?
- Rename _importing_ references to _import_ to match with _cattle-config-**import**.yaml_ and use uniformly 
- Fix GKE P1 tests
