### PR TITLE
EKS P1Provisioning

### DIFF
--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -2,6 +2,7 @@ package helper
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"time"
@@ -88,7 +89,7 @@ func UpgradeClusterKubernetesVersion(cluster *management.Cluster, upgradeToVersi
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 			return *cluster.EKSStatus.UpstreamSpec.KubernetesVersion
-		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(Equal(upgradeToVersion))
+		}, tools.SetTimeout(15*time.Minute), 30*time.Second).Should(Equal(upgradeToVersion))
 		// ensure nodegroup version is same in Rancher
 		for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
 			Expect(*ng.Version).To(Equal(currentVersion))
@@ -131,7 +132,7 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 				}
 			}
 			return true
-		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(BeTrue())
+		}, tools.SetTimeout(15*time.Minute), 30*time.Second).Should(BeTrue())
 	}
 	return cluster, nil
 }
@@ -195,7 +196,7 @@ func AddNodeGroup(cluster *management.Cluster, increaseBy int, client *rancher.C
 	return cluster, nil
 }
 
-// AddNodeGroupToConfig adds a nodegroup to the config; it uses the nodegroup template defined in CATTLE_TEST_CONFIG file
+// AddNodeGroupToConfig adds a nodegroup to the list; it uses the nodegroup template defined in CATTLE_TEST_CONFIG file
 func AddNodeGroupToConfig(eksClusterConfig eks.ClusterConfig, ngCount int) (eks.ClusterConfig, error) {
 
 	var updateNodeGroupsList []eks.NodeGroupConfig
@@ -290,6 +291,142 @@ func ScaleNodeGroup(cluster *management.Cluster, client *rancher.Client, nodeCou
 		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(BeTrue())
 	}
 
+	return cluster, nil
+}
+
+// UpdateLogging updates the logging of a EKS cluster, Types: api, audit, authenticator, controllerManager, scheduler
+// if checkClusterConfig is true, it validates the update
+func UpdateLogging(cluster *management.Cluster, client *rancher.Client, loggingTypes []string, checkClusterConfig bool) (*management.Cluster, error) {
+	upgradedCluster := cluster
+	*upgradedCluster.EKSConfig.LoggingTypes = loggingTypes
+
+	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
+	Expect(err).To(BeNil())
+
+	if checkClusterConfig {
+		// Check if the desired config is set correctly
+		Expect(*upgradedCluster.EKSConfig.LoggingTypes).Should(HaveExactElements(loggingTypes))
+
+		Eventually(func() []string {
+			ginkgo.GinkgoLogr.Info("Waiting for the logging changes to appear in EKSStatus.UpstreamSpec ...")
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			fmt.Println(*cluster.EKSStatus.UpstreamSpec.LoggingTypes)
+			return *cluster.EKSStatus.UpstreamSpec.LoggingTypes
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(HaveExactElements(loggingTypes))
+	}
+	return cluster, nil
+}
+
+// UpdateAccess updates the network access of a EKS cluster, Types: publicAccess, privateAccess
+// if checkClusterConfig is true, it validates the update
+func UpdateAccess(cluster *management.Cluster, client *rancher.Client, publicAccess, privateAccess bool, checkClusterConfig bool) (*management.Cluster, error) {
+	upgradedCluster := cluster
+	*upgradedCluster.EKSConfig.PublicAccess = publicAccess
+	*upgradedCluster.EKSConfig.PrivateAccess = privateAccess
+
+	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
+
+	if checkClusterConfig {
+		Eventually(func() bool {
+			// Check if the desired config is set correctly
+			Expect(*upgradedCluster.EKSConfig.PublicAccess).Should(Equal(publicAccess))
+			Expect(*upgradedCluster.EKSConfig.PrivateAccess).Should(Equal(privateAccess))
+
+			ginkgo.GinkgoLogr.Info("Waiting for the access changes to appear in EKSStatus.UpstreamSpec ...")
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return *cluster.EKSStatus.UpstreamSpec.PublicAccess == publicAccess && *cluster.EKSStatus.UpstreamSpec.PrivateAccess == privateAccess
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(BeTrue())
+	}
+	return cluster, err
+}
+
+// UpdatePublicAccessSources updates the network access sources of a EKS cluster
+// if checkClusterConfig is true, it validates the update
+func UpdatePublicAccessSources(cluster *management.Cluster, client *rancher.Client, publicAccessSources []string, checkClusterConfig bool) (*management.Cluster, error) {
+	upgradedCluster := cluster
+	*upgradedCluster.EKSConfig.PublicAccessSources = append(*upgradedCluster.EKSConfig.PublicAccessSources, publicAccessSources...)
+
+	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
+	Expect(err).To(BeNil())
+
+	if checkClusterConfig {
+		// Check if the desired config is set correctly
+		Expect(*upgradedCluster.EKSConfig.PublicAccessSources).Should(ContainElements(publicAccessSources))
+
+		Eventually(func() []string {
+			ginkgo.GinkgoLogr.Info("Waiting for the publicaccess sources changes to appear in EKSStatus.UpstreamSpec ...")
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return *cluster.EKSStatus.UpstreamSpec.PublicAccessSources
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(ContainElements(publicAccessSources))
+	}
+	return cluster, nil
+}
+
+// UpdateClusterTags updates the tags of a EKS cluster
+// if wait is set to true, it waits until the update is complete; if checkClusterConfig is true, it validates the update
+func UpdateClusterTags(cluster *management.Cluster, client *rancher.Client, tags map[string]string, checkClusterConfig bool) (*management.Cluster, error) {
+	upgradedCluster := cluster
+	maps.Copy(*upgradedCluster.EKSConfig.Tags, tags)
+
+	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
+	Expect(err).To(BeNil())
+
+	if checkClusterConfig {
+		Eventually(func() bool {
+			// Check if the desired config is set correctly
+			for key, value := range tags {
+				Expect(*cluster.EKSConfig.Tags).Should(HaveKeyWithValue(key, value))
+			}
+
+			ginkgo.GinkgoLogr.Info("Waiting for the cluster tag changes to appear in EKSStatus.UpstreamSpec ...")
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return helpers.CheckMapKeys(tags, *cluster.EKSStatus.UpstreamSpec.Tags)
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(BeTrue())
+	}
+	return cluster, nil
+}
+
+// UpdateNodegroupMetadata updates the tags & labels of a EKS Node groups
+// if wait is set to true, it waits until the update is complete; if checkClusterConfig is true, it validates the update
+func UpdateNodegroupMetadata(cluster *management.Cluster, client *rancher.Client, tags, labels map[string]string, checkClusterConfig bool) (*management.Cluster, error) {
+	upgradedCluster := cluster
+	for i := range upgradedCluster.EKSConfig.NodeGroups {
+		*upgradedCluster.EKSConfig.NodeGroups[i].Tags = tags
+		*upgradedCluster.EKSConfig.NodeGroups[i].Labels = labels
+	}
+
+	var err error
+	cluster, err = client.Management.Cluster.Update(cluster, &upgradedCluster)
+	Expect(err).To(BeNil())
+
+	if checkClusterConfig {
+		// Check if the desired config is set correctly
+		for _, ng := range cluster.EKSConfig.NodeGroups {
+			for key, value := range tags {
+				Expect(*ng.Tags).Should(HaveKeyWithValue(key, value))
+			}
+			for key, value := range labels {
+				Expect(*ng.Labels).Should(HaveKeyWithValue(key, value))
+			}
+		}
+
+		Eventually(func() bool {
+			ginkgo.GinkgoLogr.Info("Waiting for the nodegroup metadata changes to appear in EKSStatus.UpstreamSpec ...")
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+
+			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+				if helpers.CheckMapKeys(tags, *ng.Tags) && helpers.CheckMapKeys(labels, *ng.Labels) {
+					return true
+				}
+			}
+			return false
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(BeTrue())
+	}
 	return cluster, nil
 }
 

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/clusters/eks"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
@@ -24,7 +25,7 @@ var _ = Describe("P1Provisioning", func() {
 		GinkgoLogr.Info(fmt.Sprintf("While provisioning, using kubernetes version %s for cluster %s", k8sVersion, clusterName))
 	})
 
-	Context("Provisioning a cluster with invalid config", func() {
+	Context("Provisioning/Editing a cluster with invalid config", func() {
 
 		AfterEach(func() {
 			if ctx.ClusterCleanup && cluster != nil {
@@ -77,7 +78,50 @@ var _ = Describe("P1Provisioning", func() {
 				Expect(err).To(BeNil())
 				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "node group names must be unique")
 			}, "1m", "3s").Should(BeTrue())
+		})
 
+		It("Fail to create cluster with only Security groups", func() {
+			testCaseID = 120
+
+			sg := []string{namegen.AppendRandomString("sg-"), namegen.AppendRandomString("sg-")}
+			updateFunc := func(clusterConfig *eks.ClusterConfig) {
+				clusterConfig.SecurityGroups = sg
+			}
+			var err error
+			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, region, updateFunc)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("subnets must be provided if security groups are provided")))
+		})
+
+		It("Fail to update invalid values for Public Access Endpoints", func() {
+			testCaseID = 146
+
+			var err error
+			cidr := []string{namegen.AppendRandomString("invalid")}
+			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, region, nil)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			cluster, _ = helper.UpdatePublicAccessSources(cluster, ctx.RancherAdminClient, cidr, false)
+
+			Eventually(func() bool {
+				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "InvalidParameterException: The following CIDRs are invalid in publicAccessCidrs")
+			}, "1m", "3s").Should(BeTrue())
+		})
+
+		It("Fail to update both Public/Private access as false", func() {
+			testCaseID = 147
+
+			var err error
+			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, region, nil)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			_, err = helper.UpdateAccess(cluster, ctx.RancherAdminClient, false, false, false)
+			Expect(err).To(MatchError(ContainSubstring("public access, private access, or both must be enabled")))
 		})
 	})
 
@@ -85,7 +129,9 @@ var _ = Describe("P1Provisioning", func() {
 
 		BeforeEach(func() {
 			var err error
-			k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, true)
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
+			Expect(err).To(BeNil())
+			upgradeToVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
 			Expect(err).To(BeNil())
 			GinkgoLogr.Info(fmt.Sprintf("While provisioning, using kubernetes version %s for cluster %s", k8sVersion, clusterName))
 
@@ -122,6 +168,95 @@ var _ = Describe("P1Provisioning", func() {
 				Expect(err).To(BeNil())
 				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "all nodegroup kubernetes versionsmust be equal to or one minor version lower than the cluster kubernetes version")
 			}, "1m", "3s").Should(BeTrue())
+		})
+
+		It("Update k8s version of cluster and add node groups", func() {
+			testCaseID = 125
+
+			var err error
+			By("upgrading the ControlPlane", func() {
+				cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true)
+				Expect(err).To(BeNil())
+			})
+
+			By("adding a NodeGroup", func() {
+				cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, true, false)
+				Expect(err).To(BeNil())
+			})
+
+			By("deleting the NodeGroup", func() {
+				cluster, err = helper.DeleteNodeGroup(cluster, ctx.RancherAdminClient, true, false)
+				Expect(err).To(BeNil())
+			})
+
+			// wait until the update is visible on the cluster
+			Eventually(func() bool {
+				GinkgoLogr.Info("Waiting for the versin of new nodegroup to appear in EKSStatus.UpstreamSpec ...")
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+					if *ng.Version != upgradeToVersion {
+						return false
+					}
+				}
+				return true
+			}, "5m", "15s").Should(BeTrue())
+		})
+
+		It("should successfully update a cluster while it is still in updating state", func() {
+			testCaseID = 148
+			updateClusterInUpdatingState(cluster, ctx.RancherAdminClient)
+		})
+	})
+
+	When("a cluster is created", func() {
+
+		BeforeEach(func() {
+			var err error
+			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, region, nil)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		It("Update cluster logging types", func() {
+			testCaseID = 128
+
+			var err error
+			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
+			By("Adding the LoggingTypes", func() {
+				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
+				Expect(err).To(BeNil())
+			})
+
+			By("Removing the LoggingTypes", func() {
+				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, []string{loggingTypes[0]}, true)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		It("Update Tags and Labels", func() {
+			testCaseID = 131
+
+			var err error
+			tags := map[string]string{
+				"foo":        "bar",
+				"testCaseID": "144",
+			}
+
+			labels := map[string]string{
+				"testCaseID": "142",
+			}
+
+			By("Adding cluster tags", func() {
+				cluster, err = helper.UpdateClusterTags(cluster, ctx.RancherAdminClient, tags, true)
+				Expect(err).To(BeNil())
+			})
+
+			By("Adding Nodegroup tags & labels", func() {
+				cluster, err = helper.UpdateNodegroupMetadata(cluster, ctx.RancherAdminClient, tags, labels, true)
+				Expect(err).To(BeNil())
+			})
 		})
 	})
 })

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -331,3 +331,11 @@ func FilterUIUnsupportedVersions(versions []string, client *rancher.Client) (fil
 	}
 	return
 }
+
+// CheckMapElements checks if map1 keys are subset of map2
+func CheckMapKeys(map1, map2 map[string]string) (exists bool) {
+	for key := range map1 {
+		_, exists = map2[key]
+	}
+	return
+}


### PR DESCRIPTION
### What does this PR do?
Adds automation for EKS P1 Provisioning tests, Qase IDs - 120, 146, 147, 125, 148, 128, 131, 144, and 142

### Checklist:
- [x] GitHub Actions:
:green_circle: https://github.com/rancher/hosted-providers-e2e/actions/runs/10217897213