### PR TITLE
Use stgregistry for rancher v2.7-head and 2.8-head

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ install-cert-manager: ## Install cert-manager via Helm on the k8s cluster
 install-rancher: ## Install Rancher via Helm on the k8s cluster
 	helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 	helm repo update
-	if [[ "${RANCHER_VERSION}" == "2.8-head" || "${RANCHER_VERSION}" == "2.7-head" ]]; then \
-		EXTRA_OPTIONS="--set rancherImage=stgregistry.suse.com/rancher/rancher \
-		--set 'extraEnv[0].name=CATTLE_AGENT_IMAGE' \
-		--set 'extraEnv[0].value=stgregistry.suse.com/rancher/rancher-agent:v${RANCHER_VERSION}'"; \
-	else \
-		EXTRA_OPTIONS=""; \
-	fi
+ifeq (${RANCHER_VERSION}, $(filter ${RANCHER_VERSION}, 2.7-head 2.8-head)
+	EXTRA_OPTIONS="--set rancherImage=stgregistry.suse.com/rancher/rancher \
+		--set 'extraEnv[1].name=CATTLE_AGENT_IMAGE' \
+		--set 'extraEnv[1].value=stgregistry.suse.com/rancher/rancher-agent:v${RANCHER_VERSION}'"
+else
+	EXTRA_OPTIONS=""
+endif
 	helm install rancher --devel rancher-latest/rancher \
 		--namespace cattle-system \
 		--create-namespace \
@@ -51,13 +51,13 @@ install-rancher: ## Install Rancher via Helm on the k8s cluster
 install-rancher-hosted-nightly-chart: ## Install Rancher via Helm with hosted providers nightly chart
 	helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 	helm repo update
-	if [[ "${RANCHER_VERSION}" == "2.8-head" || "${RANCHER_VERSION}" == "2.7-head" ]]; then \
-		EXTRA_OPTIONS="--set rancherImage=stgregistry.suse.com/rancher/rancher \
+ifeq (${RANCHER_VERSION}, $(filter ${RANCHER_VERSION}, 2.7-head 2.8-head)
+	EXTRA_OPTIONS="--set rancherImage=stgregistry.suse.com/rancher/rancher \
 		--set 'extraEnv[1].name=CATTLE_AGENT_IMAGE' \
-		--set 'extraEnv[1].value=stgregistry.suse.com/rancher/rancher-agent:v${RANCHER_VERSION}'"; \
-	else \
-		EXTRA_OPTIONS=""; \
-	fi
+		--set 'extraEnv[1].value=stgregistry.suse.com/rancher/rancher-agent:v${RANCHER_VERSION}'"
+else
+	EXTRA_OPTIONS=""
+endif
 	helm install rancher --devel rancher-latest/rancher \
 		--namespace cattle-system \
 		--version ${RANCHER_VERSION} \


### PR DESCRIPTION
Fixes https://github.com/rancher/hosted-providers-e2e/issues/149

Low priority as our actions are using `2.9-head`

* Actions are using `2.9-head` by default so it should not affect anything but in case we need to test against `2.7-head` or `2.8-head` by setting RANCHER_VERSION it will use correct image location on stgregistry.
* replaced deprecated `installCRDs` in install-cert-manager target

Other scenarios like testing `2.8.7-rc1` are not covered by this PR.

Testrun on GKE with `2.8-head`: https://github.com/rancher/hosted-providers-e2e/actions/runs/10420872364




