### PR TITLE
Fix GetK8sVersion for all the hosted providers

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -467,7 +467,7 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 	}
 
 	fmt.Println("Creating AKS cluster ...")
-	args := []string{"aks", "create", "--resource-group", clusterName, "--generate-ssh-keys", "--kubernetes-version", k8sVersion, "--enable-managed-identity", "--name", clusterName, "--subscription", subscriptionID, "--node-count", nodes, "--tags", formattedTags}
+	args := []string{"aks", "create", "--resource-group", clusterName, "--generate-ssh-keys", "--kubernetes-version", k8sVersion, "--enable-managed-identity", "--name", clusterName, "--subscription", subscriptionID, "--node-count", nodes, "--tags", formattedTags, "--location", location}
 	fmt.Printf("Running command: az %v\n", args)
 	out, err = proc.RunW("az", args...)
 	if err != nil {

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -1,10 +1,7 @@
 package helper
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -154,16 +151,17 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 	return cluster, nil
 }
 
-// ListSingleVariantAKSAvailableVersions returns a list of single variants of minor versions
+// ListSingleVariantAKSAllVersions returns a list of single variants of minor versions in descending order
 // For e.g 1.27.5, 1.26.6, 1.25.8
-func ListSingleVariantAKSAvailableVersions(client *rancher.Client, cloudCredentialID, region string) (availableVersions []string, err error) {
+func ListSingleVariantAKSAllVersions(client *rancher.Client, cloudCredentialID, region string) (availableVersions []string, err error) {
 	availableVersions, err = kubernetesversions.ListAKSAllVersions(client, cloudCredentialID, region)
 	if err != nil {
 		return nil, err
 	}
 	var singleVersionList []string
 	var oldMinor uint64
-	for _, version := range availableVersions {
+	for i := len(availableVersions) - 1; i >= 0; i-- {
+		version := availableVersions[i]
 		semVersion := semver.MustParse(version)
 		if currentMinor := semVersion.Minor(); oldMinor != currentMinor {
 			singleVersionList = append(singleVersionList, version)
@@ -175,7 +173,7 @@ func ListSingleVariantAKSAvailableVersions(client *rancher.Client, cloudCredenti
 
 // GetK8sVersionVariantAKS returns a variant of a given minor K8s version
 func GetK8sVersionVariantAKS(minorVersion string, client *rancher.Client, cloudCredentialID, region string) (string, error) {
-	versions, err := ListSingleVariantAKSAvailableVersions(client, cloudCredentialID, region)
+	versions, err := ListSingleVariantAKSAllVersions(client, cloudCredentialID, region)
 	if err != nil {
 		return "", err
 	}
@@ -331,7 +329,7 @@ func ScaleNodePool(cluster *management.Cluster, client *rancher.Client, nodeCoun
 	return cluster, nil
 }
 
-// ListAKSAvailableVersions is a function to list and return only available AKS versions for a specific cluster.
+// ListAKSAvailableVersions lists all the available and UI supported AKS versions for cluster upgrade; in ascending order: 1.28.0, 1.28.3, etc.
 func ListAKSAvailableVersions(client *rancher.Client, clusterID string) ([]string, error) {
 	// kubernetesversions.ListAKSAvailableVersions expects cluster.Version.GitVersion to be available, which it is not sometimes, so we fetch the cluster again to ensure it has all the available data
 	cluster, err := client.Management.Cluster.ByID(clusterID)
@@ -542,65 +540,22 @@ func DeleteAKSClusteronAzure(clusterName string) error {
 
 //====================================================================Azure CLI (end)=================================
 
-// defaultAKS returns the default AKS version used by Rancher; if forUpgrade is true, it returns the second-highest minor k8s version
-func defaultAKS(client *rancher.Client, cloudCredentialID, region string, forUpgrade bool) (defaultAKS string, err error) {
-	url := fmt.Sprintf("%s://%s/meta/aksVersions", "https", client.RancherConfig.Host)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
-
-	q := req.URL.Query()
-	q.Add("cloudCredentialId", cloudCredentialID)
-	q.Add("region", region)
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
-	if err != nil {
-		return
-	}
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return
-	}
-
-	var versions []string
-	if err = json.Unmarshal(bodyBytes, &versions); err != nil {
-		return
-	}
-
-	maxValue := helpers.HighestK8sMinorVersionSupportedByUI(client)
-
-	// Iterate in the reverse order to get the highest version
-	// We obtain the value similar to UI; ref: https://github.com/rancher/ui/blob/master/lib/shared/addon/components/cluster-driver/driver-azureaks/component.js#L140
-	// For upgrade tests, it returns a variant of the second-highest minor version
-	for i := len(versions) - 1; i >= 0; i-- {
-		version := versions[i]
-		// If UI maxValue not yet supported by operator
-		if !strings.Contains(version, maxValue) {
-			maxValue = versions[len(versions)-1]
-		}
-
-		if forUpgrade {
-			if result := helpers.VersionCompare(version, maxValue); result == -1 {
-				return version, nil
-			}
-		} else {
-			if strings.Contains(version, maxValue) {
-				return version, nil
-			}
-		}
-	}
-
-	return
-}
-
 // GetK8sVersion returns the k8s version to be used by the test;
 // this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the default UI value returned by defaultAKS.
 func GetK8sVersion(client *rancher.Client, cloudCredentialID, region string, forUpgrade bool) (string, error) {
 	if k8sMinorVersion := helpers.DownstreamK8sMinorVersion; k8sMinorVersion != "" {
 		return GetK8sVersionVariantAKS(k8sMinorVersion, client, cloudCredentialID, region)
 	}
-	return defaultAKS(client, cloudCredentialID, region, forUpgrade)
+	allVariants, err := ListSingleVariantAKSAllVersions(client, cloudCredentialID, region)
+	if err != nil {
+		return "", err
+	}
+
+	if forUpgrade {
+		if len(allVariants) < 2 {
+			return "", errors.New(fmt.Sprintf("no versions available for upgrade; available versions: %s. Try changing the location.", strings.Join(allVariants, ", ")))
+		}
+		return allVariants[1], nil
+	}
+	return allVariants[0], nil
 }

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -541,7 +541,8 @@ func DeleteAKSClusteronAzure(clusterName string) error {
 //====================================================================Azure CLI (end)=================================
 
 // GetK8sVersion returns the k8s version to be used by the test;
-// this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the default UI value returned by defaultAKS.
+// this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the highest available version
+// or second-highest minor version in case of upgrade scenarios
 func GetK8sVersion(client *rancher.Client, cloudCredentialID, region string, forUpgrade bool) (string, error) {
 	if k8sMinorVersion := helpers.DownstreamK8sMinorVersion; k8sMinorVersion != "" {
 		return GetK8sVersionVariantAKS(k8sMinorVersion, client, cloudCredentialID, region)
@@ -551,11 +552,5 @@ func GetK8sVersion(client *rancher.Client, cloudCredentialID, region string, for
 		return "", err
 	}
 
-	if forUpgrade {
-		if len(allVariants) < 2 {
-			return "", errors.New(fmt.Sprintf("no versions available for upgrade; available versions: %s. Try changing the location.", strings.Join(allVariants, ", ")))
-		}
-		return allVariants[1], nil
-	}
-	return allVariants[0], nil
+	return helpers.DefaultK8sVersion(allVariants, forUpgrade)
 }

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -245,11 +245,12 @@ var _ = Describe("P1Provisioning", func() {
 	It("should not be able to select NP K8s version; CP K8s version should take precedence", func() {
 		testCaseID = 182
 
-		k8sVersions, err := helper.ListSingleVariantAKSAvailableVersions(ctx.RancherAdminClient, ctx.CloudCred.ID, location)
+		k8sVersions, err := helper.ListSingleVariantAKSAllVersions(ctx.RancherAdminClient, ctx.CloudCred.ID, location)
 		Expect(err).To(BeNil())
 		Expect(len(k8sVersions)).To(BeNumerically(">=", 2))
-		cpK8sVersion := k8sVersions[0]
-		npK8sVersion := k8sVersions[1]
+		// CP > NP
+		cpK8sVersion := k8sVersions[1]
+		npK8sVersion := k8sVersions[0]
 
 		GinkgoLogr.Info(fmt.Sprintf("Using NP K8s version: %s and CP K8s version: %s", npK8sVersion, cpK8sVersion))
 

--- a/hosted/aks/support_matrix/support_matrix_suite_test.go
+++ b/hosted/aks/support_matrix/support_matrix_suite_test.go
@@ -38,7 +38,7 @@ func TestSupportMatrix(t *testing.T) {
 	ctx = helpers.CommonBeforeSuite()
 	helpers.CreateStdUserClient(&ctx)
 	var err error
-	availableVersionList, err = helper.ListSingleVariantAKSAvailableVersions(ctx.StdUserClient, ctx.CloudCred.ID, location)
+	availableVersionList, err = helper.ListSingleVariantAKSAllVersions(ctx.StdUserClient, ctx.CloudCred.ID, location)
 	Expect(err).To(BeNil())
 	RunSpecs(t, "SupportMatrix Suite")
 }

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -438,15 +438,24 @@ func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFu
 	return client.Management.Cluster.Update(cluster, &upgradedCluster)
 }
 
-// ListEKSAvailableVersions is a function to list and return only available EKS versions for a specific cluster.
-func ListEKSAvailableVersions(client *rancher.Client, clusterID string) (availableVersions []string, err error) {
-
-	allAvailableVersions, err := kubernetesversions.ListEKSAllVersions(client)
+// ListEKSAvailableVersions lists all the available and UI supported EKS versions for cluster upgrade.
+func ListEKSAvailableVersions(client *rancher.Client, cluster *management.Cluster) (availableVersions []string, err error) {
+	allAvailableVersions, err := kubernetesversions.ListEKSAvailableVersions(client, cluster)
 	if err != nil {
 		return nil, err
 	}
 
 	return helpers.FilterUIUnsupportedVersions(allAvailableVersions, client), nil
+}
+
+// ListEKSAllVersions lists all the versions supported by UI
+func ListEKSAllVersions(client *rancher.Client) (allVersions []string, err error) {
+	allVersions, err = kubernetesversions.ListEKSAllVersions(client)
+	if err != nil {
+		return
+	}
+
+	return helpers.FilterUIUnsupportedVersions(allVersions, client), nil
 }
 
 // <==============================EKS CLI==============================>
@@ -572,44 +581,22 @@ func DeleteEKSClusterOnAWS(region string, clusterName string) error {
 
 // <==============================EKS CLI(end)==============================>
 
-// defaultEKS returns a version less than the highest version or K8S_UPGRADE_MINOR_VERSION if it is set.
-// Note: It does not return the default version used by UI which is the highest supported version.
-func defaultEKS(client *rancher.Client, forUpgrade bool) (defaultEKS string, err error) {
-
-	var allVersions []string
-	allVersions, err = kubernetesversions.ListEKSAllVersions(client)
-	if err != nil {
-		return
-	}
-
-	versions := helpers.FilterUIUnsupportedVersions(allVersions, client)
-	maxValue := helpers.HighestK8sMinorVersionSupportedByUI(client)
-
-	for i := 0; i < len(versions); i++ {
-		version := versions[i]
-		// If UI maxValue not yet supported by operator
-		if !strings.Contains(version, maxValue) {
-			maxValue = versions[0]
-		}
-
-		if forUpgrade {
-			if result := helpers.VersionCompare(version, maxValue); result == -1 {
-				return version, nil
-			}
-		} else {
-			if strings.Contains(version, maxValue) {
-				return version, nil
-			}
-		}
-	}
-	return
-}
-
 // GetK8sVersion returns the k8s version to be used by the test;
 // this value can either be envvar DOWNSTREAM_K8S_MINOR_VERSION or the default UI value returned by DefaultEKS.
 func GetK8sVersion(client *rancher.Client, forUpgrade bool) (string, error) {
 	if k8sVersion := helpers.DownstreamK8sMinorVersion; k8sVersion != "" {
 		return k8sVersion, nil
 	}
-	return defaultEKS(client, forUpgrade)
+	allVariants, err := ListEKSAllVersions(client)
+	if err != nil {
+		return "", err
+	}
+
+	if forUpgrade {
+		if len(allVariants) < 2 {
+			return "", errors.New(fmt.Sprintf("no versions available for upgrade; available versions: %s", strings.Join(allVariants, ", ")))
+		}
+		return allVariants[1], nil
+	}
+	return allVariants[0], nil
 }

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -582,7 +582,8 @@ func DeleteEKSClusterOnAWS(region string, clusterName string) error {
 // <==============================EKS CLI(end)==============================>
 
 // GetK8sVersion returns the k8s version to be used by the test;
-// this value can either be envvar DOWNSTREAM_K8S_MINOR_VERSION or the default UI value returned by DefaultEKS.
+// this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the highest available version
+// or second-highest minor version in case of upgrade scenarios
 func GetK8sVersion(client *rancher.Client, forUpgrade bool) (string, error) {
 	if k8sVersion := helpers.DownstreamK8sMinorVersion; k8sVersion != "" {
 		return k8sVersion, nil
@@ -592,11 +593,5 @@ func GetK8sVersion(client *rancher.Client, forUpgrade bool) (string, error) {
 		return "", err
 	}
 
-	if forUpgrade {
-		if len(allVariants) < 2 {
-			return "", errors.New(fmt.Sprintf("no versions available for upgrade; available versions: %s", strings.Join(allVariants, ", ")))
-		}
-		return allVariants[1], nil
-	}
-	return allVariants[0], nil
+	return helpers.DefaultK8sVersion(allVariants, forUpgrade)
 }

--- a/hosted/eks/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
+++ b/hosted/eks/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
@@ -162,7 +162,7 @@ func commonchecks(ctx *helpers.Context, cluster *management.Cluster, clusterName
 
 	var latestVersion *string
 	By(fmt.Sprintf("fetching a list of available k8s versions and ensure the v%s is present in the list and upgrading the cluster to it", k8sUpgradedVersion), func() {
-		versions, err := helper.ListEKSAvailableVersions(ctx.RancherAdminClient, cluster.ID)
+		versions, err := helper.ListEKSAvailableVersions(ctx.RancherAdminClient, cluster)
 		Expect(err).To(BeNil())
 		Expect(versions).ToNot(BeEmpty())
 

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -1,10 +1,7 @@
 package helper
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -569,46 +566,6 @@ func DeleteGKEClusterOnGCloud(zone, project, clusterName string) error {
 
 // <==============================================================================GCLOUD CLI (end)==============================>
 
-// defaultGKE returns the default GKE version used by Rancher
-func defaultGKE(client *rancher.Client, projectID, cloudCredentialID, zone, region string) (defaultGKE string, err error) {
-	url := fmt.Sprintf("%s://%s/meta/gkeVersions", "https", client.RancherConfig.Host)
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Add("Authorization", "Bearer "+client.RancherConfig.AdminToken)
-
-	q := req.URL.Query()
-	q.Add("cloudCredentialId", cloudCredentialID)
-
-	if zone != "" {
-		q.Add("zone", zone)
-	} else if region != "" {
-		q.Add("region", region)
-	}
-
-	q.Add("projectId", projectID)
-	req.URL.RawQuery = q.Encode()
-
-	resp, err := client.Management.APIBaseClient.Ops.Client.Do(req)
-	if err != nil {
-		return
-	}
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return
-	}
-
-	var mapResponse map[string]interface{}
-	if err = json.Unmarshal(bodyBytes, &mapResponse); err != nil {
-		return
-	}
-
-	defaultGKE = mapResponse["defaultClusterVersion"].(string)
-
-	return
-}
-
 // GetK8sVersion returns the k8s version to be used by the test;
 // this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the default UI value returned by DefaultGKE
 // or the second-highest minor k8s version if forUpgrade is true; which it is in case of k8s upgrade tests.
@@ -617,22 +574,16 @@ func GetK8sVersion(client *rancher.Client, projectID, cloudCredentialID, zone, r
 		return GetK8sVersionVariantGKE(k8sMinorVersion, client, projectID, cloudCredentialID, zone, region)
 	}
 
-	if !forUpgrade {
-		return defaultGKE(client, projectID, cloudCredentialID, zone, region)
-	}
-
 	allVariants, err := ListSingleVariantGKEAvailableVersions(client, projectID, cloudCredentialID, zone, region)
 	if err != nil {
 		return "", err
 	}
 
-	// defaultValue has highest supported minorVersion
-	defaultValue, _ := defaultGKE(client, projectID, cloudCredentialID, zone, region)
-	for _, v := range allVariants {
-		if comparator := helpers.VersionCompare(v, defaultValue); comparator == -1 {
-			return v, nil
+	if forUpgrade {
+		if len(allVariants) < 2 {
+			return "", errors.New(fmt.Sprintf("no versions available for upgrade; available versions: %s", strings.Join(allVariants, ", ")))
 		}
+		return allVariants[1], nil
 	}
-
-	return "", nil
+	return allVariants[0], nil
 }

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -567,8 +567,8 @@ func DeleteGKEClusterOnGCloud(zone, project, clusterName string) error {
 // <==============================================================================GCLOUD CLI (end)==============================>
 
 // GetK8sVersion returns the k8s version to be used by the test;
-// this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the default UI value returned by DefaultGKE
-// or the second-highest minor k8s version if forUpgrade is true; which it is in case of k8s upgrade tests.
+// this value can either be a variant of envvar DOWNSTREAM_K8S_MINOR_VERSION or the highest available version
+// or second-highest minor version in case of upgrade scenarios
 func GetK8sVersion(client *rancher.Client, projectID, cloudCredentialID, zone, region string, forUpgrade bool) (string, error) {
 	if k8sMinorVersion := helpers.DownstreamK8sMinorVersion; k8sMinorVersion != "" {
 		return GetK8sVersionVariantGKE(k8sMinorVersion, client, projectID, cloudCredentialID, zone, region)
@@ -579,11 +579,5 @@ func GetK8sVersion(client *rancher.Client, projectID, cloudCredentialID, zone, r
 		return "", err
 	}
 
-	if forUpgrade {
-		if len(allVariants) < 2 {
-			return "", errors.New(fmt.Sprintf("no versions available for upgrade; available versions: %s", strings.Join(allVariants, ", ")))
-		}
-		return allVariants[1], nil
-	}
-	return allVariants[0], nil
+	return helpers.DefaultK8sVersion(allVariants, forUpgrade)
 }

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -341,3 +341,16 @@ func CheckMapKeys(map1, map2 map[string]string) (exists bool) {
 	}
 	return
 }
+
+// DefaultK8sVersion receives a list of version sorted in descending order (1.29, 1.28, 1.27, etc.);
+// it returns the k8s version to be used by the test depending on forUpgrade param
+func DefaultK8sVersion(descVersions []string, forUpgrade bool) (string, error) {
+	if !forUpgrade {
+		return descVersions[0], nil
+	}
+
+	if len(descVersions) < 2 {
+		return "", fmt.Errorf("no versions available for upgrade; available versions: %s; try changing the location/region", strings.Join(descVersions, ", "))
+	}
+	return descVersions[1], nil
+}


### PR DESCRIPTION
### What does this PR do?
1. Simplify `GetK8sVersion` for all the hosted providers to call list single variants of each minor version and return a version based on `forUpgrade` parameter.
2. Rename AKS `ListSingleVariantAKSAvailableVersions` to `ListSingleVariantAKSAllVersions`, also modify it to return the versions in descending order 1.28.3, 1.28.0, etc, and modify the tests using this function with required changes.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #147

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - [GKE P0/Support Matrix :green_circle:  (import k8s upgrade is re-run)](https://github.com/rancher/hosted-providers-e2e/actions/runs/10593165181/job/29354275476), [GKE P0 Import re-run :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/10597550011) [EKS P0/Support Matrix :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/10593162397/job/29354269851), [AKS P0/Support Matrix :green_circle: (Failure with 1.27.16 is also reproducible manually and looks like a temporary failure)](https://github.com/rancher/hosted-providers-e2e/actions/runs/10593159634/job/29354269902)
1. GKE P1 on 2.9-head uses 1.30.3-gke.1969000 - https://github.com/rancher/hosted-providers-e2e/actions/runs/10575523066/job/29299429366
2. GKE P0 on 2.8-head uses 1.27.16-gke.1234000 (upgrade=true), and 1.28.13-gke.1006000 (upgrade=false) - https://github.com/rancher/hosted-providers-e2e/actions/runs/10575520397/job/29299407442
3. GKE Sync on 2.8-head - https://github.com/rancher/hosted-providers-e2e/actions/runs/10580174818
4. AKS P1 on 2.9-head uses 1.30.3 - https://github.com/rancher/hosted-providers-e2e/actions/runs/10575516457/job/29299399455
5. AKS P0 on 2.8-head uses 1.27.16 (upgrade=true), and 1.28.12 (upgrade=false) - https://github.com/rancher/hosted-providers-e2e/actions/runs/10575511076/job/29299401402
6. EKS P0 on 2.8-head uses 1.27 (ugprade=true), and 1.28 (upgrade=false) - https://github.com/rancher/hosted-providers-e2e/actions/runs/10575527300/job/29301589326
7. EKS P1 on 2.9-head - https://github.com/rancher/hosted-providers-e2e/actions/runs/10578087657
8. EKS Sync on 2.8-head - https://github.com/rancher/hosted-providers-e2e/actions/runs/10580193647

### Special notes for your reviewer:
