### PR TITLE
Release matrix and existing rancher enablement

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -216,7 +216,7 @@ jobs:
           echo -e "Exported values:\nQASE_RUN_ID=${ID}\nQASE_RUN_DESCRIPTION=${QASE_RUN_DESCRIPTION}\nQASE_RUN_NAME=${QASE_RUN_NAME}"
 
       - name: Provisioning cluster tests
-        if:  ${{ steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p0_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p0_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -226,7 +226,7 @@ jobs:
           make e2e-provisioning-tests
 
       - name: Import cluster tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p0_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p0_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -236,7 +236,7 @@ jobs:
           make e2e-import-tests
 
       - name: Provisioning cluster P1 tests
-        if:  ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p1_provisioning') }}
+        if:  ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p1_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -246,7 +246,7 @@ jobs:
           make e2e-p1-provisioning-tests
 
       - name: Import cluster P1 tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p1_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p1_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -256,7 +256,7 @@ jobs:
           make e2e-p1-import-tests
 
       - name: Support matrix provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'support_matrix_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'support_matrix_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -266,7 +266,7 @@ jobs:
           make e2e-support-matrix-provisioning-tests
 
       - name: Support matrix import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'support_matrix_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'support_matrix_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -276,7 +276,7 @@ jobs:
           make e2e-support-matrix-import-tests
 
       - name: K8s Chart Support provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'k8s_chart_support_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'k8s_chart_support_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -288,7 +288,7 @@ jobs:
           make e2e-k8s-chart-support-provisioning-tests
 
       - name: K8s Chart Support import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'k8s_chart_support_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'k8s_chart_support_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -300,7 +300,7 @@ jobs:
           make e2e-k8s-chart-support-import-tests
 
       - name: Sync provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'sync_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'sync_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -311,7 +311,7 @@ jobs:
           make e2e-sync-provisioning-tests
 
       - name: Sync import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'sync_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'sync_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -339,21 +339,23 @@ jobs:
         env:
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
           RANCHER_BEHIND_PROXY: ${{ inputs.proxy == true }}
-        if: ${{ steps.prepare-rancher.outcome == 'success' }}
+        if: ${{ always() && steps.prepare-rancher.outcome == 'success' }}
         run: |
           chmod +x ${{ env.RANCHER_LOG_COLLECTOR }}
           bash ${{ env.RANCHER_LOG_COLLECTOR }}
 
       - name: Upload cluster logs
-        if: ${{ steps.prepare-rancher.outcome == 'success' }}
+        if: ${{ always() && steps.prepare-rancher.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
-          name: support-logs
+          name: support-logs-${{ inputs.hosted_provider }}
           path: ${{ github.workspace }}/logs/*
           if-no-files-found: ignore
 
       - name: Add summary
-        if: ${{ !cancelled() }}
+        env:
+          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+        if: ${{ always() && steps.prepare-rancher.outcome == 'success' }}
         run: |
           # Add summary
           echo "## General information" >> ${GITHUB_STEP_SUMMARY}
@@ -361,6 +363,8 @@ jobs:
           echo "K3s on Rancher Manager: ${{ inputs.k3s_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Downstream ${{ inputs.hosted_provider }} minor version: ${{ inputs.downstream_k8s_minor_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Tests run: ${{ inputs.tests_to_run }}" >> ${GITHUB_STEP_SUMMARY}
+          OPERATOR_HELM_VERSION=$(helm get metadata rancher-${{ inputs.hosted_provider }}-operator -n cattle-system -o json | jq -r .version)
+          echo "Installed rancher-${{ inputs.hosted_provider }}-operator chart version: $OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}
 
   delete-runner:
     if: ${{ always() && inputs.destroy_runner == true }}

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -1,0 +1,68 @@
+name: Release-matrix
+run-name: Rancher `${{ inputs.rancher_version }}` on `${{ inputs.k3s_version }}` running `${{ inputs.tests_to_run }}`
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_version:
+        description: Rancher version channel/version/head_version
+        required: true
+        type: string
+        default: latest/devel/2.10
+      k3s_version:
+        description: k3s version of local cluster
+        required: true
+        type: string
+        default: v1.30.5+k3s1
+      runner_template:
+        description: Runner template to use
+        default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
+        type: string
+      operator_nightly_chart:
+        description: Install hosted-provider nightly chart
+        default: false
+        required: true
+        type: boolean
+      destroy_runner:
+        description: Destroy the auto-generated self-hosted runner
+        default: true
+        type: boolean
+      downstream_cluster_cleanup:
+        description: Cleanup downstream clusters after test
+        default: true
+        type: boolean
+      downstream_k8s_minor_version:
+        description: Downstream cluster minor K8s version to test (e.g., 1.30)
+      rancher_installed:
+        description: Rancher details if already installed
+        default: 'hostname/password'
+        type: string
+      tests_to_run:
+        description: Tests to run
+        required: true
+        default: p0_provisioning/p0_import
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
+
+jobs:
+  e2e-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [aks, eks, gke]
+    uses: ./.github/workflows/main.yaml
+    secrets: inherit
+    with:
+      hosted_provider: ${{ matrix.provider }}
+      rancher_version: ${{ inputs.rancher_version }}
+      k3s_version: ${{ inputs.k3s_version }}
+      operator_nightly_chart: ${{ inputs.operator_nightly_chart }}
+      tests_to_run: ${{ inputs.tests_to_run }}
+      destroy_runner: ${{ inputs.destroy_runner }}
+      runner_template: ${{ inputs.runner_template }}
+      downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
+      rancher_installed: ${{ inputs.rancher_installed }}
+      downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup }}
+      proxy: ${{ inputs.proxy }}

--- a/install_test.go
+++ b/install_test.go
@@ -224,14 +224,14 @@ NO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0.0/16,.
 		})
 
 		if nightlyChart == "enabled" {
-			By(fmt.Sprintf("Install nightly %s-operator via Helm", providerOperator), func() {
+			By(fmt.Sprintf("Install nightly rancher-%s-operator via Helm", providerOperator), func() {
 				// Get the current date to use as the build date
 				buildDate := time.Now().Format("20060102")
 
-				RunHelmCmdWithRetry("upgrade", "--install", providerOperator+"-operator-crds",
+				RunHelmCmdWithRetry("upgrade", "--install", "rancher-"+providerOperator+"-operator-crds",
 					"oci://ttl.sh/"+providerOperator+"-operator/rancher-"+providerOperator+"-operator-crd",
 					"--version", buildDate)
-				RunHelmCmdWithRetry("upgrade", "--install", providerOperator+"-operator",
+				RunHelmCmdWithRetry("upgrade", "--install", "rancher-"+providerOperator+"-operator",
 					"oci://ttl.sh/"+providerOperator+"-operator/rancher-"+providerOperator+"-operator",
 					"--version", buildDate, "--namespace", "cattle-system")
 			})


### PR DESCRIPTION
Backports of:
https://github.com/rancher/hosted-providers-e2e/pull/216 Release matrix testing all operators at once
https://github.com/rancher/hosted-providers-e2e/pull/217 More matrix stuff
https://github.com/rancher/hosted-providers-e2e/pull/219 Allow usage of self hosted rancher

Testrun: TBD (waiting for 2.9 to finish)