### PR TITLE
Automate Qase:  218, 182, and 219

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -472,6 +472,24 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 	return nil
 }
 
+// ClusterExistsOnAzure gets a list of cluster based on the name filter and returns true if the cluster is not in Deleting state;
+// it returns false if the cluster does not exist or is in Deleting state.
+func ClusterExistsOnAzure(clusterName, resourceGroup string) (bool, error) {
+	fmt.Println("Showing AKS cluster ...")
+	args := []string{"aks", "show", "--subscription", subscriptionID, "--name", clusterName, "--resource-group", resourceGroup}
+	//❯ az aks show --subscription 80de5134-ca65-4731-be21-13fb1f0910a2 --output table --name pkumaraks --resource-group pkaks
+	fmt.Printf("Running command: az %v\n", args)
+	out, err := proc.RunW("az", args...)
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to show cluster: "+out)
+	}
+	fmt.Println(out)
+	if !strings.Contains(out, "Deleting") {
+		return true, nil
+	}
+	return false, nil
+}
+
 // convertMapToAKSString converts the map of labels to a string format acceptable by azure CLI
 // acceptable format: `--tags "owner=hostedproviders" "testname=sometest"`
 func convertMapToAKSString(tags map[string]string) string {

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -482,7 +482,6 @@ func ClusterExistsOnAzure(clusterName, resourceGroup string) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to show cluster: "+out)
 	}
-	fmt.Println(out)
 	if !strings.Contains(out, "Deleting") {
 		return true, nil
 	}

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -477,7 +477,6 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 func ClusterExistsOnAzure(clusterName, resourceGroup string) (bool, error) {
 	fmt.Println("Showing AKS cluster ...")
 	args := []string{"aks", "show", "--subscription", subscriptionID, "--name", clusterName, "--resource-group", resourceGroup}
-	//❯ az aks show --subscription 80de5134-ca65-4731-be21-13fb1f0910a2 --output table --name pkumaraks --resource-group pkaks
 	fmt.Printf("Running command: az %v\n", args)
 	out, err := proc.RunW("az", args...)
 	if err != nil {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -24,7 +24,7 @@ var _ = Describe("P1Provisioning", func() {
 		GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 	})
 	AfterEach(func() {
-		if ctx.ClusterCleanup && cluster != nil {
+		if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
 		} else {
@@ -79,5 +79,123 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 176
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
+
+		It("recreating a cluster while it is being deleted should recreate the cluster", func() {
+			testCaseID = 218
+
+			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			// Wait until the cluster begins deletion process before recreating
+			Eventually(func() bool {
+				exists, err := helper.ClusterExistsOnAzure(clusterName, cluster.AKSConfig.ResourceGroup)
+				Expect(err).To(BeNil())
+				return exists
+			}, "1m", "5s").Should(BeFalse())
+
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
+			Expect(err).To(BeNil())
+
+			// wait until the error is visible on the provisioned cluster
+			Eventually(func() bool {
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				return cluster.State == "provisioning" && cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "an AKSClusterConfig exists with the same name")
+			}, "30s", "2s").Should(BeTrue())
+
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
 	})
+
+	It("deleting a cluster while it is in creation state should delete it from rancher and cloud console", func() {
+		testCaseID = 218
+		var err error
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
+		Expect(err).To(BeNil())
+
+		// Wait for the cluster to appear on cloud console before deleting it
+		Eventually(func() bool {
+			exists, err := helper.ClusterExistsOnAzure(clusterName, cluster.AKSConfig.ResourceGroup)
+			// ignore the error that occurs when resource group or cluster could not be found
+			if err != nil {
+				if strings.Contains(err.Error(), fmt.Sprintf("Resource group '%s' could not be found", cluster.AKSConfig.ResourceGroup)) || strings.Contains(err.Error(), "not found") {
+					err = nil
+				}
+			}
+			Expect(err).To(BeNil())
+			return exists
+		}, "1m", "5s").Should(BeTrue())
+
+		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		err = helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+
+		// Wait until the cluster finishes provisioning and then begins deletion process
+		Eventually(func() bool {
+			exists, err := helper.ClusterExistsOnAzure(clusterName, cluster.AKSConfig.ResourceGroup)
+			if err != nil {
+				if strings.Contains(err.Error(), fmt.Sprintf("Resource group '%s' could not be found", cluster.AKSConfig.ResourceGroup)) || strings.Contains(err.Error(), "not found") {
+					err = nil
+				}
+			}
+			Expect(err).To(BeNil())
+			return exists
+		}, "10m", "10s").Should(BeFalse())
+
+		// Keep the cluster variable as is so that there is no error in AfterEach; failed delete operation will return an empty cluster
+		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not found"))
+	})
+
+	It("should not be able to select NP K8s version; CP K8s version should take precedence", func() {
+		testCaseID = 182
+
+		k8sVersions, err := helper.ListSingleVariantAKSAvailableVersions(ctx.RancherAdminClient, ctx.CloudCred.ID, location)
+		Expect(err).To(BeNil())
+		Expect(len(k8sVersions)).To(BeNumerically(">=", 2))
+		cpK8sVersion := k8sVersions[0]
+		npK8sVersion := k8sVersions[1]
+
+		GinkgoLogr.Info(fmt.Sprintf("Using NP K8s version: %s and CP K8s version: %s", npK8sVersion, cpK8sVersion))
+
+		updateFunc := func(clusterConfig *aks.ClusterConfig) {
+			nodePools := *clusterConfig.NodePools
+			for i := range nodePools {
+				nodePools[i].OrchestratorVersion = &npK8sVersion
+			}
+			*clusterConfig.NodePools = nodePools
+		}
+
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, cpK8sVersion, location, updateFunc)
+		Expect(err).To(BeNil())
+
+		Expect(*cluster.AKSConfig.KubernetesVersion).To(Equal(cpK8sVersion))
+		for _, np := range cluster.AKSConfig.NodePools {
+			Expect(*np.OrchestratorVersion).To(Equal(cpK8sVersion))
+		}
+
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+
+		Eventually(func() bool {
+			GinkgoLogr.Info("Waiting for the k8s upgrade to appear in AKSStatus.UpstreamSpec...")
+			clusterState, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			if *clusterState.AKSStatus.UpstreamSpec.KubernetesVersion != cpK8sVersion {
+				return false
+			}
+
+			for _, np := range clusterState.AKSStatus.UpstreamSpec.NodePools {
+				if *np.OrchestratorVersion != cpK8sVersion {
+					return false
+				}
+			}
+			return true
+		}, "5m", "5s").Should(BeTrue(), "Failed while waiting for k8s upgrade.")
+	})
+
 })

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -81,7 +81,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		It("recreating a cluster while it is being deleted should recreate the cluster", func() {
-			testCaseID = 218
+			testCaseID = 219
 
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -475,7 +475,6 @@ func ClusterExistsOnGCloud(clusterName, project, zone string) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, "Failed to list cluster: "+out)
 	}
-	fmt.Println(out)
 	if strings.Contains(out, "RUNNING") || strings.Contains(out, "PROVISIONING") {
 		return true, nil
 	}

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -60,12 +60,7 @@ var _ = Describe("P1Provisioning", func() {
 			Eventually(func() bool {
 				clusterState, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
-				for _, condition := range clusterState.Conditions {
-					if strings.Contains(condition.Message, "Invalid value for field \"node_pool.name\"") {
-						return true
-					}
-				}
-				return false
+				return clusterState.Transitioning == "error" && strings.Contains(clusterState.TransitioningMessage, "Invalid value for field \"node_pool.name\"")
 			}, "60s", "2s").Should(BeTrue())
 
 		})
@@ -84,12 +79,7 @@ var _ = Describe("P1Provisioning", func() {
 			Eventually(func() bool {
 				clusterState, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
-				for _, condition := range clusterState.Conditions {
-					if strings.Contains(condition.Message, "Cluster.initial_node_count must be greater than zero") {
-						return true
-					}
-				}
-				return false
+				return clusterState.Transitioning == "error" && strings.Contains(clusterState.TransitioningMessage, "Cluster.initial_node_count must be greater than zero")
 			}, "60s", "2s").Should(BeTrue())
 
 		})


### PR DESCRIPTION
### What does this PR do?
Automate:
- 218: Delete the cluster while cluster is in creation state
- 219: Re-create a cluster while its in deletion state
- 182: User should not be able to select Nodepool k8s version during creation
- Fix GKE tests to use cluster.Transitioning and cluster.TransitioningMessage instead of conditions.
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [GKE :green_circle:] https://github.com/rancher/hosted-providers-e2e/actions/runs/10197984645/job/28212002904, [AKS :green_circle:] https://github.com/rancher/hosted-providers-e2e/actions/runs/10197970137/job/28211990711

### Special notes for your reviewer:
