### PR TITLE
Fix: Cluster deletion is skipped if timeout happens in WaitUntilClusterIsReady

### DIFF
--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -139,14 +139,14 @@ func WaitUntilClusterIsReady(cluster *management.Cluster, client *rancher.Client
 	opts := metav1.ListOptions{FieldSelector: "metadata.name=" + cluster.ID, TimeoutSeconds: &defaults.WatchTimeoutSeconds}
 	watchInterface, err := client.GetManagementWatchInterface(management.ClusterType, opts)
 	if err != nil {
-		return nil, err
+		return cluster, err
 	}
 
 	watchFunc := shepherdclusters.IsHostedProvisioningClusterReady
 
 	err = wait.WatchWait(watchInterface, watchFunc)
 	if err != nil {
-		return nil, err
+		return cluster, err
 	}
 	var updatedCluster *management.Cluster
 	updatedCluster, err = client.Management.Cluster.ByID(cluster.ID)


### PR DESCRIPTION
### What does this PR do?
Whenever a test times out at `WaitUntilClusterIsReady`, it returns a nil cluster, due to which the cluster is not deleted. This PR should fix this.
```
------------------------------
• [FAILED] [1800.626 seconds]
P0Provisioning when a cluster is created [BeforeEach] should successfully provision the regional cluster & add, delete, scale nodepool
  [BeforeEach] /home/gh-runner/actions-runner/_work/hosted-providers-e2e/hosted-providers-e2e/hosted/gke/p0/p0_provisioning_test.go:68
  [It] /home/gh-runner/actions-runner/_work/hosted-providers-e2e/hosted-providers-e2e/hosted/gke/p0/p0_provisioning_test.go:96

  Captured StdOut/StdErr Output >>
  Skipping downstream cluster deletion:  auto-gke-hp-ci-hzloh
  << Captured StdOut/StdErr Output

  Timeline >>
  "level"=0 "msg"="Using K8s version 1.31.3-gke.1162000 for cluster auto-gke-hp-ci-hzloh"
  [FAILED] in [BeforeEach] - /home/gh-runner/actions-runner/_work/hosted-providers-e2e/hosted-providers-e2e/hosted/gke/p0/p0_provisioning_test.go:85 @ 12/16/24 09:24:19.455
  << Timeline

  [FAILED] Expected
      <*errors.errorString | 0xc0006a60d0>: 
      timeout waiting on condition
      ***
          s: "timeout waiting on condition",
      ***
  to be nil
  In [BeforeEach] at: /home/gh-runner/actions-runner/_work/hosted-providers-e2e/hosted-providers-e2e/hosted/gke/p0/p0_provisioning_test.go:85 @ 12/16/24 09:24:19.455
```
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) -  https://github.com/rancher/hosted-providers-e2e/actions/runs/12350788310

### Special notes for your reviewer:
