### PR TITLE
Automate Qase: 177, 270, 205, 193

### DIFF
--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -51,6 +51,11 @@ var _ = Describe("P1Import", func() {
 			testCaseID = 266
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
+
+		It("should be able to update tags", func() {
+			testCaseID = 270
+			updateTagsCheck(cluster, ctx.RancherAdminClient)
+		})
 	})
 
 	When("a cluster is created with multiple nodepools", func() {

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -52,7 +52,7 @@ var _ = Describe("P1Import", func() {
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should be able to update tags", func() {
+		It("should be able to update tags", func() {
 			testCaseID = 270
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -52,7 +52,7 @@ var _ = Describe("P1Import", func() {
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
 
-		It("should be able to update tags", func() {
+		FIt("should be able to update tags", func() {
 			testCaseID = 270
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -2,6 +2,7 @@ package p1_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,6 +32,61 @@ var _ = Describe("P1Provisioning", func() {
 			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 		}
 	})
+
+	It("should successfully create cluster with multiple nodepools in multiple AZs", func() {
+		testCaseID = 193
+		updateFunc := func(aksConfig *aks.ClusterConfig) {
+			nodepools := *aksConfig.NodePools
+			npTemplate := nodepools[0]
+			var updatedNodePools []aks.NodePool
+			for i := 1; i <= 3; i++ {
+				az := []string{strconv.Itoa(i)}
+				for _, mode := range []string{"User", "System"} {
+					updatedNodePools = append(updatedNodePools, aks.NodePool{
+						AvailabilityZones:   &az,
+						EnableAutoScaling:   npTemplate.EnableAutoScaling,
+						MaxPods:             npTemplate.MaxPods,
+						MaxCount:            npTemplate.MaxCount,
+						MinCount:            npTemplate.MinCount,
+						Mode:                mode,
+						Name:                pointer.String(fmt.Sprintf("%s%d", strings.ToLower(mode), i)),
+						NodeCount:           npTemplate.NodeCount,
+						OrchestratorVersion: pointer.String(k8sVersion),
+						OsDiskSizeGB:        npTemplate.OsDiskSizeGB,
+						OsDiskType:          npTemplate.OsDiskType,
+						OsType:              npTemplate.OsType,
+						VMSize:              npTemplate.VMSize,
+					})
+				}
+			}
+			aksConfig.NodePools = &updatedNodePools
+		}
+		var err error
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+		for _, np := range cluster.AKSConfig.NodePools {
+			npName := *np.Name
+			az := npName[len(npName)-1]
+			Expect(*np.AvailabilityZones).To(Equal([]string{string(az)}))
+		}
+	})
+
+	It("should be able to create a cluster with empty tag", func() {
+		testCaseID = 205
+		updateFunc := func(aksConfig *aks.ClusterConfig) {
+			aksConfig.Tags["empty-tag"] = ""
+		}
+		var err error
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+	})
+
 	When("a cluster with invalid config is created", func() {
 		It("should fail to create a cluster with 0 nodecount", func() {
 			testCaseID = 186
@@ -51,6 +107,7 @@ var _ = Describe("P1Provisioning", func() {
 				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "agentPoolProfile.count was 0. It must be greater or equal to minCount:1 and less than or equal to maxCount:1000")
 			}, "1m", "2s").Should(BeTrue())
 		})
+
 		It("should fail to create a cluster with 0 nodepool", func() {
 			testCaseID = 187
 			updateFunc := func(aksConfig *aks.ClusterConfig) {
@@ -66,6 +123,7 @@ var _ = Describe("P1Provisioning", func() {
 			}, "1m", "2s").Should(BeTrue())
 		})
 	})
+
 	When("a cluster is created", func() {
 		BeforeEach(func() {
 			var err error
@@ -78,6 +136,11 @@ var _ = Describe("P1Provisioning", func() {
 		It("should be able to update autoscaling", func() {
 			testCaseID = 176
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
+		})
+
+		It("should be able to update tags", func() {
+			testCaseID = 177
+			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
 		It("recreating a cluster while it is being deleted should recreate the cluster", func() {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -33,7 +33,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	FIt("should successfully create cluster with multiple nodepools in multiple AZs", func() {
+	It("should successfully create cluster with multiple nodepools in multiple AZs", func() {
 		testCaseID = 193
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			nodepools := *aksConfig.NodePools
@@ -74,7 +74,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	FIt("should be able to create a cluster with empty tag", func() {
+	It("should be able to create a cluster with empty tag", func() {
 		testCaseID = 205
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			aksConfig.Tags["empty-tag"] = ""
@@ -138,7 +138,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should be able to update tags", func() {
+		It("should be able to update tags", func() {
 			testCaseID = 177
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -33,7 +33,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	It("should successfully create cluster with multiple nodepools in multiple AZs", func() {
+	FIt("should successfully create cluster with multiple nodepools in multiple AZs", func() {
 		testCaseID = 193
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			nodepools := *aksConfig.NodePools
@@ -74,7 +74,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	It("should be able to create a cluster with empty tag", func() {
+	FIt("should be able to create a cluster with empty tag", func() {
 		testCaseID = 205
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			aksConfig.Tags["empty-tag"] = ""
@@ -138,7 +138,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
 
-		It("should be able to update tags", func() {
+		FIt("should be able to update tags", func() {
 			testCaseID = 177
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -85,6 +85,8 @@ var _ = Describe("P1Provisioning", func() {
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
 		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+		Expect(cluster.AKSConfig.Tags).To(HaveKeyWithValue("empty-tag", ""))
+		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
 	When("a cluster with invalid config is created", func() {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -33,7 +33,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	It("should successfully create cluster with multiple nodepools in multiple AZs", func() {
+	FIt("should successfully create cluster with multiple nodepools in multiple AZs", func() {
 		testCaseID = 193
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			nodepools := *aksConfig.NodePools
@@ -74,7 +74,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	It("should be able to create a cluster with empty tag", func() {
+	FIt("should be able to create a cluster with empty tag", func() {
 		testCaseID = 205
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			aksConfig.Tags["empty-tag"] = ""
@@ -140,7 +140,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateAutoScaling(cluster, ctx.RancherAdminClient)
 		})
 
-		It("should be able to update tags", func() {
+		FIt("should be able to update tags", func() {
 			testCaseID = 177
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -221,6 +221,6 @@ func updateTagsCheck(cluster *management.Cluster, client *rancher.Client) {
 				}
 			}
 			return countUpstream
-		}, "5m", "5s").Should(Equal(0))
+		}, "7m", "5s").Should(Equal(0))
 	})
 }

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -174,24 +174,21 @@ func updateTagsCheck(cluster *management.Cluster, client *rancher.Client) {
 		var err error
 		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 		Expect(err).To(BeNil())
-		var count int
-		for key, value := range cluster.AKSConfig.Tags {
-			if (key == "empty-tag" && value == "") || (key == "new" && value == "tag") {
-				count++
-			}
-		}
-		Expect(count).To(Equal(2))
+		Expect(cluster.AKSConfig.Tags).To(HaveKeyWithValue("empty-tag", "tag"))
+		Expect(cluster.AKSConfig.Tags).To(HaveKeyWithValue("new", "tag"))
+
 		Eventually(func() int {
 			GinkgoLogr.Info("Waiting for the tags to be added ...")
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			var countUpstream int
+
+			var count int
 			for key, value := range cluster.AKSStatus.UpstreamSpec.Tags {
 				if (key == "empty-tag" && value == "") || (key == "new" && value == "tag") {
-					countUpstream++
+					count++
 				}
 			}
-			return countUpstream
+			return count
 		}, "5m", "5s").Should(Equal(2))
 	})
 
@@ -203,24 +200,21 @@ func updateTagsCheck(cluster *management.Cluster, client *rancher.Client) {
 		var err error
 		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 		Expect(err).To(BeNil())
-		var count int
-		for key, value := range cluster.AKSConfig.Tags {
-			if (key == "empty-tag" && value == "") || (key == "new" && value == "tag") {
-				count++
-			}
-		}
-		Expect(count).To(Equal(0))
+
+		Expect(cluster.AKSConfig.Tags).ToNot(HaveKeyWithValue("empty-tag", "tag"))
+		Expect(cluster.AKSConfig.Tags).ToNot(HaveKeyWithValue("new", "tag"))
+
 		Eventually(func() int {
 			GinkgoLogr.Info("Waiting for the tags to be removed ...")
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			var countUpstream int
+			var count int
 			for key, value := range cluster.AKSStatus.UpstreamSpec.Tags {
 				if (key == "empty-tag" && value == "") || (key == "new" && value == "tag") {
-					countUpstream++
+					count++
 				}
 			}
-			return countUpstream
+			return count
 		}, "7m", "5s").Should(Equal(0))
 	})
 }

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -174,7 +174,7 @@ func updateTagsCheck(cluster *management.Cluster, client *rancher.Client) {
 		var err error
 		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 		Expect(err).To(BeNil())
-		Expect(cluster.AKSConfig.Tags).To(HaveKeyWithValue("empty-tag", "tag"))
+		Expect(cluster.AKSConfig.Tags).To(HaveKeyWithValue("empty-tag", ""))
 		Expect(cluster.AKSConfig.Tags).To(HaveKeyWithValue("new", "tag"))
 
 		Eventually(func() int {
@@ -201,7 +201,7 @@ func updateTagsCheck(cluster *management.Cluster, client *rancher.Client) {
 		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 		Expect(err).To(BeNil())
 
-		Expect(cluster.AKSConfig.Tags).ToNot(HaveKeyWithValue("empty-tag", "tag"))
+		Expect(cluster.AKSConfig.Tags).ToNot(HaveKeyWithValue("empty-tag", ""))
 		Expect(cluster.AKSConfig.Tags).ToNot(HaveKeyWithValue("new", "tag"))
 
 		Eventually(func() int {


### PR DESCRIPTION
### What does this PR do?
- 205 - should be able to create a cluster with empty tag
- 193 - should successfully create cluster with multiple nodepools in multiple AZs
- 177, 270 - should be able to update tags

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) [p1 provisioning :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10317278927/job/28561274316, [p1 import :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10317363720/job/28561558909, [p1] https://github.com/rancher/hosted-providers-e2e/actions/runs/10469077886 (the failing test has been fixed and it works as expected locally). 

### Special notes for your reviewer:
