### PR TITLE
EKS P1Import tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,11 @@ e2e-provisioning-tests: deps ## Run the 'P0Provisioning' test suite for a given 
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Provisioning" ./hosted/${PROVIDER}/p0/
 
 e2e-p1-import-tests: deps	## Run the 'P1Import' test suite for a given ${PROVIDER}
+ifeq (${PROVIDER}, eks)
+	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P1Import" ./hosted/${PROVIDER}/p1/
+else
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Import" ./hosted/${PROVIDER}/p1/
+endif
 
 e2e-p1-provisioning-tests: deps ## Run the 'P1Provisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Provisioning" ./hosted/${PROVIDER}/p1/

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -14,86 +14,6 @@ import (
 var _ = Describe("P1Import", func() {
 	var cluster *management.Cluster
 
-	Context("Importing/Editing a cluster with invalid config", func() {
-
-		var _ = BeforeEach(func() {
-			var err error
-			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
-			Expect(err).To(BeNil())
-			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
-
-			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
-			Expect(err).To(BeNil())
-			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
-			Expect(err).To(BeNil())
-			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
-		})
-
-		AfterEach(func() {
-			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
-				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
-				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
-				Expect(err).To(BeNil())
-			} else {
-				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
-			}
-		})
-
-		It("Delete & re-import cluster", func() {
-			testCaseID = 106 // also covers 101
-
-			var err error
-			err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
-
-			Eventually(func() string {
-				cluster, _ = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				return cluster.ID
-			}, "30s", "3s").Should(BeEmpty())
-
-			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
-			Expect(err).To(BeNil())
-			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
-
-			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(ContainSubstring("cluster already exists for EKS cluster")))
-		})
-
-		It("Add node groups to the control-plane only cluster", func() {
-			testCaseID = 95
-
-			var err error
-			err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
-			err = helper.ModifyEKSNodegroupOnAWS(region, clusterName, "ranchernodes", "delete")
-			Expect(err).To(BeNil())
-
-			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
-			Expect(err).To(BeNil())
-			Eventually(func() bool {
-				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				return cluster.State == "waiting"
-			}, "5m", "15s").Should(BeTrue())
-
-			By("adding a NodeGroup", func() {
-				cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, true)
-				Expect(err).To(BeNil())
-				deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
-			})
-		})
-
-		It("Fail to update both Public/Private access as false", func() {
-			testCaseID = 103 // also covers 102
-			invalidEndpointCheck(cluster, ctx.RancherAdminClient)
-			invalidAccessValuesCheck(cluster, ctx.RancherAdminClient)
-		})
-	})
-
 	When("a cluster is imported for upgrade", func() {
 
 		BeforeEach(func() {
@@ -147,7 +67,7 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
 
-			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "2", helpers.GetCommonMetadataLabels())
+			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
 			Expect(err).To(BeNil())
 			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
 			Expect(err).To(BeNil())
@@ -164,6 +84,24 @@ var _ = Describe("P1Import", func() {
 			} else {
 				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 			}
+		})
+
+		It("Delete & re-import cluster", func() {
+			testCaseID = 106
+
+			var err error
+			err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			Eventually(func() string {
+				cluster, _ = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				return cluster.ID
+			}, "30s", "3s").Should(BeEmpty())
+
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
 		})
 
 		It("Update cluster logging types", func() {
@@ -202,6 +140,47 @@ var _ = Describe("P1Import", func() {
 			By("Adding Nodegroup tags & labels", func() {
 				cluster, err = helper.UpdateNodegroupMetadata(cluster, ctx.RancherAdminClient, tags, labels, true)
 				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("Importing/Editing a cluster with invalid config", func() {
+			It("Reimport a cluster to Rancher should fail", func() {
+				testCaseID = 101
+
+				var err error
+				cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("cluster already exists for EKS cluster")))
+			})
+
+			It("Add node groups to the control-plane only cluster", func() {
+				testCaseID = 95
+
+				var err error
+				err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.ModifyEKSNodegroupOnAWS(region, clusterName, "ranchernodes", "delete")
+				Expect(err).To(BeNil())
+
+				cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+				Expect(err).To(BeNil())
+				Eventually(func() bool {
+					cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+					Expect(err).To(BeNil())
+					return cluster.State == "waiting"
+				}, "5m", "15s").Should(BeTrue())
+
+				By("adding a NodeGroup", func() {
+					cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, true)
+					Expect(err).To(BeNil())
+					deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
+				})
+			})
+
+			It("Fail to update both Public/Private access as false and invalid values of the access", func() {
+				testCaseID = 103 // also covers 102
+				invalidEndpointCheck(cluster, ctx.RancherAdminClient)
+				invalidAccessValuesCheck(cluster, ctx.RancherAdminClient)
 			})
 		})
 	})

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -1,0 +1,208 @@
+package p1_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("P1Import", func() {
+	var cluster *management.Cluster
+
+	Context("Importing/Editing a cluster with invalid config", func() {
+
+		var _ = BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+			Expect(err).To(BeNil())
+			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+
+			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("Delete & re-import cluster", func() {
+			testCaseID = 106 // also covers 101
+
+			var err error
+			err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			Eventually(func() string {
+				cluster, _ = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				return cluster.ID
+			}, "30s", "3s").Should(BeEmpty())
+
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("cluster already exists for EKS cluster")))
+		})
+
+		It("Add node groups to the control-plane only cluster", func() {
+			testCaseID = 95
+
+			var err error
+			err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			err = helper.ModifyEKSNodegroupOnAWS(region, clusterName, "ranchernodes", "delete")
+			Expect(err).To(BeNil())
+
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			Eventually(func() bool {
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				return cluster.State == "waiting"
+			}, "5m", "15s").Should(BeTrue())
+
+			By("adding a NodeGroup", func() {
+				cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, true)
+				Expect(err).To(BeNil())
+				deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
+			})
+		})
+
+		It("Fail to update both Public/Private access as false", func() {
+			testCaseID = 103 // also covers 102
+			invalidEndpointCheck(cluster, ctx.RancherAdminClient)
+			invalidAccessValuesCheck(cluster, ctx.RancherAdminClient)
+		})
+	})
+
+	When("a cluster is imported for upgrade", func() {
+
+		BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
+			Expect(err).To(BeNil())
+			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+
+			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("Upgrade version of node group only", func() {
+			testCaseID = 88
+			upgradeNodeKubernetesVersionGTCPCheck(cluster, ctx.RancherAdminClient)
+		})
+
+		// eks-operator/issues/752
+		XIt("should successfully update a cluster while it is still in updating state", func() {
+			testCaseID = 104
+			updateClusterInUpdatingState(cluster, ctx.RancherAdminClient)
+		})
+
+		It("Update k8s version of cluster and add node groups", func() {
+			testCaseID = 90
+			upgradeCPAndAddNgCheck(cluster, ctx.RancherAdminClient)
+			deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
+		})
+	})
+
+	When("a cluster is imported", func() {
+
+		var _ = BeforeEach(func() {
+			var err error
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+			Expect(err).To(BeNil())
+			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+
+			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "2", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+
+		AfterEach(func() {
+			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+				Expect(err).To(BeNil())
+			} else {
+				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+			}
+		})
+
+		It("Update cluster logging types", func() {
+			testCaseID = 77
+
+			var err error
+			loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
+			By("Adding the LoggingTypes", func() {
+				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, loggingTypes, true)
+				Expect(err).To(BeNil())
+			})
+
+			By("Removing the LoggingTypes", func() {
+				cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, []string{loggingTypes[0]}, true)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		It("Update Tags and Labels", func() {
+			testCaseID = 81
+
+			var err error
+			tags := map[string]string{
+				"foo":        "bar",
+				"testCaseID": "98",
+			}
+			labels := map[string]string{
+				"testCaseID": "96",
+			}
+
+			By("Adding cluster tags", func() {
+				cluster, err = helper.UpdateClusterTags(cluster, ctx.RancherAdminClient, tags, true)
+				Expect(err).To(BeNil())
+			})
+
+			By("Adding Nodegroup tags & labels", func() {
+				cluster, err = helper.UpdateNodegroupMetadata(cluster, ctx.RancherAdminClient, tags, labels, true)
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -143,7 +143,7 @@ var _ = Describe("P1Import", func() {
 			})
 		})
 
-		Context("Importing/Editing a cluster with invalid config", func() {
+		Context("Reimporting/Editing a cluster with invalid config", func() {
 			It("Reimport a cluster to Rancher should fail", func() {
 				testCaseID = 101
 

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -93,7 +93,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(MatchError(ContainSubstring("subnets must be provided if security groups are provided")))
 		})
 
-		It("Fail to update both Public/Private access as false", func() {
+		It("Fail to update both Public/Private access as false and invalid values of the access", func() {
 			testCaseID = 147 // also covers 146
 
 			var err error

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -93,35 +93,16 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).To(MatchError(ContainSubstring("subnets must be provided if security groups are provided")))
 		})
 
-		It("Fail to update invalid values for Public Access Endpoints", func() {
-			testCaseID = 146
-
-			var err error
-			cidr := []string{namegen.AppendRandomString("invalid")}
-			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, region, nil)
-			Expect(err).To(BeNil())
-			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
-			cluster, _ = helper.UpdatePublicAccessSources(cluster, ctx.RancherAdminClient, cidr, false)
-
-			Eventually(func() bool {
-				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "InvalidParameterException: The following CIDRs are invalid in publicAccessCidrs")
-			}, "1m", "3s").Should(BeTrue())
-		})
-
 		It("Fail to update both Public/Private access as false", func() {
-			testCaseID = 147
+			testCaseID = 147 // also covers 146
 
 			var err error
 			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, region, nil)
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-
-			_, err = helper.UpdateAccess(cluster, ctx.RancherAdminClient, false, false, false)
-			Expect(err).To(MatchError(ContainSubstring("public access, private access, or both must be enabled")))
+			invalidEndpointCheck(cluster, ctx.RancherAdminClient)
+			invalidAccessValuesCheck(cluster, ctx.RancherAdminClient)
 		})
 	})
 
@@ -152,58 +133,16 @@ var _ = Describe("P1Provisioning", func() {
 
 		It("Upgrade version of node group only", func() {
 			testCaseID = 126
-
-			By("upgrading only the NodeGroups", func() {
-				var err error
-				upgradeToVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, false)
-				Expect(err).To(BeNil())
-				GinkgoLogr.Info("Upgrading Nodegroup's EKS version")
-				cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, false, false)
-				Expect(err).To(BeNil())
-			})
-
-			// wait until the error is visible on the cluster
-			Eventually(func() bool {
-				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "all nodegroup kubernetes versionsmust be equal to or one minor version lower than the cluster kubernetes version")
-			}, "1m", "3s").Should(BeTrue())
+			upgradeNodeKubernetesVersionGTCPCheck(cluster, ctx.RancherAdminClient)
 		})
 
 		It("Update k8s version of cluster and add node groups", func() {
 			testCaseID = 125
-
-			var err error
-			By("upgrading the ControlPlane", func() {
-				cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true)
-				Expect(err).To(BeNil())
-			})
-
-			By("adding a NodeGroup", func() {
-				cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, true, false)
-				Expect(err).To(BeNil())
-			})
-
-			By("deleting the NodeGroup", func() {
-				cluster, err = helper.DeleteNodeGroup(cluster, ctx.RancherAdminClient, true, false)
-				Expect(err).To(BeNil())
-			})
-
-			// wait until the update is visible on the cluster
-			Eventually(func() bool {
-				GinkgoLogr.Info("Waiting for the versin of new nodegroup to appear in EKSStatus.UpstreamSpec ...")
-				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
-					if *ng.Version != upgradeToVersion {
-						return false
-					}
-				}
-				return true
-			}, "5m", "15s").Should(BeTrue())
+			upgradeCPAndAddNgCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		It("should successfully update a cluster while it is still in updating state", func() {
+		// eks-operator/issues/752
+		XIt("should successfully update a cluster while it is still in updating state", func() {
 			testCaseID = 148
 			updateClusterInUpdatingState(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -231,9 +231,9 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client) 
 // upgradeNodeKubernetesVersionGTCP upgrades Nodegroup version greater than Controlplane's
 func upgradeNodeKubernetesVersionGTCPCheck(cluster *management.Cluster, client *rancher.Client) {
 	var err error
-	upgradeToVersion, err := helper.GetK8sVersion(client, false)
+	upgradeToVersion, err = helper.GetK8sVersion(client, false)
 	Expect(err).To(BeNil())
-	GinkgoLogr.Info("Upgrading only Nodegroup's EKS version")
+	GinkgoLogr.Info("Upgrading only Nodegroup's EKS version to: " + upgradeToVersion)
 	cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeToVersion, client, false, false)
 	Expect(err).To(BeNil())
 
@@ -245,7 +245,7 @@ func upgradeNodeKubernetesVersionGTCPCheck(cluster *management.Cluster, client *
 	}, "1m", "3s").Should(BeTrue())
 }
 
-// deleteAllEKSNodegroupOnAWS removes clusters nodegroups on EKS
+// deleteAllEKSNodegroupOnAWS removes cluster's nodegroups on EKS
 func deleteAllEKSNodegroupOnAWS(cluster *management.Cluster) {
 	for _, ng := range cluster.EKSConfig.NodeGroups {
 		err := helper.ModifyEKSNodegroupOnAWS(cluster.EKSConfig.Region, cluster.EKSConfig.DisplayName, *ng.NodegroupName, "delete")
@@ -278,7 +278,7 @@ func upgradeCPAndAddNgCheck(cluster *management.Cluster, client *rancher.Client)
 	var err error
 	originalLen := len(cluster.EKSConfig.NodeGroups)
 	newNodeGroupName := pointer.String(namegen.AppendRandomString("ng"))
-	upgradeToVersion, err := helper.GetK8sVersion(client, false)
+	upgradeToVersion, err = helper.GetK8sVersion(client, false)
 	Expect(err).To(BeNil())
 	GinkgoLogr.Info("Upgrading control plane to version:" + upgradeToVersion)
 

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -16,6 +16,7 @@ package p1_test
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,7 +28,10 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/eks"
+	"github.com/rancher/shepherd/pkg/config"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"k8s.io/utils/pointer"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
@@ -222,4 +226,98 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client) 
 		Expect(out).ShouldNot(HaveExactElements(loggingTypes))
 	})
 
+}
+
+// upgradeNodeKubernetesVersionGTCP upgrades Nodegroup version greater than Controlplane's
+func upgradeNodeKubernetesVersionGTCPCheck(cluster *management.Cluster, client *rancher.Client) {
+	var err error
+	upgradeToVersion, err := helper.GetK8sVersion(client, false)
+	Expect(err).To(BeNil())
+	GinkgoLogr.Info("Upgrading only Nodegroup's EKS version")
+	cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeToVersion, client, false, false)
+	Expect(err).To(BeNil())
+
+	// wait until the error is visible on the cluster
+	Eventually(func() bool {
+		cluster, err := client.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "all nodegroup kubernetes versionsmust be equal to or one minor version lower than the cluster kubernetes version")
+	}, "1m", "3s").Should(BeTrue())
+}
+
+// deleteAllEKSNodegroupOnAWS removes clusters nodegroups on EKS
+func deleteAllEKSNodegroupOnAWS(cluster *management.Cluster) {
+	for _, ng := range cluster.EKSConfig.NodeGroups {
+		err := helper.ModifyEKSNodegroupOnAWS(cluster.EKSConfig.Region, cluster.EKSConfig.DisplayName, *ng.NodegroupName, "delete")
+		Expect(err).To(BeNil())
+	}
+}
+
+// invalidEndpointCheck updates PublicAccess Sources
+func invalidEndpointCheck(cluster *management.Cluster, client *rancher.Client) {
+	var err error
+	cidr := []string{namegen.AppendRandomString("invalid")}
+	cluster, _ = helper.UpdatePublicAccessSources(cluster, client, cidr, false)
+
+	Eventually(func() bool {
+		cluster, err = client.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "InvalidParameterException: The following CIDRs are invalid in publicAccessCidrs")
+	}, "2m", "3s").Should(BeTrue())
+}
+
+// invalidAccessCheck disbales both PublicAccess & PrivateAccess
+func invalidAccessValuesCheck(cluster *management.Cluster, client *rancher.Client) {
+	var err error
+	_, err = helper.UpdateAccess(cluster, client, false, false, false)
+	Expect(err).To(MatchError(ContainSubstring("public access, private access, or both must be enabled")))
+}
+
+func upgradeCPAndAddNgCheck(cluster *management.Cluster, client *rancher.Client) {
+
+	var err error
+	originalLen := len(cluster.EKSConfig.NodeGroups)
+	newNodeGroupName := pointer.String(namegen.AppendRandomString("ng"))
+	upgradeToVersion, err := helper.GetK8sVersion(client, false)
+	Expect(err).To(BeNil())
+	GinkgoLogr.Info("Upgrading control plane to version:" + upgradeToVersion)
+
+	By("upgrading the ControlPlane", func() {
+		cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true)
+		Expect(err).To(BeNil())
+	})
+
+	var eksClusterConfig management.EKSClusterConfigSpec
+	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
+
+	updateFunc := func(cluster *management.Cluster) {
+		var updatedNodeGroupsList []management.NodeGroup
+		newNodeGroup := eksClusterConfig.NodeGroups[0]
+		newNodeGroup.NodegroupName = newNodeGroupName
+		updatedNodeGroupsList = append(updatedNodeGroupsList, newNodeGroup)
+		cluster.EKSConfig.NodeGroups = updatedNodeGroupsList
+	}
+
+	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
+	Expect(err).To(BeNil())
+	Expect(len(cluster.EKSConfig.NodeGroups)).To(BeEquivalentTo(originalLen))
+	for _, ng := range cluster.EKSConfig.NodeGroups {
+		Expect(ng.NodegroupName).To(Equal(newNodeGroupName))
+	}
+
+	err = clusters.WaitClusterToBeUpgraded(client, cluster.ID)
+	Expect(err).To(BeNil())
+
+	// wait until the update is visible on the cluster
+	Eventually(func() bool {
+		GinkgoLogr.Info("Waiting for the version of new nodegroup to appear in EKSStatus.UpstreamSpec ...")
+		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+			if ng.Version == nil || *ng.Version != upgradeToVersion {
+				return false
+			}
+		}
+		return true
+	}, "5m", "15s").Should(BeTrue())
 }

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -55,6 +55,7 @@ var _ = Describe("SyncImport", func() {
 		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
 			testCaseID = 112
 			syncRancherToAWSCheck(cluster, ctx.RancherAdminClient)
+			deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
 		})
 	})
 })

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -291,6 +291,8 @@ func GetCommonMetadataLabels() map[string]string {
 
 	if !clusterCleanup {
 		metadataLabels["janitor-ignore"] = "true"
+	} else {
+		metadataLabels["aws-janitor"] = "marked-for-deletion"
 	}
 	return metadataLabels
 }

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -292,7 +292,7 @@ func GetCommonMetadataLabels() map[string]string {
 	if !clusterCleanup {
 		metadataLabels["janitor-ignore"] = "true"
 	} else {
-		metadataLabels["aws-janitor"] = "marked-for-deletion"
+		metadataLabels["aws-janitor/marked-for-deletion"] = "true"
 	}
 	return metadataLabels
 }


### PR DESCRIPTION
### What does this PR do?
- Adds automation for EKS P1 import tests
- Refactors common P1 functions
- Add tag _aws-janitor=marked-for-deletion_ to cleanup EKS cluster on janitor next run, instead of next+1 run

### Checklist:
- [x] GitHub Actions:
P1Provisioning - :green_circle: https://github.com/rancher/hosted-providers-e2e/actions/runs/10441389153
P1Import- :green_circle: https://github.com/rancher/hosted-providers-e2e/actions/runs/10454461150

