### PR TITLE
Bump shepherd and Automate Qase 127 (+fixes for 126 and 255)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
-	github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724 // rancher/shepherd release/v2.9-HEAD commit
+	github.com/rancher/shepherd v0.0.0-20240927124745-2cec0756a561 // rancher/shepherd release/v2.9-HEAD commit
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/apimachinery v0.30.2
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/rancher/rke v1.6.2-rc.2 h1:YB+v428/YqtLKiPX8tNgX4QRtTDdN06np+zDVRoEtm
 github.com/rancher/rke v1.6.2-rc.2/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
 github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724 h1:vjVOvNFue8lBRoacEZWjk9E/6zrRa9q74DbjwbRXeSc=
 github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
+github.com/rancher/shepherd v0.0.0-20240927124745-2cec0756a561 h1:hM4lF6DmQGej8abHM5HHiHp24pc6sPkz0IIQm43S2Tc=
+github.com/rancher/shepherd v0.0.0-20240927124745-2cec0756a561/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -86,8 +86,8 @@ var _ = Describe("P1Provisioning", func() {
 			k8sVersions, err := helper.ListEKSAllVersions(ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
 
-			cpK8sVersion := k8sVersions[0]
-			ngK8sVersion := k8sVersions[1]
+			cpK8sVersion := k8sVersions[1]
+			ngK8sVersion := k8sVersions[0]
 
 			updateFunc := func(clusterConfig *eks.ClusterConfig) {
 				var updatedNodeGroupsList []eks.NodeGroupConfig

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -76,7 +76,7 @@ var _ = Describe("P1Provisioning", func() {
 			Eventually(func() bool {
 				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
-				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "node group names must be unique")
+				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "is not unique within the cluster")
 			}, "1m", "3s").Should(BeTrue())
 		})
 

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -80,6 +80,35 @@ var _ = Describe("P1Provisioning", func() {
 			}, "1m", "3s").Should(BeTrue())
 		})
 
+		It("Fail to create cluster with different k8s versions on control plane and on nodegroup", func() {
+			testCaseID = 127
+
+			k8sVersions, err := helper.ListEKSAllVersions(ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			cpK8sVersion := k8sVersions[0]
+			ngK8sVersion := k8sVersions[1]
+
+			updateFunc := func(clusterConfig *eks.ClusterConfig) {
+				var updatedNodeGroupsList []eks.NodeGroupConfig
+				for _, ng := range *clusterConfig.NodeGroupsConfig {
+					ng.Version = pointer.String(ngK8sVersion)
+					updatedNodeGroupsList = append([]eks.NodeGroupConfig{ng}, updatedNodeGroupsList...)
+				}
+				*clusterConfig.NodeGroupsConfig = updatedNodeGroupsList
+			}
+
+			GinkgoLogr.Info(fmt.Sprintf("Kubernetes version %s for control plane and %s for nodegroup on cluster %s", cpK8sVersion, ngK8sVersion, clusterName))
+			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, cpK8sVersion, region, updateFunc)
+			Expect(err).To(BeNil())
+
+			Eventually(func() bool {
+				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+				Expect(err).To(BeNil())
+				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "version must match cluster")
+			}, "1m", "3s").Should(BeTrue())
+		})
+
 		It("Fail to create cluster with only Security groups", func() {
 			testCaseID = 120
 

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -241,7 +241,7 @@ func upgradeNodeKubernetesVersionGTCPCheck(cluster *management.Cluster, client *
 	Eventually(func() bool {
 		cluster, err := client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(BeNil())
-		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "all nodegroup kubernetes versionsmust be equal to or one minor version lower than the cluster kubernetes version")
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "are not compatible: the node group version may only be up to three minor versions older than the cluster version")
 	}, "1m", "3s").Should(BeTrue())
 }
 


### PR DESCRIPTION
### What does this PR do?

* shepherd bump needed for setting k8s version on EKS nodegroup
* implemented Qase 127 - testcase for setting different k8s versions on cp and ng
* fixes for Qase 126 and 255 - in both cases error messages changed

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable): p1_provisioning https://github.com/rancher/hosted-providers-e2e/actions/runs/11127637779
