### PR TITLE
Move workaround for imported clusters to WaitUntilClusterIsReady

### DIFF
--- a/hosted/aks/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_import_test.go
@@ -21,8 +21,6 @@ var _ = Describe("K8sChartSupportImport", func() {
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
-		// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-		cluster.AKSConfig = cluster.AKSStatus.UpstreamSpec
 	})
 	AfterEach(func() {
 		if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/aks/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
+++ b/hosted/aks/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
@@ -21,8 +21,6 @@ var _ = Describe("K8sChartSupportUpgradeImport", func() {
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
-		// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-		cluster.AKSConfig = cluster.AKSStatus.UpstreamSpec
 	})
 	AfterEach(func() {
 		if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/aks/p0/p0_import_test.go
+++ b/hosted/aks/p0/p0_import_test.go
@@ -62,8 +62,6 @@ var _ = Describe("P0Import", func() {
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
-				// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-				cluster.AKSConfig = cluster.AKSStatus.UpstreamSpec
 			})
 
 			AfterEach(func() {

--- a/hosted/eks/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/eks/k8s_chart_support/k8s_chart_support_import_test.go
@@ -21,8 +21,6 @@ var _ = Describe("K8sChartSupportImport", func() {
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
-		// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-		cluster.EKSConfig = cluster.EKSStatus.UpstreamSpec
 
 	})
 	AfterEach(func() {

--- a/hosted/eks/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
+++ b/hosted/eks/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
@@ -21,9 +21,6 @@ var _ = Describe("K8sChartSupportUpgradeImport", func() {
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
-		//Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-		cluster.EKSConfig = cluster.EKSStatus.UpstreamSpec
-
 	})
 	AfterEach(func() {
 		if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/eks/p0/p0_import_test.go
+++ b/hosted/eks/p0/p0_import_test.go
@@ -62,8 +62,6 @@ var _ = Describe("P0Import", func() {
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
-				// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-				cluster.EKSConfig = cluster.EKSStatus.UpstreamSpec
 			})
 			AfterEach(func() {
 				if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
+++ b/hosted/gke/k8s_chart_support/k8s_chart_support_import_test.go
@@ -24,9 +24,6 @@ var _ = Describe("K8sChartSupportImport", func() {
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
-
-		// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-		cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 	})
 
 	AfterEach(func() {

--- a/hosted/gke/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
+++ b/hosted/gke/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
@@ -24,8 +24,6 @@ var _ = Describe("K8sChartSupportUpgradeImport", func() {
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
-		// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-		cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 	})
 
 	AfterEach(func() {

--- a/hosted/gke/p0/p0_import_test.go
+++ b/hosted/gke/p0/p0_import_test.go
@@ -63,8 +63,6 @@ var _ = Describe("P0Import", func() {
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
-				// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-				cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 			})
 			AfterEach(func() {
 				if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -44,8 +44,6 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-			cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 		})
 
 		It("should fail to reimport an imported cluster", func() {
@@ -131,8 +129,6 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-			cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 		})
 
 		It("for a given NodePool with a non-windows imageType, updating it to a windows imageType should fail", func() {
@@ -169,8 +165,6 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-			cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 		})
 
 		It("should successfully update a cluster while it is still in updating state", func() {

--- a/hosted/gke/p1/sync_import_test.go
+++ b/hosted/gke/p1/sync_import_test.go
@@ -48,8 +48,6 @@ var _ = Describe("SyncImport", func() {
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
-				// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-				cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 			})
 			AfterEach(func() {
 				if ctx.ClusterCleanup && cluster != nil {


### PR DESCRIPTION
### What does this PR do?
Instead of writing the workaround for every test, move the workaround to WaitUntilClusterIsReady().
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [p0_import :green_circle:] https://github.com/rancher/hosted-providers-e2e/actions/runs/10175907710, https://github.com/rancher/hosted-providers-e2e/actions/runs/10175905481, https://github.com/rancher/hosted-providers-e2e/actions/runs/10175910262

### Special notes for your reviewer:
