### PR TITLE
Update GCP template mainly for updated azure-cli package

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -19,7 +19,7 @@ on:
         default: v1.28.9+k3s1
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
         type: string
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
@@ -61,7 +61,7 @@ jobs:
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_import' }}
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}
-      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -19,7 +19,7 @@ on:
         default: v1.28.9+k3s1
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
         type: string
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
@@ -61,7 +61,7 @@ jobs:
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_import' }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
-      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -19,7 +19,7 @@ on:
         default: v1.28.9+k3s1
       runner_template:
         description: Runner template to use
-        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
         type: string
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
@@ -61,7 +61,7 @@ jobs:
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || 'p0_provisioning/p0_import' }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
-      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v2' }}
+      runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
       downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}


### PR DESCRIPTION
### What does this PR do?
OpenSUSE 15.6 updated by using `zypper ref && zypper up` - it brought new `azure-cli-2.58.0`


### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable): p0_provisioning https://github.com/rancher/hosted-providers-e2e/actions/runs/11162312245/job/31026692722
