### PR TITLE
Fix GKE and AKS failure due to aws-janitor tag

### DIFF
--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -291,7 +291,7 @@ func GetCommonMetadataLabels() map[string]string {
 
 	if !clusterCleanup {
 		metadataLabels["janitor-ignore"] = "true"
-	} else {
+	} else if Provider == "eks" {
 		metadataLabels["aws-janitor/marked-for-deletion"] = "true"
 	}
 	return metadataLabels


### PR DESCRIPTION
### What does this PR do?
This PR fixes GH action failure due to the newly added aws-janitor tag.
```
 ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Invalid field 'resource_labels.key': "aws-janitor/marked-for-deletion". It must only contain lowercase letters ([a-z]), numeric characters ([0-9]), underscores (_) and dashes (-), and must start with a letter. International characters are allowed.
```
```
\nRESPONSE 400: 400 Bad Request\nERROR CODE: InvalidTagNameCharacters\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n    \"code\": \"InvalidTagNameCharacters\",\n    \"message\": \"The tag names 'aws-janitor/marked-for-deletion' have reserved characters '<,>,%,&,\\\\,?,/' or control characters. These characters are only allowed for tags that start with the prefix 'hidden, link'.\"\n  }\n}\n--------------------------------------------------------------------------------\n , requeuing"
```
Failing Actions: [AKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/10501782733), [GKE](https://github.com/rancher/hosted-providers-e2e/actions/runs/10501751104)
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [AKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/10505497407), [GKE](https://github.com/rancher/hosted-providers-e2e/actions/runs/10505500069)

### Special notes for your reviewer:
