### PR TITLE
Adapt used AMI for GPU enabled nodepool in EKS

### DIFF
--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -164,7 +164,8 @@ var _ = Describe("P1Provisioning", func() {
 		var amiID string
 		amiID, err = helper.GetFromEKS(region, clusterName, "nodegroup", ".[].ImageID", "--name", gpuNodeName)
 		Expect(err).To(BeNil())
-		Expect(amiID).To(Equal("AL2_x86_64_GPU"))
+		GinkgoLogr.Info(fmt.Sprintf("Used AMI for GPU enabled nodegroup in EKS cluster: %s", amiID))
+		Expect(amiID).To(Or(Equal("AL2_x86_64_GPU"), Equal("AL2023_x86_64_NVIDIA")))
 	})
 
 	Context("Upgrade testing", func() {


### PR DESCRIPTION
### What does this PR do?
Should fix this issue on EKS p1_provisioning in CI - now it will accept both AMIs for GPU enabled Nodepools (the change is present in `2.10` and `main` only)
![image](https://github.com/user-attachments/assets/4b7528ca-d4ba-43ec-9f23-59ecd9f896d9)

### Checklist:
- [x] GitHub Actions (if applicable):
* https://github.com/rancher/hosted-providers-e2e/actions/runs/12232378796/job/34126770946#step:17:290


