### PR TITLE
Automate Qase 222, 210, 261, 209, 217, 195, 230

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -199,11 +199,21 @@ func AddNodePool(cluster *management.Cluster, increaseBy int, client *rancher.Cl
 
 	for i := 1; i <= increaseBy; i++ {
 		newNodepool := management.AKSNodePool{
+			AvailabilityZones: npTemplate.AvailabilityZones,
 			Count:             pointer.Int64(1),
-			VMSize:            npTemplate.VMSize,
-			Mode:              npTemplate.Mode,
 			EnableAutoScaling: npTemplate.EnableAutoScaling,
+			MaxCount:          npTemplate.MaxCount,
+			MaxPods:           npTemplate.MaxPods,
+			MaxSurge:          npTemplate.MaxSurge,
+			MinCount:          npTemplate.MinCount,
+			Mode:              npTemplate.Mode,
 			Name:              pointer.String(namegen.RandStringLower(5)),
+			NodeLabels:        npTemplate.NodeLabels,
+			NodeTaints:        npTemplate.NodeTaints,
+			OsDiskSizeGB:      npTemplate.OsDiskSizeGB,
+			OsDiskType:        npTemplate.OsDiskType,
+			OsType:            npTemplate.OsType,
+			VMSize:            npTemplate.VMSize,
 		}
 		updateNodePoolsList = append(updateNodePoolsList, newNodepool)
 

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -182,6 +182,11 @@ var _ = Describe("P1Import", func() {
 			updateSystemNodePoolCheck(cluster, ctx.RancherAdminClient)
 		})
 
+		It("should successfully edit mode of the nodepool", func() {
+			testCaseID = 291
+			updateNodePoolModeCheck(cluster, ctx.RancherAdminClient)
+		})
+
 	})
 
 	When("a cluster is created and imported for upgrade", func() {


### PR DESCRIPTION
### What does this PR do?
1. Automates Qase  222, 210, 261, 209, 217, 195, 230
2. Modifies `AddNodePool` to include all the fields wrt r/shepherd update.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [:green_circle: ] https://github.com/rancher/hosted-providers-e2e/actions/runs/10996501122/job/30530056580 - the failing test is due to https://github.com/rancher/aks-operator/issues/667, it has been marked as pending.

### Special notes for your reviewer:
