### PR TITLE
[Backport-2.10] Automate Qase 274, 94, 97, 99, 143, 145, 107, 105 & Adapt used AMI for GPU enabled nodepool in EKS

### DIFF
--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
@@ -13,6 +14,24 @@ import (
 
 var _ = Describe("P1Import", func() {
 	var cluster *management.Cluster
+
+	BeforeEach(func() {
+		var err error
+		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+		Expect(err).To(BeNil())
+		GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+	})
+
+	AfterEach(func() {
+		if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
+			err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+			Expect(err).To(BeNil())
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
 
 	When("a cluster is imported for upgrade", func() {
 
@@ -28,17 +47,6 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
-		})
-
-		AfterEach(func() {
-			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
-				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
-				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
-				Expect(err).To(BeNil())
-			} else {
-				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
-			}
 		})
 
 		It("Upgrade version of node group only", func() {
@@ -58,31 +66,65 @@ var _ = Describe("P1Import", func() {
 		})
 	})
 
-	When("a cluster is imported", func() {
-
-		var _ = BeforeEach(func() {
-			var err error
-			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+	It("should successfully Import cluster with ONLY control plane", func() {
+		testCaseID = 94
+		err := helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--without-nodegroup")
+		Expect(err).To(BeNil())
+		cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, region)
+		Expect(err).To(BeNil())
+		Eventually(func() bool {
+			cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			GinkgoLogr.Info(fmt.Sprintf("Using kubernetes version %s for cluster %s", k8sVersion, clusterName))
+			return cluster.Transitioning == "error" && cluster.TransitioningMessage == "Cluster must have at least one managed nodegroup or one self-managed node."
+		}, "5m", "2s").Should(BeTrue())
+		cluster.EKSConfig = cluster.EKSStatus.UpstreamSpec
+		cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, false)
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
 
-			err = helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+	})
+
+	It("successfully import EKS cluster with self-managed nodes", func() {
+		testCaseID = 107
+		err := helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels(), "--managed=false")
+		Expect(err).To(BeNil())
+		cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, region)
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+	})
+
+	When("a cluster with multiple nodegroups is imported", func() {
+		BeforeEach(func() {
+			err := helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
 			Expect(err).To(BeNil())
+			for i := 0; i < 2; i++ {
+				err = helper.AddNodeGroupOnAWS(namegen.AppendRandomString("ng"), clusterName, region)
+				Expect(err).To(BeNil())
+			}
 			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, region)
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 			Expect(err).To(BeNil())
 		})
 
-		AfterEach(func() {
-			if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
-				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-				Expect(err).To(BeNil())
-				err = helper.DeleteEKSClusterOnAWS(region, clusterName)
-				Expect(err).To(BeNil())
-			} else {
-				fmt.Println("Skipping downstream cluster deletion: ", clusterName)
-			}
+		It("should successfully Import cluster with at least 2 nodegroups", func() {
+			testCaseID = 105
+			helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+		})
+	})
+
+	When("a cluster is imported", func() {
+
+		var _ = BeforeEach(func() {
+			err := helper.CreateEKSClusterOnAWS(region, clusterName, k8sVersion, "1", helpers.GetCommonMetadataLabels())
+			Expect(err).To(BeNil())
+			cluster, err = helper.ImportEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, region)
+			Expect(err).To(BeNil())
+			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
 		})
 
 		It("Delete & re-import cluster", func() {
@@ -121,25 +163,7 @@ var _ = Describe("P1Import", func() {
 
 		It("Update Tags and Labels", func() {
 			testCaseID = 81
-
-			var err error
-			tags := map[string]string{
-				"foo":        "bar",
-				"testCaseID": "98",
-			}
-			labels := map[string]string{
-				"testCaseID": "96",
-			}
-
-			By("Adding cluster tags", func() {
-				cluster, err = helper.UpdateClusterTags(cluster, ctx.RancherAdminClient, tags, true)
-				Expect(err).To(BeNil())
-			})
-
-			By("Adding Nodegroup tags & labels", func() {
-				cluster, err = helper.UpdateNodegroupMetadata(cluster, ctx.RancherAdminClient, tags, labels, true)
-				Expect(err).To(BeNil())
-			})
+			updateTagsAndLabels(cluster, ctx.RancherAdminClient)
 		})
 
 		Context("Reimporting/Editing a cluster with invalid config", func() {

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -159,7 +159,8 @@ var _ = Describe("P1Provisioning", func() {
 		var amiID string
 		amiID, err = helper.GetFromEKS(region, clusterName, "nodegroup", ".[].ImageID", "--name", gpuNodeName)
 		Expect(err).To(BeNil())
-		Expect(amiID).To(Equal("AL2_x86_64_GPU"))
+		GinkgoLogr.Info(fmt.Sprintf("Used AMI for GPU enabled nodegroup in EKS cluster: %s", amiID))
+		Expect(amiID).To(Or(Equal("AL2_x86_64_GPU"), Equal("AL2023_x86_64_NVIDIA")))
 	})
 
 	When("a cluster is created for upgrade", func() {


### PR DESCRIPTION
### What does this PR do?
Backport of #200 and #214 

We would like to check EKS AMI when GPU is enabled, also other tests from original PR#200 were backported 

### Checklist:
- [ ] GitHub Actions (if applicable) https://github.com/rancher/hosted-providers-e2e/actions/runs/12238284940
