### PR TITLE
Automate Qase: 183, 189, 190, 191, 267, 268, 269

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -448,9 +448,7 @@ func UpdateAutoScaling(cluster *management.Cluster, client *rancher.Client, enab
 
 // UpdateCluster is a generic function to update a cluster
 func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFunc func(*management.Cluster)) (*management.Cluster, error) {
-	upgradedCluster := new(management.Cluster)
-	upgradedCluster.Name = cluster.Name
-	upgradedCluster.AKSConfig = cluster.AKSConfig
+	upgradedCluster := cluster
 
 	updateFunc(upgradedCluster)
 

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -446,6 +446,17 @@ func UpdateAutoScaling(cluster *management.Cluster, client *rancher.Client, enab
 	return cluster, nil
 }
 
+// UpdateCluster is a generic function to update a cluster
+func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFunc func(*management.Cluster)) (*management.Cluster, error) {
+	upgradedCluster := new(management.Cluster)
+	upgradedCluster.Name = cluster.Name
+	upgradedCluster.AKSConfig = cluster.AKSConfig
+
+	updateFunc(upgradedCluster)
+
+	return client.Management.Cluster.Update(cluster, &upgradedCluster)
+}
+
 // ====================================================================Azure CLI (start)=================================
 // Create Azure AKS cluster using AZ CLI
 func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion string, nodes string, tags map[string]string) error {
@@ -469,6 +480,22 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 
 	fmt.Println("Created AKS cluster: ", clusterName)
 
+	return nil
+}
+
+// AddNodePoolOnAzure adds nodepool to an AKS cluster via CLI; helpful when creating a cluster with multiple nodepools
+func AddNodePoolOnAzure(npName, clusterName, resourceGroupName, nodeCount string, extraArgs ...string) error {
+	fmt.Println("Adding node pool ...")
+	args := []string{"aks", "nodepool", "add", "--resource-group", resourceGroupName, "--cluster-name", clusterName, "--name", npName, "--node-count", nodeCount}
+	if len(extraArgs) > 0 {
+		args = append(args, extraArgs...)
+	}
+	fmt.Printf("Running command: az %v\n", args)
+	out, err := proc.RunW("az", args...)
+	if err != nil {
+		return errors.Wrap(err, "Failed to add node pool: "+out)
+	}
+	fmt.Println("Added node pool: ", npName)
 	return nil
 }
 

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -486,7 +486,7 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 // AddNodePoolOnAzure adds nodepool to an AKS cluster via CLI; helpful when creating a cluster with multiple nodepools
 func AddNodePoolOnAzure(npName, clusterName, resourceGroupName, nodeCount string, extraArgs ...string) error {
 	fmt.Println("Adding node pool ...")
-	args := []string{"aks", "nodepool", "add", "--resource-group", resourceGroupName, "--cluster-name", clusterName, "--name", npName, "--node-count", nodeCount}
+	args := []string{"aks", "nodepool", "add", "--resource-group", resourceGroupName, "--cluster-name", clusterName, "--name", npName, "--node-count", nodeCount, "--subscription", subscriptionID}
 	if len(extraArgs) > 0 {
 		args = append(args, extraArgs...)
 	}

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -53,7 +53,7 @@ var _ = Describe("P1Import", func() {
 		})
 	})
 
