### PR TITLE
AZ CLI Removal

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -157,12 +157,6 @@ jobs:
           else
             make prepare-e2e-ci-rancher
           fi
-
-      - name: Install Azure cli
-        run: |
-          sudo zypper clean --all
-          sudo zypper install -y azure-cli
-          pip install azure-cli
             
       - name: Login to Azure
         uses: azure/login@v2.1.1


### PR DESCRIPTION
### What does this PR do?
Removes AZ CLI installation code as it already seemed installed on the latest runner template, and zypper upgrade for the package errors out.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes - Failing CI https://github.com/rancher/hosted-providers-e2e/actions/runs/10173991179/job/28139007477

### Checklist:
- [x] GitHub Actions:
https://github.com/rancher/hosted-providers-e2e/actions/runs/10175208035/job/28142257485
