### PR TITLE
Don't use SSH for AKS nodes

### DIFF
--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -474,7 +474,7 @@ func CreateAKSClusterOnAzure(location string, clusterName string, k8sVersion str
 	}
 
 	fmt.Println("Creating AKS cluster ...")
-	args := []string{"aks", "create", "--resource-group", clusterName, "--generate-ssh-keys", "--kubernetes-version", k8sVersion, "--enable-managed-identity", "--name", clusterName, "--subscription", subscriptionID, "--node-count", nodes, "--tags", formattedTags, "--location", location}
+	args := []string{"aks", "create", "--resource-group", clusterName, "--no-ssh-key", "--kubernetes-version", k8sVersion, "--enable-managed-identity", "--name", clusterName, "--subscription", subscriptionID, "--node-count", nodes, "--tags", formattedTags, "--location", location}
 	args = append(args, clusterCreateArgs...)
 	fmt.Printf("Running command: az %v\n", args)
 	out, err = proc.RunW("az", args...)


### PR DESCRIPTION
### What does this PR do?

After bumping `azure-cli` on our runner template I noticed that there is a problem with creating ssh keys via `az aks create ... --generate-ssh-keys` command. 

I believe the problem is concurrency when ginkgo is trying to provision two clusters in parallel and then two `az aks create` commands are trying to write a new SSH keypair at the same time which leads to this error in CI:
![image](https://github.com/user-attachments/assets/1a89de42-7fe5-444d-818e-2217810ade57)

~So trying to add a random sleep <0-2s> to prevent this.~ Final solution is to replace `--generate-ssh-key` by `--no-ssh-key` flag as we don't need SSH access to nodes.

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) AKS p0_import https://github.com/rancher/hosted-providers-e2e/actions/runs/11234381541

### Special notes for your reviewer:
