### PR TITLE
Run P1Prov in parallel nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ e2e-p1-import-tests: deps	## Run the 'P1Import' test suite for a given ${PROVIDE
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P1Import" ./hosted/${PROVIDER}/p1/
 
 e2e-p1-provisioning-tests: deps ## Run the 'P1Provisioning' test suite for a given ${PROVIDER}
-	ginkgo ${STANDARD_TEST_OPTIONS} --focus "P1Provisioning" ./hosted/${PROVIDER}/p1/
+	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "P1Provisioning" ./hosted/${PROVIDER}/p1/
 
 e2e-sync-import-tests: deps ## Run "SyncImport" test suite for a given ${PROVIDER}
 	ginkgo ${STANDARD_TEST_OPTIONS} --nodes 2 --focus "SyncImport" ./hosted/${PROVIDER}/p1

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -459,7 +459,8 @@ var _ = Describe("P1Provisioning", func() {
 
 	})
 
-	It("should successfully create 2 clusters in the same RG", func() {
+	XIt("should successfully create 2 clusters in the same RG", func() {
+		// TODO: Refer https://github.com/rancher/hosted-providers-e2e/issues/192
 		testCaseID = 217
 		rgName := namegen.AppendRandomString("custom-aks-rg")
 		updateFunc := func(aksConfig *aks.ClusterConfig) {

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -19,10 +19,9 @@ import (
 )
 
 var (
-	ctx         helpers.Context
-	clusterName string
-	testCaseID  int64
-	location    = helpers.GetAKSLocation()
+	ctx                   helpers.Context
+	clusterName, location string
+	testCaseID            int64
 )
 
 func TestP1(t *testing.T) {
@@ -39,6 +38,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 var _ = BeforeEach(func() {
 	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+	location = helpers.GetAKSLocation()
 })
 
 var _ = ReportBeforeEach(func(report SpecReport) {
@@ -494,7 +494,7 @@ func noAvailabilityZoneP0Checks(cluster *management.Cluster, client *rancher.Cli
 
 	By("Adding a nodepool", func() {
 		initialNPCount := len(cluster.AKSConfig.NodePools)
-		newNPName := fmt.Sprintf("newNPName%s", namegen.RandStringLower(3))
+		newNPName := fmt.Sprintf("newpool%s", namegen.RandStringLower(3))
 		updateFunc := func(cluster *management.Cluster) {
 			nodepools := cluster.AKSConfig.NodePools
 			npTemplate := nodepools[0]


### PR DESCRIPTION
### What does this PR do?
Made changes to run P1 Provisioning tests in parallel nodes so it completes execution within suite timeout.

### Checklist:
- [x] GitHub Actions:
[AKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/11538406232), [EKS](https://github.com/rancher/hosted-providers-e2e/actions/runs/11456865282), [GKE](https://github.com/rancher/hosted-providers-e2e/actions/runs/11460218371)

### Special notes for your reviewer:
Above jobs are run on non-nightly build as `eks-operator/pull/876` is not yet ported to `main`