### PR TITLE
Automate Qase 265 and 35; Update a cluster when in updating state

### DIFF
--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -108,6 +108,8 @@ func UpgradeKubernetesVersion(cluster *management.Cluster, upgradeToVersion stri
 		}
 	}
 
+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Kubernetes version for cluster %s will be upgraded to %s", cluster.Name, upgradeToVersion))
+
 	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
 	if err != nil {
 		return nil, err

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -187,7 +187,7 @@ func AddNodePool(cluster *management.Cluster, client *rancher.Client, increaseBy
 			Autoscaling:       npTemplate.Autoscaling,
 			Management:        npTemplate.Management,
 			MaxPodsConstraint: npTemplate.MaxPodsConstraint,
-			Name:              pointer.String(namegen.RandStringLower(5)),
+			Name:              pointer.String(namegen.AppendRandomString("np")),
 		}
 		updateNodePoolsList = append(updateNodePoolsList, newNodepool)
 	}

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -149,7 +149,7 @@ var _ = Describe("P1Import", func() {
 		})
 	})
 
-	FWhen("a cluster is created for upgrade scenario", func() {
+	When("a cluster is created for upgrade scenario", func() {
 
 		BeforeEach(func() {
 			var err error
@@ -170,7 +170,7 @@ var _ = Describe("P1Import", func() {
 
 		It("should successfully update a cluster while it is still in updating state", func() {
 			testCaseID = 265
-			updateClutserInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
+			updateClusterInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
 		})
 
 	})

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -113,7 +113,6 @@ var _ = Describe("P1Import", func() {
 	})
 
 	When("a cluster is created with at least 2 node pools", func() {
-		var cluster *management.Cluster
 
 		BeforeEach(func() {
 			var err error
@@ -140,6 +139,7 @@ var _ = Describe("P1Import", func() {
 
 				upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
 			})
+			Expect(err).To(BeNil())
 
 			Eventually(func() bool {
 				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -149,7 +149,7 @@ var _ = Describe("P1Import", func() {
 		})
 	})
 
-	When("a cluster is created for upgrade scenario", func() {
+	FWhen("a cluster is created for upgrade scenario", func() {
 
 		BeforeEach(func() {
 			var err error

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -19,7 +19,7 @@ var _ = Describe("P1Import", func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCred.ID, zone, "", false)
 		Expect(err).To(BeNil())
-		GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+		GinkgoLogr.Info(fmt.Sprintf("While importing, using kubernetes version %s for cluster %s", k8sVersion, clusterName))
 	})
 
 	AfterEach(func() {
@@ -170,7 +170,7 @@ var _ = Describe("P1Import", func() {
 
 		It("should successfully update a cluster while it is still in updating state", func() {
 			testCaseID = 265
-			updateClusterInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
+			updateClusterInUpdatingState(cluster, ctx.RancherAdminClient)
 		})
 
 	})

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -58,20 +58,20 @@ var _ = Describe("P1Import", func() {
 		It("should be able to update mutable parameter", func() {
 			testCaseID = 52
 			By("disabling the services", func() {
-				updateLoggingAndMonitoringServiceCheck(ctx, cluster, "none", "none")
+				updateLoggingAndMonitoringServiceCheck(cluster, ctx.RancherAdminClient, "none", "none")
 			})
 			By("enabling the services", func() {
-				updateLoggingAndMonitoringServiceCheck(ctx, cluster, "monitoring.googleapis.com/kubernetes", "logging.googleapis.com/kubernetes")
+				updateLoggingAndMonitoringServiceCheck(cluster, ctx.RancherAdminClient, "monitoring.googleapis.com/kubernetes", "logging.googleapis.com/kubernetes")
 			})
 		})
 
 		It("should be able to update autoscaling", func() {
 			testCaseID = 53
 			By("enabling autoscaling", func() {
-				updateAutoScaling(ctx, cluster, true)
+				updateAutoScaling(cluster, ctx.RancherAdminClient, true)
 			})
 			By("disabling autoscalling", func() {
-				updateAutoScaling(ctx, cluster, false)
+				updateAutoScaling(cluster, ctx.RancherAdminClient, false)
 			})
 		})
 

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -247,7 +247,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	FWhen("a cluster is created for upgrade scenarios", func() {
+	When("a cluster is created for upgrade scenarios", func() {
 
 		BeforeEach(func() {
 			var err error
@@ -263,7 +263,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		It("should successfully update a cluster while it is still in updating state", func() {
 			testCaseID = 35
-			updateClutserInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
+			updateClusterInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
 		})
 	})
 })

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -247,7 +247,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	When("a cluster is created for upgrade scenarios", func() {
+	FWhen("a cluster is created for upgrade scenarios", func() {
 
 		BeforeEach(func() {
 			var err error

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/gke"
 	"github.com/rancher/shepherd/pkg/config"
 
@@ -249,7 +248,6 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	When("a cluster is created for upgrade scenarios", func() {
-		var upgradeK8sVersion string
 
 		BeforeEach(func() {
 			var err error
@@ -261,37 +259,11 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-
-			var availableVersions []string
-			availableVersions, err = helper.ListGKEAvailableVersions(ctx.RancherAdminClient, cluster.ID)
-			Expect(err).To(BeNil())
-			upgradeK8sVersion = availableVersions[0]
 		})
 
 		It("should successfully update a cluster while it is still in updating state", func() {
 			testCaseID = 35
-			var err error
-			currentNodePoolCount := len(cluster.GKEConfig.NodePools)
-			cluster, err = helper.UpgradeKubernetesVersion(cluster, upgradeK8sVersion, ctx.RancherAdminClient, false, false, false)
-			Expect(err).To(BeNil())
-			Expect(*cluster.GKEConfig.KubernetesVersion).To(Equal(upgradeK8sVersion))
-
-			err = clusters.WaitClusterToBeInUpgrade(ctx.RancherAdminClient, cluster.ID)
-			Expect(err).To(BeNil())
-
-			cluster, err = helper.AddNodePool(cluster, ctx.RancherAdminClient, 1, "", false, false)
-			Expect(err).To(BeNil())
-
-			Expect(len(cluster.GKEConfig.NodePools)).Should(BeNumerically("==", currentNodePoolCount+1))
-
-			err = clusters.WaitClusterToBeUpgraded(ctx.RancherAdminClient, cluster.ID)
-			Expect(err).To(BeNil())
-
-			Eventually(func() bool {
-				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				return len(cluster.GKEStatus.UpstreamSpec.NodePools) == currentNodePoolCount+1 && *cluster.GKEStatus.UpstreamSpec.KubernetesVersion == upgradeK8sVersion
-			}, "5m", "5s").Should(BeTrue())
+			updateClutserInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
 		})
 	})
 })

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -21,7 +21,7 @@ var _ = Describe("P1Provisioning", func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCred.ID, zone, "", false)
 		Expect(err).To(BeNil())
-		GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+		GinkgoLogr.Info(fmt.Sprintf("While provisioning, using kubernetes version %s for cluster %s", k8sVersion, clusterName))
 	})
 
 	AfterEach(func() {
@@ -124,7 +124,8 @@ var _ = Describe("P1Provisioning", func() {
 			return exists
 		}, "10m", "10s").Should(BeFalse())
 
-		_, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+		// Keep the cluster variable as is so that there is no error in AfterEach; failed delete operation will return an empty cluster
+		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
 
@@ -263,7 +264,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		It("should successfully update a cluster while it is still in updating state", func() {
 			testCaseID = 35
-			updateClusterInUpdatingStateCheck(cluster, ctx.RancherAdminClient)
+			updateClusterInUpdatingState(cluster, ctx.RancherAdminClient)
 		})
 	})
 })

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -170,20 +170,20 @@ var _ = Describe("P1Provisioning", func() {
 		It("should be able to update mutable parameter loggingService and monitoringService", func() {
 			testCaseID = 28
 			By("disabling the services", func() {
-				updateLoggingAndMonitoringServiceCheck(ctx, cluster, "none", "none")
+				updateLoggingAndMonitoringServiceCheck(cluster, ctx.RancherAdminClient, "none", "none")
 			})
 			By("enabling the services", func() {
-				updateLoggingAndMonitoringServiceCheck(ctx, cluster, "monitoring.googleapis.com/kubernetes", "logging.googleapis.com/kubernetes")
+				updateLoggingAndMonitoringServiceCheck(cluster, ctx.RancherAdminClient, "monitoring.googleapis.com/kubernetes", "logging.googleapis.com/kubernetes")
 			})
 		})
 
 		It("should be able to update autoscaling", func() {
 			testCaseID = 29
 			By("enabling autoscaling", func() {
-				updateAutoScaling(ctx, cluster, true)
+				updateAutoScaling(cluster, ctx.RancherAdminClient, true)
 			})
 			By("disabling autoscaling", func() {
-				updateAutoScaling(ctx, cluster, false)
+				updateAutoScaling(cluster, ctx.RancherAdminClient, false)
 			})
 		})
 

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -25,7 +25,7 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	AfterEach(func() {
-		if ctx.ClusterCleanup && cluster != nil {
+		if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
 		} else {
@@ -101,7 +101,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 	})
 
-	It("deleting a cluster while it is in creation state should delete the it from rancher and cloud console", func() {
+	It("deleting a cluster while it is in creation state should delete it from rancher and cloud console", func() {
 		testCaseID = 25
 		var err error
 		cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, zone, project, 1)
@@ -128,7 +128,6 @@ var _ = Describe("P1Provisioning", func() {
 		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not found"))
-
 	})
 
 	When("a cluster is created", func() {
@@ -219,15 +218,6 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-		})
-
-		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
-				err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
-			} else {
-				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
-			}
 		})
 
 		It("for a given NodePool with a non-windows imageType, updating it to a windows imageType should fail", func() {

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -230,7 +230,7 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 	})
 }
 
-// updateClusterInUpdatingStateCheck runs checks to ensure cluster in an updating state can be updated
+// updateClusterInUpdatingState runs checks to ensure cluster in an updating state can be updated
 func updateClusterInUpdatingState(cluster *management.Cluster, client *rancher.Client) {
 	availableVersions, err := helper.ListGKEAvailableVersions(client, cluster.ID)
 	Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -234,6 +234,7 @@ func updateClutserInUpdatingStateCheck(cluster *management.Cluster, client *ranc
 	availableVersions, err := helper.ListGKEAvailableVersions(client, cluster.ID)
 	Expect(err).To(BeNil())
 	upgradeK8sVersion := availableVersions[0]
+
 	currentNodePoolCount := len(cluster.GKEConfig.NodePools)
 	cluster, err = helper.UpgradeKubernetesVersion(cluster, upgradeK8sVersion, client, false, false, false)
 	Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -230,7 +230,8 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 	})
 }
 
-func updateClutserInUpdatingStateCheck(cluster *management.Cluster, client *rancher.Client) {
+// updateClusterInUpdatingStateCheck runs checks to ensure cluster in an updating state can be updated
+func updateClusterInUpdatingStateCheck(cluster *management.Cluster, client *rancher.Client) {
 	availableVersions, err := helper.ListGKEAvailableVersions(client, cluster.ID)
 	Expect(err).To(BeNil())
 	upgradeK8sVersion := availableVersions[0]

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -66,14 +66,14 @@ var _ = ReportAfterEach(func(report SpecReport) {
 })
 
 // updateLoggingAndMonitoringServiceCheck tests updating `loggingService` and `monitoringService`
-func updateLoggingAndMonitoringServiceCheck(ctx helpers.Context, cluster *management.Cluster, updateMonitoringValue, updateLoggingValue string) {
+func updateLoggingAndMonitoringServiceCheck(cluster *management.Cluster, client *rancher.Client, updateMonitoringValue, updateLoggingValue string) {
 	var err error
-	cluster, err = helper.UpdateMonitoringAndLoggingService(cluster, ctx.RancherAdminClient, updateMonitoringValue, updateLoggingValue, true, true)
+	cluster, err = helper.UpdateMonitoringAndLoggingService(cluster, client, updateMonitoringValue, updateLoggingValue, true, true)
 	Expect(err).To(BeNil())
 }
 
 // updateAutoScaling tests updating `autoscaling` for GKE node pools
-func updateAutoScaling(ctx helpers.Context, cluster *management.Cluster, autoscale bool) {
+func updateAutoScaling(cluster *management.Cluster, client *rancher.Client, autoscale bool) {
 	for _, np := range cluster.GKEConfig.NodePools {
 		if np.Autoscaling != nil {
 			Expect(np.Autoscaling.Enabled).ToNot(BeEquivalentTo(autoscale))
@@ -81,7 +81,7 @@ func updateAutoScaling(ctx helpers.Context, cluster *management.Cluster, autosca
 	}
 
 	var err error
-	cluster, err = helper.UpdateAutoScaling(cluster, ctx.RancherAdminClient, autoscale, true, true)
+	cluster, err = helper.UpdateAutoScaling(cluster, client, autoscale, true, true)
 	Expect(err).To(BeNil())
 }
 

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -231,7 +231,7 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 }
 
 // updateClusterInUpdatingStateCheck runs checks to ensure cluster in an updating state can be updated
-func updateClusterInUpdatingStateCheck(cluster *management.Cluster, client *rancher.Client) {
+func updateClusterInUpdatingState(cluster *management.Cluster, client *rancher.Client) {
 	availableVersions, err := helper.ListGKEAvailableVersions(client, cluster.ID)
 	Expect(err).To(BeNil())
 	upgradeK8sVersion := availableVersions[0]


### PR DESCRIPTION
### What does this PR do?
- Automate update a cluster when it is updating state.
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [focused :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10089978301/job/27898489778, [p1 :brown_circle: ] ~https://github.com/rancher/hosted-providers-e2e/actions/runs/10090752510~, https://github.com/rancher/hosted-providers-e2e/actions/runs/10095368829 (ran the failed test locally after fix and it passes)

### Special notes for your reviewer:
