### PR TITLE
Run Sync and EKS tests in parallel nodes and Bump k8s version

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
-run-name: AKS ${{ inputs.downstream_k8s_minor_version }} on Rancher v${{ inputs.rancher_version || '2.9-head' }} deployed on ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
+run-name: AKS ${{ inputs.downstream_k8s_minor_version }} on Rancher v${{ inputs.rancher_version || '2.9-head' }} deployed on ${{ inputs.k3s_version || 'v1.30.2+k3s1' }}
 
 on:
   schedule:
@@ -17,7 +17,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.28.9+k3s1
+        default: v1.30.2+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -36,7 +36,7 @@ on:
         default: true
         type: boolean
       downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g. 1.28)
+        description: Downstream cluster minor K8s version to test (e.g. 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -58,7 +58,7 @@ jobs:
     with:
       hosted_provider: aks
       rancher_version: ${{ inputs.rancher_version || '2.9-head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.30.2+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 4 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 4 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
-run-name: EKS ${{ inputs.downstream_k8s_minor_version }} on Rancher v${{ inputs.rancher_version || '2.9-head' }} deployed on ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
+run-name: EKS ${{ inputs.downstream_k8s_minor_version }} on Rancher v${{ inputs.rancher_version || '2.9-head' }} deployed on ${{ inputs.k3s_version || 'v1.30.2+k3s1' }}
 
 on:
   schedule:
@@ -17,7 +17,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.28.9+k3s1
+        default: v1.30.2+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -36,7 +36,7 @@ on:
         default: true
         type: boolean
       downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g. 1.28)
+        description: Downstream cluster minor K8s version to test (e.g. 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -58,7 +58,7 @@ jobs:
     with:
       hosted_provider: eks
       rancher_version: ${{ inputs.rancher_version || '2.9-head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.30.2+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 4 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 4 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
-run-name: GKE ${{ inputs.downstream_k8s_minor_version }} on Rancher v${{ inputs.rancher_version || '2.9-head' }} deployed on ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
+run-name: GKE ${{ inputs.downstream_k8s_minor_version }} on Rancher v${{ inputs.rancher_version || '2.9-head' }} deployed on ${{ inputs.k3s_version || 'v1.30.2+k3s1' }}
 
 on:
   schedule:
@@ -17,7 +17,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.28.9+k3s1
+        default: v1.30.2+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -36,7 +36,7 @@ on:
         default: true
         type: boolean
       downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g. 1.28)
+        description: Downstream cluster minor K8s version to test (e.g. 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -58,7 +58,7 @@ jobs:
     with:
       hosted_provider: gke
       rancher_version: ${{ inputs.rancher_version || '2.9-head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.28.9+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.30.2+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 4 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 4 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}

--- a/Makefile
+++ b/Makefile
@@ -140,33 +140,22 @@ e2e-provisioning-tests: deps ## Run the 'P0Provisioning' test suite for a given 
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P0Provisioning" ./hosted/${PROVIDER}/p0/
 
 e2e-p1-import-tests: deps	## Run the 'P1Import' test suite for a given ${PROVIDER}
-ifeq (${PROVIDER}, eks)
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P1Import" ./hosted/${PROVIDER}/p1/
-else
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Import" ./hosted/${PROVIDER}/p1/
-endif
 
 e2e-p1-provisioning-tests: deps ## Run the 'P1Provisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Provisioning" ./hosted/${PROVIDER}/p1/
 
+e2e-sync-import-tests: deps ## Run "SyncImport" test suite for a given ${PROVIDER}
+	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SyncImport" ./hosted/${PROVIDER}/p1
 
-# Support Matrix test has not been parallelized for EKS because we hit resource limits when running it in parallel
+e2e-sync-provisioning-tests: deps ## Run "SyncProvisioning" test suite for a given ${PROVIDER}
+	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SyncProvisioning" ./hosted/${PROVIDER}/p1
+
 e2e-support-matrix-import-tests: deps ## Run the 'SupportMatrixImport' test suite for a given ${PROVIDER}
-ifeq (${PROVIDER}, eks)
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SupportMatrixImport" ./hosted/${PROVIDER}/support_matrix/
-else
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SupportMatrixImport" ./hosted/${PROVIDER}/support_matrix/
-endif
-
 
 e2e-support-matrix-provisioning-tests: deps ## Run the 'SupportMatrixProvisioning' test suite for a given ${PROVIDER}
-ifeq (${PROVIDER}, eks)
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SupportMatrixProvisioning" ./hosted/${PROVIDER}/support_matrix/
-else
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SupportMatrixProvisioning" ./hosted/${PROVIDER}/support_matrix/
-endif
-
-
 
 e2e-k8s-chart-support-import-tests-upgrade: deps ## Run the 'K8sChartSupportUpgradeImport' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportUpgradeImport" ./hosted/${PROVIDER}/k8s_chart_support/upgrade
@@ -179,12 +168,6 @@ e2e-k8s-chart-support-import-tests: deps ## Run the 'K8sChartSupportImport' test
 
 e2e-k8s-chart-support-provisioning-tests: deps ## Run the 'K8sChartSupportProvisioning' test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --focus "K8sChartSupportProvisioning" ./hosted/${PROVIDER}/k8s_chart_support
-
-e2e-sync-provisioning-tests: deps ## Run "SyncProvisioning" test suite for a given ${PROVIDER}
-	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SyncProvisioning" ./hosted/${PROVIDER}/p1
-
-e2e-sync-import-tests: deps ## Run "SyncImport" test suite for a given ${PROVIDER}
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "SyncImport" ./hosted/${PROVIDER}/p1
 
 clean-k3s:	## Uninstall k3s cluster
 	/usr/local/bin/k3s-uninstall.sh


### PR DESCRIPTION
### What does this PR do?
- With increased VPC limit and janitor fixes, it would be feasible to run SyncImport tests and EKS tests in parallel nodes.
- Bump local cluster k8s version to highest supported with respect to v2.9

### Checklist:
- [x] GitHub Actions:
EKS: https://github.com/rancher/hosted-providers-e2e/actions/runs/11288636844
AKS: https://github.com/rancher/hosted-providers-e2e/actions/runs/11288917687/job/31397718461#step:24:193
GKE: https://github.com/rancher/hosted-providers-e2e/actions/runs/11288537289/job/31396539524#step:24:173

### Special notes for your reviewer:
Collect logs job failure to be triaged separately.