### PR TITLE
Fix az janitor query

### DIFF
--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -19,7 +19,7 @@ jobs:
         continue-on-error: true
         run: |
           # Get the AKS clusters by prefix
-          for rg in $(az group list --query "[?starts_with(name,'auto-aks-hp-ci')].{Name: name}" | jq -r ".[] | .Name" 2> /dev/null); do
+          for rg in $(az group list --query "[?starts_with(name,'auto-aks-hp-ci')].name" | jq -r ".[]" 2> /dev/null); do
             echo "Deleting AKS resource group: $rg"
             az group delete --name $rg --yes
           done

--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -19,7 +19,7 @@ jobs:
         continue-on-error: true
         run: |
           # Get the AKS clusters by prefix
-          for rg in $(az group list --query "[?contains(name,'auto-aks-hp-ci')].{Name: name}" | jq -r ".[] | .Name" 2> /dev/null); do
+          for rg in $(az group list --query "[?starts_with(name,'auto-aks-hp-ci')].{Name: name}" | jq -r ".[] | .Name" 2> /dev/null); do
             echo "Deleting AKS resource group: $rg"
             az group delete --name $rg --yes
           done


### PR DESCRIPTION
### What does this PR do?
The current query lists Node resource groups along with parent AKS resource groups. eg. `MC_auto-aks-hp-ci-hfzlv_auto-aks-hp-ci-hfzlv_centralindia`
This change lists only AKS resource groups since Node resource groups get auto-deleted along with them.

- [x] GitHub Actions:
Unfixed run: https://github.com/rancher/hosted-providers-e2e/actions/runs/11287010203/job/31392235896#step:3:13
Fixed run: https://github.com/rancher/hosted-providers-e2e/actions/runs/11287948455/job/31394785232