### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,5 @@ updates:
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
     - dependency-name: "github.com/rancher/client-go"
     - dependency-name: "github.com/rancher/shepherd"
+    - dependency-name: "github.com/rancher/rancher"
+    

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,4 +28,3 @@ updates:
     - dependency-name: "github.com/rancher/client-go"
     - dependency-name: "github.com/rancher/shepherd"
     - dependency-name: "github.com/rancher/rancher"
-    


### PR DESCRIPTION
### What does this PR do?
rancher/rancher dependency was added in https://github.com/rancher/hosted-providers-e2e/pull/165. This PR ignores Dependabot update for it as we maintain it manually.