-	FWhen("a cluster is created with multiple nodepools", func() {
+	When("a cluster is created with multiple nodepools", func() {
 		BeforeEach(func() {
 			var err error
 			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
@@ -82,7 +82,7 @@ var _ = Describe("P1Import", func() {
 
 	})
 
-	FWhen("a cluster is created and imported for upgrade", func() {
+	When("a cluster is created and imported for upgrade", func() {
 		BeforeEach(func() {
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, true)

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -12,10 +12,77 @@ import (
 )
 
 var _ = Describe("P1Import", func() {
+	var k8sVersion string
+	var cluster *management.Cluster
+	BeforeEach(func() {
+		var err error
+		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
+		Expect(err).NotTo(HaveOccurred())
+		GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
+	})
+
+	AfterEach(func() {
+		if ctx.ClusterCleanup {
+			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			if cluster != nil && cluster.ID != "" {
+				err = helper.DeleteAKSClusteronAzure(clusterName)
+				Expect(err).To(BeNil())
+			}
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
+
 	When("a cluster is created", func() {
-		var cluster *management.Cluster
 		BeforeEach(func() {
-			k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, false)
+			var err error
+			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		It("should be able to update autoscaling", func() {
+			testCaseID = 266
+			updateAutoScaling(cluster, ctx.RancherAdminClient)
+		})
+	})
+
+	FWhen("a cluster is created with multiple nodepools", func() {
+		BeforeEach(func() {
+			var err error
+			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+
+			// AKS already consists on one system pool, so we add a user pool
+			err = helper.AddNodePoolOnAzure("userpool", clusterName, clusterName, "2", "--mode", "User")
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		It("should not be able to remove system nodepool", func() {
+			testCaseID = 267
+			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
+		})
+		It("should to able to delete a nodepool and add a new one", func() {
+			testCaseID = 268
+			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)
+		})
+
+	})
+
+	FWhen("a cluster is created and imported for upgrade", func() {
+		BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, true)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
@@ -27,20 +94,10 @@ var _ = Describe("P1Import", func() {
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
 		})
-		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
-				err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
-				err = helper.DeleteAKSClusteronAzure(clusterName)
-				Expect(err).To(BeNil())
-			} else {
-				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
-			}
-		})
 
-		It("should be able to update autoscaling", func() {
-			testCaseID = 266
-			updateAutoScaling(cluster, ctx.RancherAdminClient)
+		It("NP cannot be upgraded to k8s version greater than CP k8s version", func() {
+			testCaseID = 269
+			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient)
 		})
 	})
 

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -23,12 +23,13 @@ var _ = Describe("P1Import", func() {
 
 	AfterEach(func() {
 		if ctx.ClusterCleanup {
-			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
 			if cluster != nil && cluster.ID != "" {
-				err = helper.DeleteAKSClusteronAzure(clusterName)
+				err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			}
+			err := helper.DeleteAKSClusteronAzure(clusterName)
+			Expect(err).To(BeNil())
+
 		} else {
 			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 		}
@@ -68,10 +69,12 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should not be able to remove system nodepool", func() {
+		XIt("should not be able to remove system nodepool", func() {
+			// Blocked on https://github.com/rancher/aks-operator/issues/619
 			testCaseID = 267
 			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
 		})
+
 		It("should to able to delete a nodepool and add a new one", func() {
 			testCaseID = 268
 			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -109,7 +109,7 @@ var _ = Describe("P1Provisioning", func() {
 
 	})
 
-	FWhen("a cluster is created for upgrade", func() {
+	When("a cluster is created for upgrade", func() {
 		BeforeEach(func() {
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, true)
@@ -217,7 +217,7 @@ var _ = Describe("P1Provisioning", func() {
 		}, "5m", "5s").Should(BeTrue(), "Failed while waiting for k8s upgrade.")
 	})
 
-	FWhen("a cluster is created for with user and system mode nodepool", func() {
+	When("a cluster is created for with user and system mode nodepool", func() {
 		BeforeEach(func() {
 			updateFunc := func(clusterConfig *aks.ClusterConfig) {
 				nodePools := *clusterConfig.NodePools

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -109,6 +109,25 @@ var _ = Describe("P1Provisioning", func() {
 
 	})
 
+	FWhen("a cluster is created for upgrade", func() {
+		BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, true)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
+
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, nil)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("NP cannot be upgraded to k8s version greater than CP k8s version", func() {
+			testCaseID = 183
+			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient)
+		})
+	})
+
 	It("deleting a cluster while it is in creation state should delete it from rancher and cloud console", func() {
 		testCaseID = 218
 		var err error
@@ -196,6 +215,59 @@ var _ = Describe("P1Provisioning", func() {
 			}
 			return true
 		}, "5m", "5s").Should(BeTrue(), "Failed while waiting for k8s upgrade.")
+	})
+
+	FWhen("a cluster is created for with user and system mode nodepool", func() {
+		BeforeEach(func() {
+			updateFunc := func(clusterConfig *aks.ClusterConfig) {
+				nodePools := *clusterConfig.NodePools
+				npTemplate := nodePools[0]
+				var updatedNodePools []aks.NodePool
+				for _, mode := range []string{"User", "System"} {
+					np := aks.NodePool{
+						AvailabilityZones:   npTemplate.AvailabilityZones,
+						EnableAutoScaling:   npTemplate.EnableAutoScaling,
+						MaxPods:             npTemplate.MaxPods,
+						MaxCount:            npTemplate.MaxCount,
+						MinCount:            npTemplate.MinCount,
+						Mode:                mode,
+						Name:                pointer.String(fmt.Sprintf("%spool", strings.ToLower(mode))),
+						NodeCount:           npTemplate.NodeCount,
+						OrchestratorVersion: &k8sVersion,
+						OsDiskSizeGB:        npTemplate.OsDiskSizeGB,
+						OsDiskType:          npTemplate.OsDiskType,
+						OsType:              npTemplate.OsType,
+						VMSize:              npTemplate.VMSize,
+					}
+					updatedNodePools = append(updatedNodePools, np)
+
+				}
+				*clusterConfig.NodePools = updatedNodePools
+			}
+			var err error
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		It("should successfully create the cluster", func() {
+			testCaseID = 189
+			helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+
+			Expect(len(cluster.AKSConfig.NodePools)).To(Equal(4))
+			Expect(len(cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(4))
+		})
+
+		It("should to able to delete a nodepool and add a new one", func() {
+			testCaseID = 190
+			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)
+		})
+
+		It("should not be able to remove system nodepool", func() {
+			testCaseID = 191
+			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
+		})
 	})
 
 })

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -255,8 +255,8 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 189
 			helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
 
-			Expect(len(cluster.AKSConfig.NodePools)).To(Equal(4))
-			Expect(len(cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(4))
+			Expect(len(cluster.AKSConfig.NodePools)).To(Equal(2))
+			Expect(len(cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(2))
 		})
 
 		It("should to able to delete a nodepool and add a new one", func() {

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -1,6 +1,8 @@
 package p1_test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -8,7 +10,9 @@ import (
 	. "github.com/rancher-sandbox/qase-ginkgo"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"k8s.io/utils/pointer"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
@@ -60,4 +64,106 @@ func updateAutoScaling(cluster *management.Cluster, client *rancher.Client) {
 		cluster, err = helper.UpdateAutoScaling(cluster, client, false, 0, 0, true)
 		Expect(err).To(BeNil())
 	})
+}
+
+func removeSystemNpCheck(cluster *management.Cluster, client *rancher.Client) {
+	updateFunc := func(cluster *management.Cluster) {
+		var upgradedNodePools []management.AKSNodePool
+		for _, np := range cluster.AKSConfig.NodePools {
+			if np.Mode == "User" {
+				upgradedNodePools = append(upgradedNodePools, np)
+			}
+		}
+		cluster.AKSConfig.NodePools = upgradedNodePools
+	}
+	var err error
+	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
+	Expect(err).To(BeNil())
+	Eventually(func() bool {
+		cluster, err = client.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "There has to be at least one system agent pool")
+	}, "5m", "5s").Should(BeTrue())
+}
+
+func deleteAndAddNpCheck(cluster *management.Cluster, client *rancher.Client) {
+	npToBeDeleted := cluster.AKSConfig.NodePools[0]
+	updateFunc := func(cluster *management.Cluster) {
+		upgradedNodePools := cluster.AKSConfig.NodePools[1:]
+
+		upgradedNodePools = append(upgradedNodePools, management.AKSNodePool{
+			AvailabilityZones:   npToBeDeleted.AvailabilityZones,
+			Count:               npToBeDeleted.Count,
+			EnableAutoScaling:   npToBeDeleted.EnableAutoScaling,
+			MaxCount:            npToBeDeleted.MaxCount,
+			MaxPods:             npToBeDeleted.MaxPods,
+			MaxSurge:            npToBeDeleted.MaxSurge,
+			MinCount:            npToBeDeleted.MinCount,
+			Mode:                "System",
+			Name:                pointer.String(fmt.Sprintf("newpool%s", namegen.RandStringLower(3))),
+			NodeLabels:          npToBeDeleted.NodeLabels,
+			NodeTaints:          npToBeDeleted.NodeTaints,
+			OrchestratorVersion: npToBeDeleted.OrchestratorVersion,
+			OsDiskSizeGB:        npToBeDeleted.OsDiskSizeGB,
+			OsDiskType:          npToBeDeleted.OsDiskType,
+			OsType:              npToBeDeleted.OsType,
+			VMSize:              npToBeDeleted.VMSize,
+			VnetSubnetID:        npToBeDeleted.VnetSubnetID,
+		})
+		cluster.AKSConfig.NodePools = upgradedNodePools
+	}
+	var err error
+	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
+	Expect(err).To(BeNil())
+	var (
+		npDeleted = true
+		npAdded   = false
+	)
+	for _, np := range cluster.AKSConfig.NodePools {
+		if *np.Name == *npToBeDeleted.Name {
+			npDeleted = false
+		}
+		if *np.Name == "newpool" {
+			npAdded = true
+		}
+	}
+	Expect(npAdded).To(BeTrue())
+	Expect(npDeleted).To(BeTrue())
+
+	err = clusters.WaitClusterToBeUpgraded(client, cluster.ID)
+	Expect(err).To(BeNil())
+
+	Eventually(func() bool {
+		cluster, err = client.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		var (
+			npDeletedFromUpstream = true
+			npAddedToUpstream     = false
+		)
+		for _, np := range cluster.AKSConfig.NodePools {
+			if *np.Name == "newpool" {
+				npAddedToUpstream = true
+			}
+			if *np.Name == *npToBeDeleted.Name {
+				npDeletedFromUpstream = false
+			}
+		}
+		return npAddedToUpstream && npDeletedFromUpstream
+	}, "5m", "5s").Should(BeTrue(), "Failed while waiting for node pools to be added and deleted")
+
+}
+
+// npUpgradeToVersionGTCPCheck runs checks when nodepool is upgraded to a version greater than control plane version
+func npUpgradeToVersionGTCPCheck(cluster *management.Cluster, client *rancher.Client) {
+	k8sVersion := cluster.AKSConfig.KubernetesVersion
+	availableVersions, err := helper.ListAKSAvailableVersions(client, cluster.ID)
+	Expect(err).To(BeNil())
+	upgradeK8sVersion := availableVersions[0]
+	cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeK8sVersion, client, false, false)
+	Expect(err).To(BeNil())
+	Eventually(func() bool {
+		cluster, err = client.Management.Cluster.ByID(cluster.ID)
+		Expect(err).NotTo(HaveOccurred())
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, fmt.Sprintf("Node pool version %s and control plane version %s are incompatible.", upgradeK8sVersion, k8sVersion))
+	}, "1m", "2s").Should(BeTrue())
 }

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -378,10 +378,7 @@ func UpdateAutoScaling(cluster *management.Cluster, client *rancher.Client, enab
 
 // UpdateCluster is a generic function to update a cluster
 func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFunc func(*management.Cluster)) (*management.Cluster, error) {
-	upgradedCluster := new(management.Cluster)
-	upgradedCluster.Name = cluster.Name
-	upgradedCluster.GKEConfig = cluster.GKEConfig
-
+	upgradedCluster := cluster
 	updateFunc(upgradedCluster)
 
 	return client.Management.Cluster.Update(cluster, &upgradedCluster)


### PR DESCRIPTION
### What does this PR do?
- 183, 269 : NP cannot be upgraded to k8s version greater than CP k8s version
- 189: A cluster with multiple nodepools should be created
- 190, 268: should to able to delete a nodepool and add a new one
- 191, 267: should not be able to remove system nodepool
- Add new helper functions: UpdateCluster, AddNodePoolOnAzure
- Update `UpdateCluster` for GKE and AKS
 
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [p1 provisioning :green_circle:  ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10264139214, [p1 import :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10264141880, [gke p1 provisioning :green_circle: :] https://github.com/rancher/hosted-providers-e2e/actions/runs/10265304108, [gke p1 import :green_circle: : ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10265307488

### Special notes for your reviewer:
