### PR TITLE
Automate Qase: 199, 200, 203, 237, 271

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -455,7 +455,7 @@ func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFu
 
 // ====================================================================Azure CLI (start)=================================
 // Create Azure AKS cluster using AZ CLI
-func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion string, nodes string, tags map[string]string) error {
+func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion string, nodes string, tags map[string]string, clusterCreateArgs ...string) error {
 	formattedTags := convertMapToAKSString(tags)
 	fmt.Println("Creating AKS resource group ...")
 	rgargs := []string{"group", "create", "--location", location, "--resource-group", clusterName, "--subscription", subscriptionID}
@@ -468,6 +468,7 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 
 	fmt.Println("Creating AKS cluster ...")
 	args := []string{"aks", "create", "--resource-group", clusterName, "--generate-ssh-keys", "--kubernetes-version", k8sVersion, "--enable-managed-identity", "--name", clusterName, "--subscription", subscriptionID, "--node-count", nodes, "--tags", formattedTags, "--location", location}
+	args = append(args, clusterCreateArgs...)
 	fmt.Printf("Running command: az %v\n", args)
 	out, err = proc.RunW("az", args...)
 	if err != nil {

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -66,7 +66,7 @@ var _ = Describe("P1Import", func() {
 
 	FIt("should be able to register a cluster with no rbac", func() {
 		testCaseID = 237
-		err := helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--no-rbac")
+		err := helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--disable-rbac")
 		Expect(err).To(BeNil())
 
 		cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -57,14 +57,14 @@ var _ = Describe("P1Import", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should be able to update cluster monitoring", func() {
+		It("should be able to update cluster monitoring", func() {
 			testCaseID = 271
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
 	})
 
-	FIt("should be able to register a cluster with no rbac", func() {
+	It("should be able to register a cluster with no rbac", func() {
 		testCaseID = 237
 		err := helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--disable-rbac")
 		Expect(err).To(BeNil())

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -56,6 +56,24 @@ var _ = Describe("P1Import", func() {
 			testCaseID = 270
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
+
+		It("should be able to update cluster monitoring", func() {
+			testCaseID = 271
+			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
+		})
+
+	})
+
+	It("should be able to register a cluster with no rbac", func() {
+		testCaseID = 237
+		err := helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--no-rbac")
+		Expect(err).To(BeNil())
+
+		cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
 	})
 
 	When("a cluster is created with multiple nodepools", func() {

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -57,14 +57,14 @@ var _ = Describe("P1Import", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		It("should be able to update cluster monitoring", func() {
+		FIt("should be able to update cluster monitoring", func() {
 			testCaseID = 271
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
 	})
 
-	It("should be able to register a cluster with no rbac", func() {
+	FIt("should be able to register a cluster with no rbac", func() {
 		testCaseID = 237
 		err := helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--no-rbac")
 		Expect(err).To(BeNil())

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -150,7 +150,7 @@ var _ = Describe("P1Provisioning", func() {
 			}, "1m", "2s").Should(BeTrue())
 		})
 
-		FIt("should fail to create cluster with Nodepool Max pods per node 9", func() {
+		It("should fail to create cluster with Nodepool Max pods per node 9", func() {
 			testCaseID = 203
 			updateFunc := func(aksConfig *aks.ClusterConfig) {
 				nodepools := *aksConfig.NodePools
@@ -190,7 +190,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should be able to update cluster monitoring", func() {
+		It("should be able to update cluster monitoring", func() {
 			testCaseID = 200
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -96,7 +96,8 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
-	FIt("should be able to create cluster with container monitoring enabled", func() {
+	XIt("should be able to create cluster with container monitoring enabled", func() {
+		// blocked by https://github.com/rancher/shepherd/issues/274
 		testCaseID = 199
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			aksConfig.Monitoring = pointer.Bool(true)
@@ -104,10 +105,12 @@ var _ = Describe("P1Provisioning", func() {
 		var err error
 		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
 		Expect(err).To(BeNil())
-		Expect(*cluster.AKSConfig.Monitoring).To(Equal(true))
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
+
 		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+
+		Expect(*cluster.AKSConfig.Monitoring).To(Equal(true))
 		Expect(*cluster.AKSStatus.UpstreamSpec.Monitoring).To(Equal(true))
 	})
 
@@ -162,7 +165,7 @@ var _ = Describe("P1Provisioning", func() {
 			Eventually(func() bool {
 				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).NotTo(HaveOccurred())
-				return cluster.Transitioning == "error" && cluster.TransitioningMessage == "The value must be between 10 and 250"
+				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "InsufficientMaxPods")
 			}, "1m", "2s").Should(BeTrue())
 
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -96,6 +96,21 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
+	It("should be able to create cluster with container monitoring enabled", func() {
+		testCaseID = 199
+		updateFunc := func(aksConfig *aks.ClusterConfig) {
+			aksConfig.Monitoring = pointer.Bool(true)
+		}
+		var err error
+		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+		Expect(err).To(BeNil())
+		Expect(*cluster.AKSConfig.Monitoring).To(Equal(true))
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+		Expect(*cluster.AKSStatus.UpstreamSpec.Monitoring).To(Equal(true))
+	})
+
 	When("a cluster with invalid config is created", func() {
 		It("should fail to create a cluster with 0 nodecount", func() {
 			testCaseID = 186
@@ -131,6 +146,26 @@ var _ = Describe("P1Provisioning", func() {
 				return cluster.Transitioning == "error" && cluster.TransitioningMessage == "at least one NodePool with mode System is required"
 			}, "1m", "2s").Should(BeTrue())
 		})
+
+		It("should fail to create cluster with Nodepool Max pods per node 9", func() {
+			testCaseID = 203
+			updateFunc := func(aksConfig *aks.ClusterConfig) {
+				nodepools := *aksConfig.NodePools
+				for i := range nodepools {
+					nodepools[i].MaxPods = pointer.Int64(9)
+				}
+				aksConfig.NodePools = &nodepools
+			}
+			var err error
+			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).NotTo(HaveOccurred())
+				return cluster.Transitioning == "error" && cluster.TransitioningMessage == "The value must be between 10 and 250"
+			}, "1m", "2s").Should(BeTrue())
+
+		})
 	})
 
 	When("a cluster is created", func() {
@@ -150,6 +185,11 @@ var _ = Describe("P1Provisioning", func() {
 		It("should be able to update tags", func() {
 			testCaseID = 177
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
+		})
+
+		It("should be able to update cluster monitoring", func() {
+			testCaseID = 200
+			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
 		It("recreating a cluster while it is being deleted should recreate the cluster", func() {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -96,7 +96,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
-	It("should be able to create cluster with container monitoring enabled", func() {
+	FIt("should be able to create cluster with container monitoring enabled", func() {
 		testCaseID = 199
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			aksConfig.Monitoring = pointer.Bool(true)
@@ -147,7 +147,7 @@ var _ = Describe("P1Provisioning", func() {
 			}, "1m", "2s").Should(BeTrue())
 		})
 
-		It("should fail to create cluster with Nodepool Max pods per node 9", func() {
+		FIt("should fail to create cluster with Nodepool Max pods per node 9", func() {
 			testCaseID = 203
 			updateFunc := func(aksConfig *aks.ClusterConfig) {
 				nodepools := *aksConfig.NodePools
@@ -187,7 +187,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		It("should be able to update cluster monitoring", func() {
+		FIt("should be able to update cluster monitoring", func() {
 			testCaseID = 200
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -12,6 +12,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/clusters"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"k8s.io/utils/pointer"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
@@ -216,5 +217,38 @@ func updateTagsCheck(cluster *management.Cluster, client *rancher.Client) {
 			}
 			return count
 		}, "7m", "5s").Should(Equal(0))
+	})
+}
+
+func updateMonitoringCheck(cluster *management.Cluster, client *rancher.Client) {
+	By("enabling the monitoring", func() {
+		updateFunc := func(cluster *management.Cluster) {
+			cluster.AKSConfig.Monitoring = pointer.Bool(true)
+		}
+		var err error
+		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
+		Expect(err).To(BeNil())
+		Expect(*cluster.AKSConfig.Monitoring).To(BeTrue())
+		Eventually(func() bool {
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
+		}, "5m", "5s").Should(BeTrue())
+	})
+
+	By("disabling the monitoring", func() {
+		updateFunc := func(cluster *management.Cluster) {
+			cluster.AKSConfig.Monitoring = pointer.Bool(false)
+		}
+		var err error
+		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
+		Expect(err).To(BeNil())
+
+		Expect(*cluster.AKSConfig.Monitoring).To(BeFalse())
+		Eventually(func() bool {
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
+		}, "5m", "5s").Should(BeFalse())
 	})
 }

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -233,7 +233,7 @@ func updateMonitoringCheck(cluster *management.Cluster, client *rancher.Client) 
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 			return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
-		}, "5m", "5s").Should(BeTrue())
+		}, "7m", "5s").Should(BeTrue())
 	})
 
 	// TODO: uncomment this once https://github.com/rancher/aks-operator/issues/584 is fixed.
@@ -250,7 +250,7 @@ func updateMonitoringCheck(cluster *management.Cluster, client *rancher.Client) 
 				cluster, err = client.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
 				return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
-			}, "5m", "5s").Should(BeFalse())
+			}, "7m", "5s").Should(BeFalse())
 		})
 	*/
 }

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -236,19 +236,21 @@ func updateMonitoringCheck(cluster *management.Cluster, client *rancher.Client) 
 		}, "5m", "5s").Should(BeTrue())
 	})
 
-	By("disabling the monitoring", func() {
-		updateFunc := func(cluster *management.Cluster) {
-			cluster.AKSConfig.Monitoring = pointer.Bool(false)
-		}
-		var err error
-		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
-		Expect(err).To(BeNil())
-
-		Expect(*cluster.AKSConfig.Monitoring).To(BeFalse())
-		Eventually(func() bool {
-			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+	// TODO: uncomment this once https://github.com/rancher/aks-operator/issues/584 is fixed.
+	/*	By("disabling the monitoring", func() {
+			updateFunc := func(cluster *management.Cluster) {
+				cluster.AKSConfig.Monitoring = pointer.Bool(false)
+			}
+			var err error
+			cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 			Expect(err).To(BeNil())
-			return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
-		}, "5m", "5s").Should(BeFalse())
-	})
+
+			Expect(*cluster.AKSConfig.Monitoring).To(BeFalse())
+			Eventually(func() bool {
+				cluster, err = client.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
+			}, "5m", "5s").Should(BeFalse())
+		})
+	*/
 }


### PR DESCRIPTION
### What does this PR do?
199: Create cluster - "Container monitoring" Enabled
200, 201, 271: Update the cluster - Enable monitoring, The user should be able to disable monitoring once enabled
203: Create cluster - Nodepool with Max pods per node 9
237: Register cluster with no RBAC

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [AKS P1 :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10609969399/job/29406608386

### Special notes for your reviewer:
