### PR TITLE
Fix cache for actions/setup-go

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -197,6 +197,8 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v5
+        env:
+          GOTOOLCHAIN: local
         with:
           go-version-file: go.mod
 

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,6 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20240719121207-baeda6b89fe3 h1:CxX3KZ
 github.com/rancher/rancher/pkg/apis v0.0.0-20240719121207-baeda6b89fe3/go.mod h1:FMQKxZ0EJjcFCcw4KUQF4bC6ilJ5GuSIvFhQEDGGTCk=
 github.com/rancher/rke v1.6.2-rc.2 h1:YB+v428/YqtLKiPX8tNgX4QRtTDdN06np+zDVRoEtmU=
 github.com/rancher/rke v1.6.2-rc.2/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
-github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724 h1:vjVOvNFue8lBRoacEZWjk9E/6zrRa9q74DbjwbRXeSc=
-github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
 github.com/rancher/shepherd v0.0.0-20240927124745-2cec0756a561 h1:hM4lF6DmQGej8abHM5HHiHp24pc6sPkz0IIQm43S2Tc=
 github.com/rancher/shepherd v0.0.0-20240927124745-2cec0756a561/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=


### PR DESCRIPTION
### What does this PR do?

* Removes outdated shepherd dependency
* Fixes go cache issue with `actions/setup-go`:

Problem is that `actions/setup-go` is confused when it sees `go 1.22.0` and `toolchain 1.22.7` in go.mod. 

The action first prepares environment for 1.22.0 (go) and then trying to override it by cached dependencies using go toolchain version 1.22.7.

By introducing this workaround we will simply install requested `go 1.22.0` (the version from go.mod) and the rest for dependencies ?should be? processed automatically within a build time.

Since `toolchain` keyword was introduced in go.mod our actions are returning errors like:
![image](https://github.com/user-attachments/assets/565029ea-f8cb-4584-a083-c92ad737e95d)

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable):  https://github.com/rancher/hosted-providers-e2e/actions/runs/11237633369/job/31240560770#step:13:87

### Special notes for your reviewer:
