### PR TITLE
Set expiration time for GCP runner secrets

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -101,9 +101,9 @@ jobs:
       - name: Create GCP secrets
         run: |
           echo -n ${{ secrets.PAT_TOKEN }} \
-            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --data-file=-
+            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --ttl="18000s" --quiet --data-file=-
           echo -n ${{ github.repository }} \
-            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --data-file=-
+            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --ttl="18000s" --quiet --data-file=-
 
   installation-and-e2e-tests:
     runs-on: ${{ needs.create-runner.outputs.uuid }}
@@ -377,9 +377,10 @@ jobs:
           credentials_json: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2
-      - name: Delete PAT token secret
+      - name: Delete GCP secrets
         run: |
           gcloud --quiet secrets delete PAT_TOKEN_${{ needs.create-runner.outputs.uuid }}
+          gcloud --quiet secrets delete GH_REPO_${{ needs.create-runner.outputs.uuid }}
       - name: Delete runner
         run: |
           gcloud --quiet compute instances delete ${{ needs.create-runner.outputs.runner }} \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -101,9 +101,9 @@ jobs:
       - name: Create GCP secrets
         run: |
           echo -n ${{ secrets.PAT_TOKEN }} \
-            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --ttl="18000s" --quiet --data-file=-
+            | gcloud secrets create PAT_TOKEN_${{ steps.generator.outputs.uuid }} --ttl="36000s" --quiet --data-file=-
           echo -n ${{ github.repository }} \
-            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --ttl="18000s" --quiet --data-file=-
+            | gcloud secrets create GH_REPO_${{ steps.generator.outputs.uuid }} --ttl="36000s" --quiet --data-file=-
 
   installation-and-e2e-tests:
     runs-on: ${{ needs.create-runner.outputs.uuid }}


### PR DESCRIPTION
### What does this PR do?
There was about 8000 Managed Secrets on GCP created by various GCP runners which costs money. 

* This PR will set Expiration time by `--ttl=18000s` for newly created secrets so they will be auto removed after 5h.
![image](https://github.com/user-attachments/assets/d853c059-e876-4053-aca6-c6a36444d812)

* Added line for deleting GH_REPO_ secret which was missing

### Checklist:
- [x] GitHub Actions (if applicable) https://github.com/rancher/hosted-providers-e2e/actions/runs/11178220140

