### PR TITLE
Debug GKE http and add random sleep prior creating cluster in p0

### DIFF
--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -16,7 +16,7 @@ mkdir -p -m 755 cluster-logs
 cd cluster-logs
 curl -L ${RANCHER_LOG_COLLECTER} -o rancherlogcollector.sh
 chmod +x rancherlogcollector.sh
-sudo ./rancherlogcollector.sh -d ../cluster-logs
+sudo ./rancherlogcollector.sh -d ../cluster-logs -s 0
 
 # Move back to logs dir
 cd ..

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -232,7 +232,7 @@ jobs:
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
         run: |
           # Enable temporary debug output for GKE operator
-          if [ ${{ inputs.hosted_provider }} == "gke" ] && [ ${{ inputs.operator_nightly_chart}} == "true" ]; then
+          if [ ${{ inputs.hosted_provider }} == "gke" ] && [ ${{ inputs.operator_nightly_chart }} == "true" ]; then
             # export RANCHER_CLIENT_DEBUG="true"
             kubectl patch deployment gke-config-operator -n cattle-system --patch '{"spec":{"template":{"spec":{"containers":[{"name":"rancher-gke-operator","env":[{"name":"GODEBUG","value":"http2debug=2"}]}]}}}}'
           fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -231,6 +231,10 @@ jobs:
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
         run: |
+          # Enable temporary shepherd debug output for GKE
+          if [ ${{ inputs.hosted_provider }} == 'gke' ]; then
+            export RANCHER_CLIENT_DEBUG="true"
+          fi
           make e2e-provisioning-tests
 
       - name: Import cluster tests

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -233,8 +233,8 @@ jobs:
         run: |
           # Enable temporary debug output for GKE operator
           if [ ${{ inputs.hosted_provider }} == 'gke' ]; then
-            export RANCHER_CLIENT_DEBUG="true"
-            kubectl patch deployment gke-config-operator -n cattle-system --patch '{"spec":{"template":{"spec":{"containers":[{"name":"rancher-gke-operator","env":[{"name":"GODEBUG","value":"http2debug=1"}]}]}}}}'
+            # export RANCHER_CLIENT_DEBUG="true"
+            kubectl patch deployment gke-config-operator -n cattle-system --patch '{"spec":{"template":{"spec":{"containers":[{"name":"rancher-gke-operator","env":[{"name":"GODEBUG","value":"http2debug=2"}]}]}}}}'
           fi
           make e2e-provisioning-tests
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -232,7 +232,7 @@ jobs:
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
         run: |
           # Enable temporary debug output for GKE operator
-          if [ ${{ inputs.hosted_provider }} == 'gke' ]; then
+          if [ ${{ inputs.hosted_provider }} == "gke" ] && [ ${{ inputs.operator_nightly_chart}} == "true" ]; then
             # export RANCHER_CLIENT_DEBUG="true"
             kubectl patch deployment gke-config-operator -n cattle-system --patch '{"spec":{"template":{"spec":{"containers":[{"name":"rancher-gke-operator","env":[{"name":"GODEBUG","value":"http2debug=2"}]}]}}}}'
           fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -231,9 +231,10 @@ jobs:
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
         run: |
-          # Enable temporary shepherd debug output for GKE
+          # Enable temporary debug output for GKE operator
           if [ ${{ inputs.hosted_provider }} == 'gke' ]; then
             export RANCHER_CLIENT_DEBUG="true"
+            kubectl patch deployment gke-config-operator -n cattle-system --patch '{"spec":{"template":{"spec":{"containers":[{"name":"rancher-gke-operator","env":[{"name":"GODEBUG","value":"http2debug=1"}]}]}}}}'
           fi
           make e2e-provisioning-tests
 

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -17,9 +17,11 @@ package p0_test
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/exp/rand"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
@@ -79,6 +81,9 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
+				nodeIndex := GinkgoParallelNode()
+				randomDelay := time.Duration((nodeIndex%3)*1000+rand.Intn(1000)) * time.Millisecond
+				time.Sleep(randomDelay)
 				cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, zone, region, project, updateFunc)
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -81,9 +81,11 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))
 
+				// Do not create clusters exactly at the same time for all ginkgo nodes
 				nodeIndex := GinkgoParallelNode()
-				randomDelay := time.Duration((nodeIndex%3)*1000+rand.Intn(1000)) * time.Millisecond
+				randomDelay := time.Duration((nodeIndex%3+1)*1000+rand.Intn(1000)) * time.Millisecond
 				time.Sleep(randomDelay)
+
 				cluster, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, zone, region, project, updateFunc)
 				Expect(err).To(BeNil())
 				cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)


### PR DESCRIPTION
### What does this PR do?

This enables debug logging by setting `GODEBUG=http2debug=2` env in gke operator pod for p0_provisioning test. Once we catch the issue we can revert.

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable):
1st nightly https://github.com/rancher/hosted-providers-e2e/actions/runs/12397006953
2nd nightly https://github.com/rancher/hosted-providers-e2e/actions/runs/12409440687

