### PR TITLE
EKS Sync automation

### DIFF
--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -41,7 +41,7 @@ on:
         default: 'hostname/password'
         type: string
       tests_to_run:
-        description: Tests to run (p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import/p1_provisioning/p1_import)
+        description: Tests to run (p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/k8s_chart_support_provisioning/k8s_chart_support_import/p1_provisioning/p1_import/sync_provisioning/sync_import)
         type: string
         required: true
         default: p0_provisioning/p0_import

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -493,6 +493,22 @@ func UpgradeEKSNodegroupOnAWS(eks_region string, clusterName string, ngName stri
 	return nil
 }
 
+func GetFromEKS(region string, clusterName string, cmd string, query string) (out string, err error) {
+	clusterArgs := []string{"eksctl", "get", "cluster", "--region=" + region, "--name=" + clusterName, "-ojson", "|", "jq", "-r"}
+	ngArgs := []string{"eksctl", "get", "nodegroup", "--region=" + region, "--cluster=" + clusterName, "-ojson", "|", "jq", "-r"}
+
+	if cmd == "cluster" {
+		clusterArgs = append(clusterArgs, query)
+		cmd = strings.Join(clusterArgs, " ")
+	} else {
+		ngArgs = append(ngArgs, query)
+		cmd = strings.Join(ngArgs, " ")
+	}
+	fmt.Printf("Running command: %s\n", cmd)
+	out, err = proc.RunW("bash", "-c", cmd)
+	return strings.TrimSpace(out), err
+}
+
 // Complete cleanup steps for Amazon EKS
 func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
 	currentKubeconfig := os.Getenv("KUBECONFIG")

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -121,13 +121,14 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 		Expect(err).To(BeNil())
 	}
 
-	// TODO: Fix flaky check
 	if checkClusterConfig {
 		Eventually(func() bool {
+			// Check if the desired config has been applied in
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
 			ginkgo.GinkgoLogr.Info("waiting for the nodegroup upgrade to appear in EKSStatus.UpstreamSpec ...")
-			// Check if the desired config has been applied in Rancher
 			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
-				if *ng.Version != upgradeToVersion {
+				if ng.Version == nil || *ng.Version != upgradeToVersion {
 					return false
 				}
 			}
@@ -441,6 +442,8 @@ func ListEKSAvailableVersions(client *rancher.Client, clusterID string) (availab
 	return helpers.FilterUIUnsupportedVersions(allAvailableVersions, client), nil
 }
 
+// <==============================EKS CLI==============================>
+
 // Create AWS EKS cluster using EKS CLI
 func CreateEKSClusterOnAWS(eks_region string, clusterName string, k8sVersion string, nodes string, tags map[string]string) error {
 	currentKubeconfig := os.Getenv("KUBECONFIG")
@@ -458,6 +461,35 @@ func CreateEKSClusterOnAWS(eks_region string, clusterName string, k8sVersion str
 	}
 	fmt.Println("Created EKS cluster: ", clusterName)
 
+	return nil
+}
+
+// Upgrade EKS cluster using EKS CLI
+func UpgradeEKSClusterOnAWS(eks_region string, clusterName string, upgradeToVersion string) error {
+
+	fmt.Println("Upgrading EKS cluster controlplane ...")
+	args := []string{"upgrade", "cluster", "--region=" + eks_region, "--name=" + clusterName, "--version=" + upgradeToVersion, "--approve"}
+	fmt.Printf("Running command: eksctl %v\n", args)
+	out, err := proc.RunW("eksctl", args...)
+	if err != nil {
+		return errors.Wrap(err, "Failed to upgrade cluster: "+out)
+	}
+
+	fmt.Println("Upgraded EKS cluster controlplane: ", clusterName)
+	return nil
+}
+
+// Upgrade EKS cluster nodegroup using EKS CLI
+func UpgradeEKSNodegroupOnAWS(eks_region string, clusterName string, ngName string, upgradeToVersion string) error {
+	fmt.Println("Upgrading EKS cluster nodegroup ...")
+	args := []string{"upgrade", "nodegroup", "--region=" + eks_region, "--name=" + ngName, "--cluster=" + clusterName, "--kubernetes-version=" + upgradeToVersion}
+	fmt.Printf("Running command: eksctl %v\n", args)
+	out, err := proc.RunW("eksctl", args...)
+	if err != nil {
+		return errors.Wrap(err, "Failed to upgrade nodegroup: "+out)
+	}
+
+	fmt.Println("Upgraded EKS cluster nodegroup: ", clusterName)
 	return nil
 }
 
@@ -484,6 +516,8 @@ func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
 
 	return nil
 }
+
+// <==============================EKS CLI(end)==============================>
 
 // defaultEKS returns a version less than the highest version or K8S_UPGRADE_MINOR_VERSION if it is set.
 // Note: It does not return the default version used by UI which is the highest supported version.

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -83,7 +83,7 @@ func p0upgradeK8sVersionChecks(cluster *management.Cluster, client *rancher.Clie
 	// Does not upgrades version since using custom LT, skip for imported cluster
 	if !helpers.IsImport {
 		By("upgrading the NodeGroups", func() {
-			cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeToVersion, client, true, false)
+			cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeToVersion, client, true, true)
 			Expect(err).To(BeNil())
 		})
 	}

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -33,7 +33,7 @@ var _ = Describe("P1Import", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 				err = helper.DeleteEKSClusterOnAWS(region, clusterName)

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -1,0 +1,80 @@
+package p1_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("P1Import", func() {
+	var cluster *management.Cluster
+
+	When("a cluster is imported for upgrade", func() {
+
+		BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
+			Expect(err).To(BeNil())
+			upgradeToVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+			Expect(err).To(BeNil())
+			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup && cluster != nil {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("Upgrade k8s version of cluster from EKS and verify it is synced back to Rancher", func() {
+			testCaseID = 114
+
+			By("upgrading the ControlPlane & NodeGroup", func() {
+				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, true)
+
+			})
+		})
+
+		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
+			testCaseID = 112
+
+			var err error
+			initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
+			By("upgrading the ControlPlane", func() {
+				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, false)
+			})
+
+			By("scaling up the NodeGroup", func() {
+				cluster, err = helper.ScaleNodeGroup(cluster, ctx.RancherAdminClient, initialNodeCount+1, true, true)
+				Expect(err).To(BeNil())
+			})
+
+			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
+			By("Adding the LoggingTypes", func() {
+				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
+				Expect(err).To(BeNil())
+			})
+
+			// Check if the desired config is set correctly
+			Expect(*cluster.EKSConfig.NodeGroups[0].DesiredSize).To(BeNumerically("==", initialNodeCount+1))
+			Expect(*cluster.EKSConfig.LoggingTypes).Should(HaveExactElements(loggingTypes))
+		})
+	})
+})

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -29,11 +29,9 @@ var _ = Describe("P1Provisioning", func() {
 	Context("Provisioning/Editing a cluster with invalid config", func() {
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
-				if cluster != nil {
-					err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
-				}
+			if ctx.ClusterCleanup {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
 			}
 		})
 
@@ -143,7 +141,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {
@@ -250,6 +248,15 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
 		})
 
 		It("Update cluster logging types", func() {

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -220,7 +220,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup && cluster.ID != "" {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -17,7 +17,6 @@ import (
 
 var _ = Describe("P1Provisioning", func() {
 	var cluster *management.Cluster
-	loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
 
 	var _ = BeforeEach(func() {
 		var err error
@@ -29,9 +28,11 @@ var _ = Describe("P1Provisioning", func() {
 	Context("Provisioning/Editing a cluster with invalid config", func() {
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup {
-				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
+			if ctx.ClusterCleanup && cluster != nil {
+				if cluster != nil {
+					err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+					Expect(err).To(BeNil())
+				}
 			}
 		})
 
@@ -141,7 +142,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup {
+			if ctx.ClusterCleanup && cluster != nil {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {
@@ -206,38 +207,6 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 148
 			updateClusterInUpdatingState(cluster, ctx.RancherAdminClient)
 		})
-
-		It("Upgrade k8s version of cluster from EKS and verify it is synced back to Rancher", func() {
-			testCaseID = 159
-
-			By("upgrading the ControlPlane & NodeGroup", func() {
-				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, true)
-			})
-		})
-
-		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
-			testCaseID = 157
-
-			var err error
-			currentNodeGroupNumber := len(cluster.EKSConfig.NodeGroups)
-			By("upgrading control plane", func() {
-				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, false)
-			})
-
-			By("adding a NodeGroup", func() {
-				cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, true, true)
-				Expect(err).To(BeNil())
-			})
-
-			By("Adding the LoggingTypes", func() {
-				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
-				Expect(err).To(BeNil())
-			})
-
-			// Check if the desired config is set correctly
-			Expect(len(cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber+1))
-			Expect(*cluster.EKSConfig.LoggingTypes).Should(HaveExactElements(loggingTypes))
-		})
 	})
 
 	When("a cluster is created", func() {
@@ -251,7 +220,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup {
+			if ctx.ClusterCleanup && cluster != nil {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {
@@ -263,6 +232,7 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 128
 
 			var err error
+			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
 			By("Adding the LoggingTypes", func() {
 				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
 				Expect(err).To(BeNil())

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -28,7 +28,7 @@ var _ = Describe("P1Provisioning", func() {
 	Context("Provisioning/Editing a cluster with invalid config", func() {
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 				if cluster != nil {
 					err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 					Expect(err).To(BeNil())
@@ -142,7 +142,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {
@@ -220,7 +220,7 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster.ID != "" {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -15,13 +15,10 @@ limitations under the License.
 package p1_test
 
 import (
-	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/epinio/epinio/acceptance/helpers/proc"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rancher-sandbox/ele-testhelpers/tools"
@@ -176,15 +173,15 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client) 
 		}
 
 		// Verify the new edits reflect in AWS and existing details do NOT change
-		out, err := getFromEKS("cluster", "'.[]|.Version'")
+		out, err := helper.GetFromEKS(region, clusterName, "cluster", "'.[]|.Version'")
 		Expect(err).To(BeNil())
 		Expect(out).To(Equal(upgradeToVersion))
 
-		out, err = getFromEKS("nodegroup", "'.|length'")
+		out, err = helper.GetFromEKS(region, clusterName, "nodegroup", "'.|length'")
 		Expect(err).To(BeNil())
 		Expect(strconv.Atoi(out)).To(Equal(currentNodeGroupNumber))
 
-		out, err = getFromEKS("nodegroup", "'.[]|.DesiredCapacity'")
+		out, err = helper.GetFromEKS(region, clusterName, "nodegroup", "'.[]|.DesiredCapacity'")
 		Expect(err).To(BeNil())
 		Expect(strconv.ParseInt(out, 10, 64)).To(Equal(initialNodeCount + 1))
 	})
@@ -198,11 +195,11 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client) 
 		Expect(*cluster.EKSConfig.LoggingTypes).ShouldNot(HaveExactElements(loggingTypes))
 
 		// Verify the new edits reflect in AWS console and existing details do NOT change
-		out, err := getFromEKS("cluster", "'.[]|.Version'")
+		out, err := helper.GetFromEKS(region, clusterName, "cluster", "'.[]|.Version'")
 		Expect(err).To(BeNil())
 		Expect(out).To(Equal(upgradeToVersion))
 
-		out, err = getFromEKS("nodegroup", "'.|length'")
+		out, err = helper.GetFromEKS(region, clusterName, "nodegroup", "'.|length'")
 		Expect(err).To(BeNil())
 		Expect(strconv.Atoi(out)).To(Equal(currentNodeGroupNumber + 1))
 	})
@@ -216,29 +213,13 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client) 
 		Expect(len(cluster.EKSConfig.NodeGroups)).To(Equal(currentNodeGroupNumber + 1))
 
 		// Verify the new edits reflect in AWS console and existing details do NOT change
-		out, err := getFromEKS("nodegroup", "'.|length'")
+		out, err := helper.GetFromEKS(region, clusterName, "nodegroup", "'.|length'")
 		Expect(err).To(BeNil())
 		Expect(strconv.Atoi(out)).To(Equal(currentNodeGroupNumber + 1))
 
-		out, err = getFromEKS("cluster", "'.[]|.Logging|.[]|.[]|.Types'")
+		out, err = helper.GetFromEKS(region, clusterName, "cluster", "'.[]|.Logging|.[]|.[]|.Types'")
 		Expect(err).To(BeNil())
 		Expect(out).ShouldNot(HaveExactElements(loggingTypes))
 	})
 
-}
-
-func getFromEKS(cmd string, query string) (out string, err error) {
-	clusterArgs := []string{"eksctl", "get", "cluster", "--region=" + region, "--name=" + clusterName, "-ojson", "|", "jq", "-r"}
-	ngArgs := []string{"eksctl", "get", "nodegroup", "--region=" + region, "--cluster=" + clusterName, "-ojson", "|", "jq", "-r"}
-
-	if cmd == "cluster" {
-		clusterArgs = append(clusterArgs, query)
-		cmd = strings.Join(clusterArgs, " ")
-	} else {
-		ngArgs = append(ngArgs, query)
-		cmd = strings.Join(ngArgs, " ")
-	}
-	fmt.Printf("Running command: %s\n", cmd)
-	out, err = proc.RunW("bash", "-c", cmd)
-	return strings.TrimSpace(out), err
 }

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -114,7 +114,6 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 
 		if !helpers.IsImport {
 			// For imported clusters, EKSConfig always has null values; so we check EKSConfig only when testing provisioned clusters
-			Expect(*cluster.EKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
 			for _, ng := range cluster.EKSConfig.NodeGroups {
 				Expect(*ng.Version).To(BeEquivalentTo(k8sVersion), "EKSConfig.NodePools check failed")
 			}

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -16,9 +16,11 @@ package p1_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
 	. "github.com/rancher-sandbox/qase-ginkgo"
 	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -93,4 +95,59 @@ func updateClusterInUpdatingState(cluster *management.Cluster, client *rancher.C
 		}
 		return exists && *cluster.EKSStatus.UpstreamSpec.KubernetesVersion == upgradeToVersion
 	}, "15m", "30s").Should(BeTrue())
+}
+
+func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Client, upgradeNodeGroup bool) {
+	var err error
+	GinkgoLogr.Info("Upgrading cluster to version:" + upgradeToVersion)
+
+	By("upgrading control plane", func() {
+		err = helper.UpgradeEKSClusterOnAWS(region, clusterName, upgradeToVersion)
+		Expect(err).To(BeNil())
+
+		Eventually(func() string {
+			GinkgoLogr.Info("Waiting for k8s upgrade to appear in EKSStatus.UpstreamSpec ...")
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return *cluster.EKSStatus.UpstreamSpec.KubernetesVersion
+		}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(Equal(upgradeToVersion), "Failed while waiting for k8s upgrade to appear in EKSStatus.UpstreamSpec")
+
+		if !helpers.IsImport {
+			// For imported clusters, EKSConfig always has null values; so we check EKSConfig only when testing provisioned clusters
+			Expect(*cluster.EKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
+			for _, ng := range cluster.EKSConfig.NodeGroups {
+				Expect(*ng.Version).To(BeEquivalentTo(k8sVersion), "EKSConfig.NodePools check failed")
+			}
+		}
+	})
+
+	if upgradeNodeGroup {
+		By("upgrading the nodegroup", func() {
+			GinkgoLogr.Info("Upgrading Nodegroup's EKS version")
+			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+				err = helper.UpgradeEKSNodegroupOnAWS(region, clusterName, *ng.NodegroupName, upgradeToVersion)
+				Expect(err).To(BeNil())
+			}
+
+			Eventually(func() bool {
+				GinkgoLogr.Info("Waiting for the nodegroup upgrade to appear in EKSStatus.UpstreamSpec ...")
+				cluster, err = client.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+					if ng.Version == nil || *ng.Version != upgradeToVersion {
+						return false
+					}
+				}
+				return true
+			}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(BeTrue(), "Failed while waiting for nodegroup k8s upgrade to appear in EKSStatus.UpstreamSpec")
+
+			if !helpers.IsImport {
+				// For imported clusters, EKSConfig always has null values; so we check EKSConfig only when testing provisioned clusters
+				Expect(*cluster.EKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
+				for _, ng := range cluster.EKSConfig.NodeGroups {
+					Expect(*ng.Version).To(BeEquivalentTo(upgradeToVersion), "EKSConfig.NodePools upgrade check failed")
+				}
+			}
+		})
+	}
 }

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -54,28 +54,7 @@ var _ = Describe("SyncImport", func() {
 
 		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
 			testCaseID = 112
-
-			var err error
-			initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
-			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
-
-			By("upgrading the ControlPlane", func() {
-				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, false)
-			})
-
-			By("scaling up the NodeGroup", func() {
-				cluster, err = helper.ScaleNodeGroup(cluster, ctx.RancherAdminClient, initialNodeCount+1, true, true)
-				Expect(err).To(BeNil())
-			})
-
-			By("Adding the LoggingTypes", func() {
-				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
-				Expect(err).To(BeNil())
-			})
-
-			// Check if the desired config is set correctly
-			Expect(*cluster.EKSConfig.NodeGroups[0].DesiredSize).To(BeNumerically("==", initialNodeCount+1))
-			Expect(*cluster.EKSConfig.LoggingTypes).Should(HaveExactElements(loggingTypes))
+			syncRancherToAWSCheck(cluster, ctx.RancherAdminClient)
 		})
 	})
 })

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -1,0 +1,81 @@
+package p1_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("SyncImport", func() {
+	var cluster *management.Cluster
+
+	When("a cluster is imported for sync", func() {
+
+		BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
+			Expect(err).To(BeNil())
+			upgradeToVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+			Expect(err).To(BeNil())
+			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup && cluster != nil {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("Upgrade k8s version of cluster from EKS and verify it is synced back to Rancher", func() {
+			testCaseID = 114
+
+			By("upgrading the ControlPlane & NodeGroup", func() {
+				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, true)
+
+			})
+		})
+
+		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
+			testCaseID = 112
+
+			var err error
+			initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
+			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
+
+			By("upgrading the ControlPlane", func() {
+				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, false)
+			})
+
+			By("scaling up the NodeGroup", func() {
+				cluster, err = helper.ScaleNodeGroup(cluster, ctx.RancherAdminClient, initialNodeCount+1, true, true)
+				Expect(err).To(BeNil())
+			})
+
+			By("Adding the LoggingTypes", func() {
+				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
+				Expect(err).To(BeNil())
+			})
+
+			// Check if the desired config is set correctly
+			Expect(*cluster.EKSConfig.NodeGroups[0].DesiredSize).To(BeNumerically("==", initialNodeCount+1))
+			Expect(*cluster.EKSConfig.LoggingTypes).Should(HaveExactElements(loggingTypes))
+		})
+	})
+})

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -33,7 +33,7 @@ var _ = Describe("SyncImport", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 				err = helper.DeleteEKSClusterOnAWS(region, clusterName)

--- a/hosted/eks/p1/sync_provisioning_test.go
+++ b/hosted/eks/p1/sync_provisioning_test.go
@@ -31,7 +31,7 @@ var _ = Describe("SyncProvisioning", func() {
 		})
 
 		AfterEach(func() {
-			if ctx.ClusterCleanup && cluster != nil {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
 				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 			} else {

--- a/hosted/eks/p1/sync_provisioning_test.go
+++ b/hosted/eks/p1/sync_provisioning_test.go
@@ -49,28 +49,7 @@ var _ = Describe("SyncProvisioning", func() {
 
 		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
 			testCaseID = 157
-
-			var err error
-			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
-			currentNodeGroupNumber := len(cluster.EKSConfig.NodeGroups)
-
-			By("upgrading control plane", func() {
-				syncK8sVersionUpgradeCheck(cluster, ctx.RancherAdminClient, false)
-			})
-
-			By("adding a NodeGroup", func() {
-				cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, true, true)
-				Expect(err).To(BeNil())
-			})
-
-			By("Adding the LoggingTypes", func() {
-				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
-				Expect(err).To(BeNil())
-			})
-
-			// Check if the desired config is set correctly
-			Expect(len(cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber+1))
-			Expect(*cluster.EKSConfig.LoggingTypes).Should(HaveExactElements(loggingTypes))
+			syncRancherToAWSCheck(cluster, ctx.RancherAdminClient)
 		})
 	})
 


### PR DESCRIPTION
### What does this PR do?
- Automates and adds EKS Sync TCs to P1 suite, Qase IDs: 112, 114, 157 and 159
- Fixes flaky check of function _UpgradeNodeKubernetesVersion_

### Checklist:
- [x] GitHub Actions:
P0: :green_circle: https://github.com/rancher/hosted-providers-e2e/actions/runs/10266613984
SyncImport/SyncProvisioning: :green_circle: https://github.com/rancher/hosted-providers-e2e/actions/runs/10282588336



