### PR TITLE
Fix EKS cleanup on a new nodegroup addition for imported clusters

### DIFF
--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -452,7 +452,7 @@ func ListEKSAvailableVersions(client *rancher.Client, clusterID string) (availab
 // <==============================EKS CLI==============================>
 
 // Create AWS EKS cluster using EKS CLI
-func CreateEKSClusterOnAWS(eks_region string, clusterName string, k8sVersion string, nodes string, tags map[string]string) error {
+func CreateEKSClusterOnAWS(region string, clusterName string, k8sVersion string, nodes string, tags map[string]string) error {
 	currentKubeconfig := os.Getenv("KUBECONFIG")
 	defer os.Setenv("KUBECONFIG", currentKubeconfig)
 
@@ -460,7 +460,7 @@ func CreateEKSClusterOnAWS(eks_region string, clusterName string, k8sVersion str
 
 	formattedTags := k8slabels.SelectorFromSet(tags).String()
 	fmt.Println("Creating EKS cluster ...")
-	args := []string{"create", "cluster", "--region=" + eks_region, "--name=" + clusterName, "--version=" + k8sVersion, "--nodegroup-name", "ranchernodes", "--nodes", nodes, "--managed", "--tags", formattedTags}
+	args := []string{"create", "cluster", "--region=" + region, "--name=" + clusterName, "--version=" + k8sVersion, "--nodegroup-name", "ranchernodes", "--nodes", nodes, "--managed", "--tags", formattedTags}
 	fmt.Printf("Running command: eksctl %v\n", args)
 	out, err := proc.RunW("eksctl", args...)
 	if err != nil {
@@ -472,10 +472,10 @@ func CreateEKSClusterOnAWS(eks_region string, clusterName string, k8sVersion str
 }
 
 // Upgrade EKS cluster using EKS CLI
-func UpgradeEKSClusterOnAWS(eks_region string, clusterName string, upgradeToVersion string) error {
+func UpgradeEKSClusterOnAWS(region string, clusterName string, upgradeToVersion string) error {
 
 	fmt.Println("Upgrading EKS cluster controlplane ...")
-	args := []string{"upgrade", "cluster", "--region=" + eks_region, "--name=" + clusterName, "--version=" + upgradeToVersion, "--approve"}
+	args := []string{"upgrade", "cluster", "--region=" + region, "--name=" + clusterName, "--version=" + upgradeToVersion, "--approve"}
 	fmt.Printf("Running command: eksctl %v\n", args)
 	out, err := proc.RunW("eksctl", args...)
 	if err != nil {
@@ -487,9 +487,9 @@ func UpgradeEKSClusterOnAWS(eks_region string, clusterName string, upgradeToVers
 }
 
 // Upgrade EKS cluster nodegroup using EKS CLI
-func UpgradeEKSNodegroupOnAWS(eks_region string, clusterName string, ngName string, upgradeToVersion string) error {
+func UpgradeEKSNodegroupOnAWS(region string, clusterName string, ngName string, upgradeToVersion string) error {
 	fmt.Println("Upgrading EKS cluster nodegroup ...")
-	args := []string{"upgrade", "nodegroup", "--region=" + eks_region, "--name=" + ngName, "--cluster=" + clusterName, "--kubernetes-version=" + upgradeToVersion}
+	args := []string{"upgrade", "nodegroup", "--region=" + region, "--name=" + ngName, "--cluster=" + clusterName, "--kubernetes-version=" + upgradeToVersion}
 	fmt.Printf("Running command: eksctl %v\n", args)
 	out, err := proc.RunW("eksctl", args...)
 	if err != nil {
@@ -517,8 +517,8 @@ func GetFromEKS(region string, clusterName string, cmd string, query string) (ou
 }
 
 // Creates/Deletes EKS cluster nodegroup using EKS CLI
-func ModifyEKSNodegroupOnAWS(eks_region string, clusterName string, ngName string, operation string) error {
-	args := []string{operation, "nodegroup", "--region=" + eks_region, "--name=" + ngName, "--cluster=" + clusterName}
+func ModifyEKSNodegroupOnAWS(region string, clusterName string, ngName string, operation string) error {
+	args := []string{operation, "nodegroup", "--region=" + region, "--name=" + ngName, "--cluster=" + clusterName}
 	if operation == "delete" {
 		args = append(args, "--disable-eviction")
 	}
@@ -531,7 +531,7 @@ func ModifyEKSNodegroupOnAWS(eks_region string, clusterName string, ngName strin
 }
 
 // Complete cleanup steps for Amazon EKS
-func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
+func DeleteEKSClusterOnAWS(region string, clusterName string) error {
 	currentKubeconfig := os.Getenv("KUBECONFIG")
 	downstreamKubeconfig := os.Getenv(helpers.DownstreamKubeconfig(clusterName))
 	defer func() {
@@ -541,10 +541,11 @@ func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
 	_ = os.Setenv("KUBECONFIG", downstreamKubeconfig)
 
 	fmt.Println("Deleting all the nodegroups ...")
-	ngNames, err := GetFromEKS(eks_region, clusterName, "nodegroup", ".[].Name")
+	ngNames, err := GetFromEKS(region, clusterName, "nodegroup", ".[].Name")
 	if err != nil {
 		return errors.Wrap(err, "Failed to list nodegroup for deletion")
 	}
+
 	if ngNames != "" {
 		for _, ngName := range strings.Split(ngNames, "\n") {
 			args := []string{"delete", "nodegroup", "--region", region, "--name", ngName, "--cluster", clusterName, "--disable-eviction", "--wait"}
@@ -558,8 +559,8 @@ func DeleteEKSClusterOnAWS(eks_region string, clusterName string) error {
 	}
 
 	fmt.Println("Deleting EKS cluster ...")
-	// TODO: Fix and wait for cluster deletion
-	args := []string{"delete", "cluster", "--region=" + eks_region, "--name=" + clusterName}
+
+	args := []string{"delete", "cluster", "--region=" + region, "--name=" + clusterName}
 	fmt.Printf("Running command: eksctl %v\n", args)
 	out, err := proc.RunW("eksctl", args...)
 	if err != nil {

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -55,7 +55,6 @@ var _ = Describe("P1Import", func() {
 		It("Update k8s version of cluster and add node groups", func() {
 			testCaseID = 90
 			upgradeCPAndAddNgCheck(cluster, ctx.RancherAdminClient)
-			deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
 		})
 	})
 
@@ -159,7 +158,7 @@ var _ = Describe("P1Import", func() {
 				var err error
 				err = helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
-				err = helper.ModifyEKSNodegroupOnAWS(region, clusterName, "ranchernodes", "delete")
+				err = helper.ModifyEKSNodegroupOnAWS(region, clusterName, "ranchernodes", "delete", "--wait")
 				Expect(err).To(BeNil())
 
 				cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
@@ -173,7 +172,6 @@ var _ = Describe("P1Import", func() {
 				By("adding a NodeGroup", func() {
 					cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, true)
 					Expect(err).To(BeNil())
-					deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
 				})
 			})
 

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -146,8 +146,8 @@ var _ = Describe("P1Import", func() {
 			It("Reimport a cluster to Rancher should fail", func() {
 				testCaseID = 101
 
-				var err error
-				cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
+				// We do not assign the cluster returned by import function to `cluster` since it will be nil and the cluster won't be deleted in AfterEach
+				_, err := helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, region)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(ContainSubstring("cluster already exists for EKS cluster")))
 			})

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -245,14 +245,6 @@ func upgradeNodeKubernetesVersionGTCPCheck(cluster *management.Cluster, client *
 	}, "1m", "3s").Should(BeTrue())
 }
 
-// deleteAllEKSNodegroupOnAWS removes cluster's nodegroups on EKS
-func deleteAllEKSNodegroupOnAWS(cluster *management.Cluster) {
-	for _, ng := range cluster.EKSConfig.NodeGroups {
-		err := helper.ModifyEKSNodegroupOnAWS(cluster.EKSConfig.Region, cluster.EKSConfig.DisplayName, *ng.NodegroupName, "delete")
-		Expect(err).To(BeNil())
-	}
-}
-
 // invalidEndpointCheck updates PublicAccess Sources
 func invalidEndpointCheck(cluster *management.Cluster, client *rancher.Client) {
 	var err error

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -55,7 +55,6 @@ var _ = Describe("SyncImport", func() {
 		It("Sync from Rancher to AWS console after a sync from AWS console to Rancher", func() {
 			testCaseID = 112
 			syncRancherToAWSCheck(cluster, ctx.RancherAdminClient)
-			deleteAllEKSNodegroupOnAWS(cluster) // Clean-up for eksctl
 		})
 	})
 })


### PR DESCRIPTION
### What does this PR do?
1. Modify `DeleteEKSClusterOnAWS` to list all the nodegroups and delete them before deleting the cluster.
2. Rename `eks_region` to `region` to conform with the Go naming convention that says 'Names in Go should in general not contain underscores'.
3. Fix EKS cluster not cleaned up for "reimport an existing cluster".
    <details><summary>Details</summary>

      ```
      • [842.949 seconds]
      P1Import when a cluster is imported Reimporting/Editing a cluster with invalid config Reimport a cluster to Rancher should fail
      /home/gh-runner/actions-runner/_work/hosted-providers-e2e/hosted-providers-e2e/hosted/eks/p1/p1_import_test.go:146
      
        Captured StdOut/StdErr Output >>
        Creating EKS cluster ...
        Running command: eksctl [create cluster --region=*** --name=auto-eks-hp-ci-qvvaw --version=1.30 --nodegroup-name ranchernodes --nodes 1 --managed --tags aws-janitor/marked-for-deletion=true,owner=hosted-providers-qa-ci-gh-runner,testfilenumber=line146_p1_import_test]
        Created EKS cluster:  auto-eks-hp-ci-qvvaw
        time="2024-08-26T16:03:02Z" level=info msg="Cluster status is active!"
        Skipping downstream cluster deletion:  auto-eks-hp-ci-qvvaw
        << Captured StdOut/StdErr Output
      
        Timeline >>
        "level"=0 "msg"="Using kubernetes version 1.30 for cluster auto-eks-hp-ci-qvvaw"
        Qase ID 101 created for run ID 860 on project HP
        << Timeline
      ------------------------------
      S
      ```

</details> 

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #153

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [p0 import] ~https://github.com/rancher/hosted-providers-e2e/actions/runs/10558562916/job/29248333175,~ [ :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10562272067

### Special notes for your reviewer:
