### PR TITLE
Enable AKS Monitoring Test

### DIFF
--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -236,21 +236,20 @@ func updateMonitoringCheck(cluster *management.Cluster, client *rancher.Client) 
 		}, "7m", "5s").Should(BeTrue())
 	})
 
-	// TODO: uncomment this once https://github.com/rancher/aks-operator/issues/584 is fixed.
-	/*	By("disabling the monitoring", func() {
-			updateFunc := func(cluster *management.Cluster) {
-				cluster.AKSConfig.Monitoring = pointer.Bool(false)
-			}
-			var err error
-			cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
-			Expect(err).To(BeNil())
+	By("disabling the monitoring", func() {
+		updateFunc := func(cluster *management.Cluster) {
+			cluster.AKSConfig.Monitoring = pointer.Bool(false)
+		}
+		var err error
+		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
+		Expect(err).To(BeNil())
 
-			Expect(*cluster.AKSConfig.Monitoring).To(BeFalse())
-			Eventually(func() bool {
-				cluster, err = client.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
-			}, "7m", "5s").Should(BeFalse())
-		})
-	*/
+		Expect(*cluster.AKSConfig.Monitoring).To(BeFalse())
+		Eventually(func() bool {
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return cluster.AKSStatus.UpstreamSpec.Monitoring != nil && *cluster.AKSStatus.UpstreamSpec.Monitoring
+		}, "7m", "5s").Should(BeFalse())
+	})
+
 }


### PR DESCRIPTION
### What does this PR do?
Re-enable disable monitoring test since aks-operator/issues/584 is fixed

### Checklist:
- [x] GitHub Actions:
Nightly chart: https://github.com/rancher/hosted-providers-e2e/actions/runs/10790181438
Regular chart: https://github.com/rancher/hosted-providers-e2e/actions/runs/10790188853
(failing test not related to the change, will check it locally)


