### PR TITLE
Automate AKS Qase: 290, 235, 260,289, 199, 207, 198, 202, 217, 204

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -64,10 +64,7 @@ func ImportAKSHostedCluster(client *rancher.Client, clusterName, cloudCredential
 		Name: clusterName,
 	}
 
-	clusterResp, err := client.Management.Cluster.Create(cluster)
-	Expect(err).To(BeNil())
-
-	return clusterResp, err
+	return client.Management.Cluster.Create(cluster)
 }
 
 // DeleteAKSHostCluster deletes the AKS cluster

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -71,9 +71,9 @@ var _ = Describe("P1Import", func() {
 		FIt("should fail to reimport an imported cluster", func() {
 			testCaseID = 235
 			_, err := helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
-			Expect(err).ToNot(BeNil())
-			GinkgoLogr.Info("Error: ", err.Error())
-			Expect(err.Error()).To(ContainSubstring("cluster already exists"))
+			Expect(err).To(HaveOccurred())
+
+			Expect(err.Error()).To(ContainSubstring("cluster already exists for AKS cluster"))
 		})
 
 		FIt("should be possible to re-import a deleted cluster", func() {
@@ -144,7 +144,7 @@ var _ = Describe("P1Import", func() {
 				Expect(err).To(BeNil())
 			})
 			By("upgrading nodepool version", func() {
-				cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true)
+				cluster, err = helper.UpgradeNodeKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true, true)
 				Expect(err).To(BeNil())
 			})
 		})

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -70,7 +70,7 @@ var _ = Describe("P1Import", func() {
 
 		FIt("should fail to reimport an imported cluster", func() {
 			testCaseID = 235
-			_, err := helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			_, err := helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, location, helpers.GetCommonMetadataLabels())
 			Expect(err).To(HaveOccurred())
 
 			Expect(err.Error()).To(ContainSubstring("cluster already exists for AKS cluster"))
@@ -86,7 +86,7 @@ var _ = Describe("P1Import", func() {
 				_, err := ctx.RancherAdminClient.Management.Cluster.ByID(clusterID)
 				return err
 			}, "10s", "1s").ShouldNot(BeNil())
-			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, location, helpers.GetCommonMetadataLabels())
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
@@ -120,13 +120,13 @@ var _ = Describe("P1Import", func() {
 			err = os.WriteFile(osConfigDotJson.Name(), []byte(osConfigJsonData), 0644)
 			Expect(err).ToNot(HaveOccurred())
 
-			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, true)
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
 			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--kubelet-config", kubeletConfigDotJson.Name(), "--linux-os-config", osConfigDotJson.Name())
 			Expect(err).To(BeNil())
-			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, location, helpers.GetCommonMetadataLabels())
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -2,6 +2,7 @@ package p1_test
 
 import (
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ var _ = Describe("P1Import", func() {
 		}
 	})
 
-	When("a cluster is created", func() {
+	When("a cluster is created and imported", func() {
 		BeforeEach(func() {
 			var err error
 			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
@@ -57,11 +58,39 @@ var _ = Describe("P1Import", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
+		FIt("should fail to change system nodepool count to 0", func() {
+			testCaseID = 290
+			updateSystemNodePoolCountToZeroCheck(cluster, ctx.RancherAdminClient)
+		})
+
 		It("should be able to update cluster monitoring", func() {
 			testCaseID = 271
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
+		FIt("should fail to reimport an imported cluster", func() {
+			testCaseID = 235
+			_, err := helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			Expect(err).ToNot(BeNil())
+			GinkgoLogr.Info("Error: ", err.Error())
+			Expect(err.Error()).To(ContainSubstring("cluster already exists"))
+		})
+
+		FIt("should be possible to re-import a deleted cluster", func() {
+			testCaseID = 239
+			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			clusterID := cluster.ID
+			Eventually(func() error {
+				// Wait until the cluster no longer exists
+				_, err := ctx.RancherAdminClient.Management.Cluster.ByID(clusterID)
+				return err
+			}, "10s", "1s").ShouldNot(BeNil())
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
 	})
 
 	It("should be able to register a cluster with no rbac", func() {
@@ -74,6 +103,51 @@ var _ = Describe("P1Import", func() {
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
 		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+	})
+
+	FWhen("a cluster with custom kubelet and os config is created and imported for upgrade", func() {
+		var upgradeToVersion string
+		BeforeEach(func() {
+			kubeletConfigJsonData := `{"cpuManagerPolicy": "static", "cpuCfsQuota": true, "cpuCfsQuotaPeriod": "200ms", "imageGcHighThreshold": 90, "imageGcLowThreshold": 70, "topologyManagerPolicy": "best-effort", "allowedUnsafeSysctls": ["kernel.msg*","net.*"], "failSwapOn": false}`
+			kubeletConfigDotJson, err := os.CreateTemp("", "custom-kubelet-*.json")
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(kubeletConfigDotJson.Name(), []byte(kubeletConfigJsonData), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			osConfigJsonData := `{"transparentHugePageEnabled": "madvise", "transparentHugePageDefrag": "defer+madvise", "swapFileSizeMB": 1500, "sysctls": {"netCoreSomaxconn": 163849, "netIpv4TcpTwReuse": true, "netIpv4IpLocalPortRange": "32000 60000"}}`
+			osConfigDotJson, err := os.CreateTemp("", "custom-os-*.json")
+			Expect(err).ToNot(HaveOccurred())
+			err = os.WriteFile(osConfigDotJson.Name(), []byte(osConfigJsonData), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCred.ID, location, true)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
+
+			err = helper.CreateAKSClusterOnAzure(location, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--kubelet-config", kubeletConfigDotJson.Name(), "--linux-os-config", osConfigDotJson.Name())
+			Expect(err).To(BeNil())
+			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, location, helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			availableVersions, err := helper.ListAKSAvailableVersions(ctx.RancherAdminClient, cluster.ID)
+			Expect(err).To(BeNil())
+			upgradeToVersion = availableVersions[0]
+		})
+
+		It("should successfully upgrade the cluster", func() {
+			testCaseID = 260
+			var err error
+			By("upgrading control plane version", func() {
+				cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true)
+				Expect(err).To(BeNil())
+			})
+			By("upgrading nodepool version", func() {
+				cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, upgradeToVersion, ctx.RancherAdminClient, true)
+				Expect(err).To(BeNil())
+			})
+		})
 	})
 
 	When("a cluster is created with multiple nodepools", func() {
@@ -101,6 +175,11 @@ var _ = Describe("P1Import", func() {
 		It("should to able to delete a nodepool and add a new one", func() {
 			testCaseID = 268
 			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)
+		})
+
+		FIt("should successfully edit System NodePool", func() {
+			testCaseID = 289
+			updateSystemNodePoolCheck(cluster, ctx.RancherAdminClient)
 		})
 
 	})

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -58,7 +58,7 @@ var _ = Describe("P1Import", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should fail to change system nodepool count to 0", func() {
+		It("should fail to change system nodepool count to 0", func() {
 			testCaseID = 290
 			updateSystemNodePoolCountToZeroCheck(cluster, ctx.RancherAdminClient)
 		})
@@ -68,7 +68,7 @@ var _ = Describe("P1Import", func() {
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should fail to reimport an imported cluster", func() {
+		It("should fail to reimport an imported cluster", func() {
 			testCaseID = 235
 			_, err := helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, location, helpers.GetCommonMetadataLabels())
 			Expect(err).To(HaveOccurred())
@@ -76,7 +76,7 @@ var _ = Describe("P1Import", func() {
 			Expect(err.Error()).To(ContainSubstring("cluster already exists for AKS cluster"))
 		})
 
-		FIt("should be possible to re-import a deleted cluster", func() {
+		It("should be possible to re-import a deleted cluster", func() {
 			testCaseID = 239
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
@@ -105,7 +105,7 @@ var _ = Describe("P1Import", func() {
 		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
 	})
 
-	FWhen("a cluster with custom kubelet and os config is created and imported for upgrade", func() {
+	When("a cluster with custom kubelet and os config is created and imported for upgrade", func() {
 		var upgradeToVersion string
 		BeforeEach(func() {
 			kubeletConfigJsonData := `{"cpuManagerPolicy": "static", "cpuCfsQuota": true, "cpuCfsQuotaPeriod": "200ms", "imageGcHighThreshold": 90, "imageGcLowThreshold": 70, "topologyManagerPolicy": "best-effort", "allowedUnsafeSysctls": ["kernel.msg*","net.*"], "failSwapOn": false}`
@@ -177,7 +177,7 @@ var _ = Describe("P1Import", func() {
 			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should successfully edit System NodePool", func() {
+		It("should successfully edit System NodePool", func() {
 			testCaseID = 289
 			updateSystemNodePoolCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -274,7 +274,7 @@ var _ = Describe("P1Provisioning", func() {
 				clusterName := namegen.AppendRandomString(helpers.ClusterNamePrefix)
 				cluster1, err := helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, location, updateFunc)
 				Expect(err).To(BeNil())
-				cluster, err = helpers.WaitUntilClusterIsReady(cluster1, ctx.RancherAdminClient)
+				cluster1, err = helpers.WaitUntilClusterIsReady(cluster1, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())
 				err = helper.DeleteAKSHostCluster(cluster1, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -100,7 +100,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
-	FIt("should be able to create cluster with container monitoring enabled", func() {
+	It("should be able to create cluster with container monitoring enabled", func() {
 		// Refer: https://github.com/rancher/shepherd/issues/274
 		testCaseID = 199
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
@@ -184,7 +184,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		FIt("should not delete the resource group when cluster is deleted", func() {
+		It("should not delete the resource group when cluster is deleted", func() {
 			testCaseID = 207
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
@@ -215,13 +215,13 @@ var _ = Describe("P1Provisioning", func() {
 			updateTagsCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should have cluster monitoring disabled by default", func() {
+		It("should have cluster monitoring disabled by default", func() {
 			testCaseID = 198
 			Expect(cluster.AKSConfig.Monitoring).To(BeNil())
 			Expect(cluster.AKSStatus.UpstreamSpec.Monitoring).To(BeNil())
 		})
 
-		FIt("should fail to change system nodepool count to 0", func() {
+		It("should fail to change system nodepool count to 0", func() {
 			testCaseID = 202
 			updateSystemNodePoolCountToZeroCheck(cluster, ctx.RancherAdminClient)
 		})
@@ -260,7 +260,7 @@ var _ = Describe("P1Provisioning", func() {
 
 	})
 
-	FIt("should successfully create 2 clusters in  the same RG", func() {
+	It("should successfully create 2 clusters in  the same RG", func() {
 		testCaseID = 217
 		rgName := namegen.AppendRandomString("custom-aks-rg")
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
@@ -444,7 +444,7 @@ var _ = Describe("P1Provisioning", func() {
 			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should successfully edit System NodePool", func() {
+		It("should successfully edit System NodePool", func() {
 			testCaseID = 204
 			updateSystemNodePoolCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -260,7 +260,7 @@ var _ = Describe("P1Provisioning", func() {
 
 	})
 
-	It("should successfully create 2 clusters in  the same RG", func() {
+	It("should successfully create 2 clusters in the same RG", func() {
 		testCaseID = 217
 		rgName := namegen.AppendRandomString("custom-aks-rg")
 		updateFunc := func(aksConfig *aks.ClusterConfig) {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -100,8 +100,8 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
-	XIt("should be able to create cluster with container monitoring enabled", func() {
-		// blocked by https://github.com/rancher/shepherd/issues/274
+	FIt("should be able to create cluster with container monitoring enabled", func() {
+		// Refer: https://github.com/rancher/shepherd/issues/274
 		testCaseID = 199
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
 			aksConfig.Monitoring = pointer.Bool(true)
@@ -109,19 +109,13 @@ var _ = Describe("P1Provisioning", func() {
 		var err error
 		cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, location, updateFunc)
 		Expect(err).To(BeNil())
-		Expect(*cluster.AKSConfig.Monitoring).To(Equal(true))
+		Expect(*cluster.AKSConfig.Monitoring).To(BeTrue())
 
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
 
 		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
-
-		Eventually(func() bool {
-			cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-			Expect(err).NotTo(HaveOccurred())
-			return *cluster.AKSStatus.UpstreamSpec.Monitoring
-		}, "5m", "5s").Should(BeTrue())
-
+		Expect(*cluster.AKSStatus.UpstreamSpec.Monitoring).To(BeTrue())
 	})
 
 	When("a cluster with invalid config is created", func() {
@@ -278,7 +272,7 @@ var _ = Describe("P1Provisioning", func() {
 			go func() {
 				defer wg.Done()
 				clusterName := namegen.AppendRandomString(helpers.ClusterNamePrefix)
-				cluster1, err := helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCred.ID, k8sVersion, location, updateFunc)
+				cluster1, err := helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, location, updateFunc)
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster1, ctx.RancherAdminClient)
 				Expect(err).To(BeNil())


### PR DESCRIPTION
### What does this PR do?
This PR automates AKS P1 provisioning and import test cases.
It also un-XIt's 199 now that r/shepherd has been updated.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) -[ :green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10938908652/job/30368087524

### Special notes for your reviewer:
testCaseID=235 failed on GH action, but tested it locally after fixing it in [f4dd5e0](https://github.com/rancher/hosted-providers-e2e/pull/168/commits/f4dd5e0ffc8637694c67339e56691cb3cf774e9b) and it passes.

<details><summary>Details</summary>
<p>


```
Will run 1 of 33 specs
time="2024-09-19T16:38:50+05:30" level=info msg="Creating Secret(cc-rqq7d)"
time="2024-09-19T16:38:55+05:30" level=info msg="Secret(cc-rqq7d) is active"
SSSStime="2024-09-19T16:39:51+05:30" level=info msg="Cluster status is active!"
Deleting AKS resource group which will delete cluster too ...
Running command: az [group delete --name auto-aks-pvala-hp-ci-mvhkm --yes --subscription 80de5134-ca65-4731-be21-13fb1f0910a2]
Deleted AKS resource group:  auto-aks-pvala-hp-ci-mvhkm
•SSS
------------------------------
P [PENDING]
P1Import when a cluster is created with multiple nodepools should not be able to remove system nodepool
/home/pvala/go/src/github.com/rancher/hosted-providers-e2e/hosted/aks/p1/p1_import_test.go:170
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 33 Specs in 450.369 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 31 Skipped
PASS | FOCUSED
```


</p>
</details> 

