### PR TITLE
Automate Qase: 176, 186, 187 and 266

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -41,7 +41,7 @@ on:
         default: 'hostname/password'
         type: string
       tests_to_run:
-        description: Tests to run (p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import)
+        description: Tests to run (p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import/p1_provisioning/p1_import)
         type: string
         required: true
         default: p0_provisioning/p0_import

--- a/hosted/aks/k8s_chart_support/k8s_chart_support_provisioning_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_provisioning_test.go
@@ -17,7 +17,7 @@ var _ = Describe("K8sChartSupportProvisioning", func() {
 	)
 	BeforeEach(func() {
 		var err error
-		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location)
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())

--- a/hosted/aks/k8s_chart_support/upgrade/k8s_chart_support_provisioning_upgrade_test.go
+++ b/hosted/aks/k8s_chart_support/upgrade/k8s_chart_support_provisioning_upgrade_test.go
@@ -17,7 +17,7 @@ var _ = Describe("K8sChartSupportUpgradeProvisioning", func() {
 	)
 	BeforeEach(func() {
 		var err error
-		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location)
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
 		Expect(err).To(BeNil())
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())

--- a/hosted/aks/p0/p0_provisioning_test.go
+++ b/hosted/aks/p0/p0_provisioning_test.go
@@ -56,7 +56,7 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
-				cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location)
+				cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -1,0 +1,9 @@
+package p1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("P1Import", func() {
+
+})

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -1,9 +1,49 @@
 package p1_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
 var _ = Describe("P1Import", func() {
+	When("a cluster is created", func() {
+		var cluster *management.Cluster
+		BeforeEach(func() {
+			k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
+
+			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			// Workaround to update the cluster; since this value is always nil
+			cluster.AKSConfig = cluster.AKSStatus.UpstreamSpec
+		})
+		AfterEach(func() {
+			if ctx.ClusterCleanup && cluster != nil {
+				err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteAKSClusteronAzure(clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("should be able to update autoscaling", func() {
+			// TODO: create testCaseID
+			updateAutoScaling(cluster, ctx.RancherAdminClient)
+		})
+	})
 
 })

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -39,7 +39,7 @@ var _ = Describe("P1Import", func() {
 		})
 
 		It("should be able to update autoscaling", func() {
-			// TODO: create testCaseID
+			testCaseID = 266
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
 	})

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -26,8 +26,6 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-			// Workaround to update the cluster; since this value is always nil
-			cluster.AKSConfig = cluster.AKSStatus.UpstreamSpec
 		})
 		AfterEach(func() {
 			if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -22,7 +22,10 @@ var _ = Describe("P1Provisioning", func() {
 			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location)
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			//var err error
+			//cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID("c-cdzqv")
+			//Expect(err).To(BeNil())
 		})
 		AfterEach(func() {
 			if ctx.ClusterCleanup && cluster != nil {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 var _ = Describe("P1Provisioning", func() {
-	var cluster *management.Cluster
 	When("a cluster is created", func() {
+		var cluster *management.Cluster
 		BeforeEach(func() {
 			k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
 			Expect(err).NotTo(HaveOccurred())
@@ -23,9 +23,6 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).NotTo(HaveOccurred())
-			//var err error
-			//cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID("c-cdzqv")
-			//Expect(err).To(BeNil())
 		})
 		AfterEach(func() {
 			if ctx.ClusterCleanup && cluster != nil {
@@ -36,10 +33,9 @@ var _ = Describe("P1Provisioning", func() {
 			}
 		})
 
-		FIt("should be able to update autoscaling", func() {
+		It("should be able to update autoscaling", func() {
 			testCaseID = 176
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
-
 	})
 })

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -1,0 +1,42 @@
+package p1_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("P1Provisioning", func() {
+	var cluster *management.Cluster
+	When("a cluster is created", func() {
+		BeforeEach(func() {
+			k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
+
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			if ctx.ClusterCleanup && cluster != nil {
+				err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		FIt("should be able to update autoscaling", func() {
+			testCaseID = 176
+			updateAutoScaling(cluster, ctx.RancherAdminClient)
+		})
+
+	})
+})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -2,35 +2,77 @@ package p1_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters/aks"
+	"k8s.io/utils/pointer"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
 var _ = Describe("P1Provisioning", func() {
-	When("a cluster is created", func() {
-		var cluster *management.Cluster
-		BeforeEach(func() {
-			k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
+	var cluster *management.Cluster
+	var k8sVersion string
+	BeforeEach(func() {
+		var err error
+		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
+		Expect(err).NotTo(HaveOccurred())
+		GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
+	})
+	AfterEach(func() {
+		if ctx.ClusterCleanup && cluster != nil {
+			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
+	When("a cluster with invalid config is created", func() {
+		It("should fail to create a cluster with 0 nodecount", func() {
+			testCaseID = 186
+			updateFunc := func(aksConfig *aks.ClusterConfig) {
+				nodepools := *aksConfig.NodePools
+				for i := range nodepools {
+					nodepools[i].NodeCount = pointer.Int64(0)
+				}
+				aksConfig.NodePools = &nodepools
+			}
+			var err error
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
 			Expect(err).NotTo(HaveOccurred())
-			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
-			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location)
+			Eventually(func() bool {
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "agentPoolProfile.count was 0. It must be greater or equal to minCount:1 and less than or equal to maxCount:1000")
+			}, "1m", "2s").Should(BeTrue())
+		})
+		It("should fail to create a cluster with 0 nodepool", func() {
+			testCaseID = 187
+			updateFunc := func(aksConfig *aks.ClusterConfig) {
+				aksConfig.NodePools = &[]aks.NodePool{}
+			}
+			var err error
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cluster.Transitioning == "error" && cluster.TransitioningMessage == "at least one NodePool with mode System is required"
+			}, "1m", "2s").Should(BeTrue())
+		})
+	})
+	When("a cluster is created", func() {
+		BeforeEach(func() {
+			var err error
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).NotTo(HaveOccurred())
-		})
-		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
-				err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
-			} else {
-				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
-			}
 		})
 
 		It("should be able to update autoscaling", func() {

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/rancher-sandbox/qase-ginkgo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
-
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
@@ -50,26 +49,20 @@ var _ = ReportAfterEach(func(report SpecReport) {
 
 // updateAutoScaling tests updating `autoscaling` for GKE node pools
 func updateAutoScaling(cluster *management.Cluster, client *rancher.Client) {
-	for _, np := range cluster.AKSConfig.NodePools {
-		if np.EnableAutoScaling != nil {
-			Expect(np.EnableAutoScaling).ToNot(BeEquivalentTo(true))
-		}
-	}
-	By("enabling autoscaling with custom minCount and maxCount", func() {
-		var err error
-		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 5, 2, true)
-		Expect(err).To(BeNil())
-	})
-	By("disabling autoscaling", func() {
-		var err error
-		cluster, err = helper.UpdateAutoScaling(cluster, client, false, 0, 0, true)
-		Expect(err).To(BeNil())
-	})
-
 	By("enabling autoscaling with default minCount and maxCount", func() {
 		var err error
 		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 0, 0, true)
 		Expect(err).To(BeNil())
 	})
 
+	By("disabling autoscaling", func() {
+		var err error
+		cluster, err = helper.UpdateAutoScaling(cluster, client, false, 0, 0, true)
+		Expect(err).To(BeNil())
+	})
+	By("enabling autoscaling with custom minCount and maxCount", func() {
+		var err error
+		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 5, 2, true)
+		Expect(err).To(BeNil())
+	})
 }

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -1,0 +1,75 @@
+package p1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/rancher-sandbox/qase-ginkgo"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var (
+	ctx         helpers.Context
+	clusterName string
+	testCaseID  int64
+	location    = helpers.GetAKSLocation()
+)
+
+func TestP1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "P1 Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	helpers.CommonSynchronizedBeforeSuite()
+	return nil
+}, func() {
+	ctx = helpers.CommonBeforeSuite()
+})
+
+var _ = BeforeEach(func() {
+	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+})
+
+var _ = ReportBeforeEach(func(report SpecReport) {
+	// Reset case ID
+	testCaseID = -1
+})
+
+var _ = ReportAfterEach(func(report SpecReport) {
+	// Add result in Qase if asked
+	Qase(testCaseID, report)
+})
+
+// updateAutoScaling tests updating `autoscaling` for GKE node pools
+func updateAutoScaling(cluster *management.Cluster, client *rancher.Client) {
+	for _, np := range cluster.AKSConfig.NodePools {
+		if np.EnableAutoScaling != nil {
+			Expect(np.EnableAutoScaling).ToNot(BeEquivalentTo(true))
+		}
+	}
+	By("enabling autoscaling with custom minCount and maxCount", func() {
+		var err error
+		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 5, 2, true)
+		Expect(err).To(BeNil())
+	})
+	By("disabling autoscaling", func() {
+		var err error
+		cluster, err = helper.UpdateAutoScaling(cluster, client, false, 0, 0, true)
+		Expect(err).To(BeNil())
+	})
+
+	By("enabling autoscaling with default minCount and maxCount", func() {
+		var err error
+		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 0, 0, true)
+		Expect(err).To(BeNil())
+	})
+
+}

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -47,22 +47,17 @@ var _ = ReportAfterEach(func(report SpecReport) {
 	Qase(testCaseID, report)
 })
 
-// updateAutoScaling tests updating `autoscaling` for GKE node pools
+// updateAutoScaling tests updating `autoscaling` for AKS node pools
 func updateAutoScaling(cluster *management.Cluster, client *rancher.Client) {
-	By("enabling autoscaling with default minCount and maxCount", func() {
+	By("enabling autoscaling with custom minCount and maxCount", func() {
 		var err error
-		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 0, 0, true)
+		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 5, 2, true)
 		Expect(err).To(BeNil())
 	})
 
 	By("disabling autoscaling", func() {
 		var err error
 		cluster, err = helper.UpdateAutoScaling(cluster, client, false, 0, 0, true)
-		Expect(err).To(BeNil())
-	})
-	By("enabling autoscaling with custom minCount and maxCount", func() {
-		var err error
-		cluster, err = helper.UpdateAutoScaling(cluster, client, true, 5, 2, true)
 		Expect(err).To(BeNil())
 	})
 }

--- a/hosted/aks/support_matrix/support_matrix_provisioning_test.go
+++ b/hosted/aks/support_matrix/support_matrix_provisioning_test.go
@@ -40,7 +40,7 @@ var _ = Describe("SupportMatrixProvisioning", func() {
 			BeforeEach(func() {
 				clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				var err error
-				cluster, err = helper.CreateAKSHostedCluster(ctx.StdUserClient, clusterName, ctx.CloudCred.ID, version, location)
+				cluster, err = helper.CreateAKSHostedCluster(ctx.StdUserClient, clusterName, ctx.CloudCred.ID, version, location, nil)
 				Expect(err).To(BeNil())
 				// Requires RancherAdminClient
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)


### PR DESCRIPTION
### What does this PR do?
Automate:
1. Create cluster with 0 nodecount
2. Create cluster with 0 nodepool
3. Test autoscaling on provisioned/imported
4. Add `updateFunc` arg to CreateAKSHostedCluster so that cluster config can be modified as per the test requirement.
5. Update all the tests to accommodate the new `updateFunc` addition.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) [p1_provisioning/p1_import :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10178190020/job/28151355133, [p0_provisioning/p0_import :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10179115186

### Special notes for your reviewer:
