### PR TITLE
Upgrade Shepherd and changes-post upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241114104736-0d5b41ca9158
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
-	github.com/rancher/shepherd v0.0.0-20250128173158-b3e7a07abe9a // rancher/shepherd main commit
+	github.com/rancher/shepherd v0.0.0-20250205140852-ba6d2793aaff // rancher/shepherd main commit
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/apimachinery v0.31.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/rancher/gke-operator v1.10.0 // indirect
 	github.com/rancher/lasso v0.0.0-20240924233157-8f384efc8813 // indirect
 	github.com/rancher/norman v0.0.0-20241001183610-78a520c160ab // indirect
-	github.com/rancher/rancher/pkg/apis v0.0.0-20241113133627-598640d1556c // indirect
+	github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded // indirect
 	github.com/rancher/rke v1.7.0-rc.5 // indirect
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde // indirect
 	github.com/rancher/wrangler v1.1.2 // indirect
@@ -129,3 +129,5 @@ replace (
 	go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-20240308221502-c3b2635212be
 	k8s.io/client-go => k8s.io/client-go v0.31.1
 )
+
+replace github.com/rancher/shepherd v0.0.0-20241113142845-1338e51b4891 => github.com/valaparthvi/shepherd v0.0.0-20250113150307-791e30f90eea

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20241114104736-0d5b41ca9158
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
-	github.com/rancher/shepherd v0.0.0-20241113142845-1338e51b4891 // rancher/shepherd main commit
+	github.com/rancher/shepherd v0.0.0-20250128173158-b3e7a07abe9a // rancher/shepherd main commit
 	github.com/sirupsen/logrus v1.9.3
 	k8s.io/apimachinery v0.31.1
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
@@ -129,5 +129,3 @@ replace (
 	go.qase.io/client => github.com/rancher/qase-go/client v0.0.0-20240308221502-c3b2635212be
 	k8s.io/client-go => k8s.io/client-go v0.31.1
 )
-
-replace github.com/rancher/shepherd v0.0.0-20241113142845-1338e51b4891 => github.com/valaparthvi/shepherd v0.0.0-20250113150307-791e30f90eea

--- a/go.sum
+++ b/go.sum
@@ -256,12 +256,10 @@ github.com/rancher/qase-go/client v0.0.0-20240308221502-c3b2635212be h1:+m6Jv5sA
 github.com/rancher/qase-go/client v0.0.0-20240308221502-c3b2635212be/go.mod h1:NP3xboG+t2p+XMnrcrJ/L384Ki0Cp3Pww/X+vm5Jcy0=
 github.com/rancher/rancher v0.0.0-20241119163817-d801b4924311 h1:1LQW1FxHHNhyPy4wvtM7o/7ZePjnQ6SwEqxV8giytlQ=
 github.com/rancher/rancher v0.0.0-20241119163817-d801b4924311/go.mod h1:yTuEmhJ7i6rs3qO5TQij0RQkoKrMMPTMjMVS/qpqH8g=
-github.com/rancher/rancher/pkg/apis v0.0.0-20241113133627-598640d1556c h1:wgRohofDe45lOK4nmA7AboPkl1AlTJgp97kQ/0nDsg8=
-github.com/rancher/rancher/pkg/apis v0.0.0-20241113133627-598640d1556c/go.mod h1:VJQNArsPMiuWlvlnfGbD5gZtGvttnsEJSbrLsHfBtuA=
+github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded h1:h2gsujsN0gxYNU1g950V2b21yOfNXA2mBHkvCWdcA20=
+github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded/go.mod h1:VJQNArsPMiuWlvlnfGbD5gZtGvttnsEJSbrLsHfBtuA=
 github.com/rancher/rke v1.7.0-rc.5 h1:kBRwXTW8CYPXvCcPLISiwGTCvJ8K/+b35D5ES0IcduM=
 github.com/rancher/rke v1.7.0-rc.5/go.mod h1:+x++Mvl0A3jIzNLiu8nkraqZXiHg6VPWv0Xl4iQCg+A=
-github.com/rancher/shepherd v0.0.0-20241113142845-1338e51b4891 h1:JbWVRcIEjz2xdpfotFiCDZVjlcwGXXwLkhjevK+GCco=
-github.com/rancher/shepherd v0.0.0-20241113142845-1338e51b4891/go.mod h1:TD6hF654momYGPQ0plWbigLSF1My6KhaxcTjWoJF/nU=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
@@ -293,6 +291,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/valaparthvi/shepherd v0.0.0-20250113150307-791e30f90eea h1:Fz/Gt2GeO8+57lajGYZu4yIxNzBIagytD0Zg/E6ch/8=
+github.com/valaparthvi/shepherd v0.0.0-20250113150307-791e30f90eea/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded h1:h2gsuj
 github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded/go.mod h1:VJQNArsPMiuWlvlnfGbD5gZtGvttnsEJSbrLsHfBtuA=
 github.com/rancher/rke v1.7.0-rc.5 h1:kBRwXTW8CYPXvCcPLISiwGTCvJ8K/+b35D5ES0IcduM=
 github.com/rancher/rke v1.7.0-rc.5/go.mod h1:+x++Mvl0A3jIzNLiu8nkraqZXiHg6VPWv0Xl4iQCg+A=
-github.com/rancher/shepherd v0.0.0-20250128173158-b3e7a07abe9a h1:2M68MtzP2PwInsKQNhaRTZ0W5I84iJw1KIUBBc+mpRY=
-github.com/rancher/shepherd v0.0.0-20250128173158-b3e7a07abe9a/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
+github.com/rancher/shepherd v0.0.0-20250205140852-ba6d2793aaff h1:ifkYlyFJEZzpo8uY0PX0oE8/36ZkDWiAPpL/EU2x5Og=
+github.com/rancher/shepherd v0.0.0-20250205140852-ba6d2793aaff/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded h1:h2gsuj
 github.com/rancher/rancher/pkg/apis v0.0.0-20241127174121-c051d99dcded/go.mod h1:VJQNArsPMiuWlvlnfGbD5gZtGvttnsEJSbrLsHfBtuA=
 github.com/rancher/rke v1.7.0-rc.5 h1:kBRwXTW8CYPXvCcPLISiwGTCvJ8K/+b35D5ES0IcduM=
 github.com/rancher/rke v1.7.0-rc.5/go.mod h1:+x++Mvl0A3jIzNLiu8nkraqZXiHg6VPWv0Xl4iQCg+A=
+github.com/rancher/shepherd v0.0.0-20250128173158-b3e7a07abe9a h1:2M68MtzP2PwInsKQNhaRTZ0W5I84iJw1KIUBBc+mpRY=
+github.com/rancher/shepherd v0.0.0-20250128173158-b3e7a07abe9a/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
@@ -291,8 +293,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/valaparthvi/shepherd v0.0.0-20250113150307-791e30f90eea h1:Fz/Gt2GeO8+57lajGYZu4yIxNzBIagytD0Zg/E6ch/8=
-github.com/valaparthvi/shepherd v0.0.0-20250113150307-791e30f90eea/go.mod h1:relMIZBbmYQyZUgVWfomrpHKO0we3AmbrUD0EFYoXyc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/hosted/aks/backup_restore/backup_restore_suite_test.go
+++ b/hosted/aks/backup_restore/backup_restore_suite_test.go
@@ -99,7 +99,8 @@ var _ = AfterEach(func() {
 
 func restoreNodesChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
-	initialNodeCount := *cluster.AKSConfig.NodePools[0].Count
+	configNodePools := *cluster.AKSConfig.NodePools
+	initialNodeCount := *configNodePools[0].Count
 
 	By("scaling up the nodepool", func() {
 		var err error

--- a/hosted/aks/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/aks/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -103,11 +103,11 @@ func commonchecks(client *rancher.Client, cluster *management.Cluster) {
 	})
 
 	By("making a change(adding a nodepool) to the cluster to re-install the operator and validating it is re-installed to the latest/original version", func() {
-		currentNodePoolNumber := len(cluster.AKSConfig.NodePools)
+		currentNodePoolNumber := len(*cluster.AKSConfig.NodePools)
 		var err error
 		cluster, err = helper.AddNodePool(cluster, 1, client, false, false)
 		Expect(err).To(BeNil())
-		Expect(len(cluster.AKSConfig.NodePools)).To(BeNumerically("==", currentNodePoolNumber+1))
+		Expect(len(*cluster.AKSConfig.NodePools)).To(BeNumerically("==", currentNodePoolNumber+1))
 
 		By("ensuring that the chart is re-installed to the latest/original version", func() {
 			helpers.WaitUntilOperatorChartInstallation(originalChartVersion, "", 0)
@@ -123,7 +123,7 @@ func commonchecks(client *rancher.Client, cluster *management.Cluster) {
 		Eventually(func() int {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return len(cluster.AKSStatus.UpstreamSpec.NodePools)
+			return len(*cluster.AKSStatus.UpstreamSpec.NodePools)
 		}, tools.SetTimeout(10*time.Minute), 3*time.Second).Should(BeNumerically("==", currentNodePoolNumber+1))
 	})
 }

--- a/hosted/aks/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
+++ b/hosted/aks/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
@@ -196,11 +196,11 @@ func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clus
 	})
 
 	By("making a change(adding a nodepool) to the cluster to re-install the operator and validating it is re-installed to the latest/upgraded version", func() {
-		currentNodePoolNumber := len(cluster.AKSConfig.NodePools)
+		currentNodePoolNumber := len(*cluster.AKSConfig.NodePools)
 		var err error
 		cluster, err = helper.AddNodePool(cluster, 1, ctx.RancherAdminClient, false, false)
 		Expect(err).To(BeNil())
-		Expect(len(cluster.AKSConfig.NodePools)).To(BeNumerically("==", currentNodePoolNumber+1))
+		Expect(len(*cluster.AKSConfig.NodePools)).To(BeNumerically("==", currentNodePoolNumber+1))
 
 		By("ensuring that the chart is re-installed to the latest/upgraded version", func() {
 			helpers.WaitUntilOperatorChartInstallation(upgradedChartVersion, "", 0)
@@ -212,7 +212,7 @@ func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clus
 		Eventually(func() int {
 			cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return len(cluster.AKSStatus.UpstreamSpec.NodePools)
+			return len(*cluster.AKSStatus.UpstreamSpec.NodePools)
 		}, tools.SetTimeout(10*time.Minute), 3*time.Second).Should(BeNumerically("==", currentNodePoolNumber+1))
 
 	})

--- a/hosted/aks/p0/p0_suite_test.go
+++ b/hosted/aks/p0/p0_suite_test.go
@@ -90,8 +90,8 @@ func p0upgradeK8sVersionCheck(cluster *management.Cluster, client *rancher.Clien
 func p0NodesChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
-
-	initialNodeCount := *cluster.AKSConfig.NodePools[0].Count
+	configNodePools := *cluster.AKSConfig.NodePools
+	initialNodeCount := *configNodePools[0].Count
 
 	By("adding a nodepool", func() {
 		var err error

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -14,6 +14,9 @@ import (
 var _ = Describe("P1Import", func() {
 	var k8sVersion string
 	BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
 		GinkgoLogr.Info(fmt.Sprintf("Running on process: %d", GinkgoParallelProcess()))
 
 		var err error

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -187,7 +187,7 @@ var _ = Describe("P1Provisioning", func() {
 		initialNPCount := len(*cluster.AKSConfig.NodePools)
 		cluster, err = helper.AddNodePool(cluster, 3, ctx.RancherAdminClient, false, false)
 		Expect(err).To(BeNil())
-		Expect(cluster.AKSConfig.NodePools).To(HaveLen(initialNPCount + 3))
+		Expect(*cluster.AKSConfig.NodePools).To(HaveLen(initialNPCount + 3))
 
 		var upgradeK8sVersion string
 		upgradeK8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, false)
@@ -208,7 +208,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cluster.AKSStatus.UpstreamSpec.NodePools).To(HaveLen(initialNPCount + 3))
+		Expect(*cluster.AKSStatus.UpstreamSpec.NodePools).To(HaveLen(initialNPCount + 3))
 		Expect(cluster.AKSStatus.UpstreamSpec.KubernetesVersion).To(Equal(upgradeK8sVersion))
 	})
 

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -136,7 +136,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
-	It("should be able to create cluster with container monitoring enabled", func() {
+	FIt("should be able to create cluster with container monitoring enabled", func() {
 		// Refer: https://github.com/rancher/shepherd/issues/274
 		testCaseID = 199
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
@@ -456,7 +456,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		It("recreating a cluster while it is being deleted should recreate the cluster", func() {
+		FIt("recreating a cluster while it is being deleted should recreate the cluster", func() {
 			testCaseID = 219
 
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
@@ -655,7 +655,7 @@ var _ = Describe("P1Provisioning", func() {
 		}, "5m", "5s").Should(BeTrue(), "Failed while waiting for k8s upgrade.")
 	})
 
-	It("should Create NP with AZ for region where AZ is not supported", func() {
+	FIt("should Create NP with AZ for region where AZ is not supported", func() {
 		testCaseID = 196
 		// none of the availability zones are supported in this location
 		location = "westus"

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -322,6 +322,7 @@ var _ = Describe("P1Provisioning", func() {
 			Eventually(func() bool {
 				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).NotTo(HaveOccurred())
+				GinkgoLogr.Info(fmt.Sprintf("cluster.Transitioning=%s cluster.TransitioningMessage=%s", cluster.Transitioning, cluster.TransitioningMessage))
 				return cluster.Transitioning == "error" && cluster.TransitioningMessage == "at least one NodePool with mode System is required"
 			}, "1m", "2s").Should(BeTrue())
 		})
@@ -476,6 +477,7 @@ var _ = Describe("P1Provisioning", func() {
 			Eventually(func() bool {
 				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
+				GinkgoLogr.Info(fmt.Sprintf("cluster.State=%s cluster.Transitioning=%s cluster.TransitioningMessage=%s", cluster.State, cluster.Transitioning, cluster.TransitioningMessage))
 				return cluster.State == "provisioning" && cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "an AKSClusterConfig exists with the same name")
 			}, "30s", "2s").Should(BeTrue())
 

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -26,6 +26,9 @@ var _ = Describe("P1Provisioning", func() {
 	var k8sVersion string
 
 	BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
 		GinkgoLogr.Info(fmt.Sprintf("Running on process: %d", GinkgoParallelProcess()))
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, false)
@@ -485,9 +488,6 @@ var _ = Describe("P1Provisioning", func() {
 	// Refer: https://github.com/rancher/hosted-providers-e2e/issues/192
 	It("should successfully create 2 clusters in the same RG", func() {
 		testCaseID = 214
-
-		// Setting this to nil ensures we do not use the `cluster` variable value from another test running in parallel with this one.
-		cluster = nil
 
 		// Create the resource group via CLI
 		rgName := namegen.AppendRandomString(helpers.ClusterNamePrefix + "-custom-rg")

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -136,7 +136,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(cluster.AKSStatus.UpstreamSpec.Tags).To(HaveKeyWithValue("empty-tag", ""))
 	})
 
-	FIt("should be able to create cluster with container monitoring enabled", func() {
+	It("should be able to create cluster with container monitoring enabled", func() {
 		// Refer: https://github.com/rancher/shepherd/issues/274
 		testCaseID = 199
 		updateFunc := func(aksConfig *aks.ClusterConfig) {
@@ -456,7 +456,7 @@ var _ = Describe("P1Provisioning", func() {
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("recreating a cluster while it is being deleted should recreate the cluster", func() {
+		It("recreating a cluster while it is being deleted should recreate the cluster", func() {
 			testCaseID = 219
 
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
@@ -655,7 +655,7 @@ var _ = Describe("P1Provisioning", func() {
 		}, "5m", "5s").Should(BeTrue(), "Failed while waiting for k8s upgrade.")
 	})
 
-	FIt("should Create NP with AZ for region where AZ is not supported", func() {
+	It("should Create NP with AZ for region where AZ is not supported", func() {
 		testCaseID = 196
 		// none of the availability zones are supported in this location
 		location = "westus"

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -104,7 +104,7 @@ var _ = Describe("P1Provisioning", func() {
 		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
 		Expect(err).To(BeNil())
 		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
-		for _, np := range cluster.AKSConfig.NodePools {
+		for _, np := range *cluster.AKSConfig.NodePools {
 			npName := *np.Name
 			az := npName[len(npName)-1]
 			Expect(*np.AvailabilityZones).To(Equal([]string{string(az)}))
@@ -181,7 +181,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		Expect(*cluster.AKSConfig.KubernetesVersion).To(Equal(k8sVersion))
 
-		initialNPCount := len(cluster.AKSConfig.NodePools)
+		initialNPCount := len(*cluster.AKSConfig.NodePools)
 		cluster, err = helper.AddNodePool(cluster, 3, ctx.RancherAdminClient, false, false)
 		Expect(err).To(BeNil())
 		Expect(cluster.AKSConfig.NodePools).To(HaveLen(initialNPCount + 3))
@@ -308,10 +308,10 @@ var _ = Describe("P1Provisioning", func() {
 			}, "1m", "2s").Should(BeTrue())
 		})
 
-		It("should fail to create a cluster with 0 nodepool", func() {
+		It("should fail to create a cluster with nil nodepool", func() {
 			testCaseID = 187
 			updateFunc := func(aksConfig *aks.ClusterConfig) {
-				aksConfig.NodePools = &[]aks.NodePool{}
+				aksConfig.NodePools = nil
 			}
 			var err error
 			cluster, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, location, updateFunc)
@@ -321,6 +321,16 @@ var _ = Describe("P1Provisioning", func() {
 				Expect(err).NotTo(HaveOccurred())
 				return cluster.Transitioning == "error" && cluster.TransitioningMessage == "at least one NodePool with mode System is required"
 			}, "1m", "2s").Should(BeTrue())
+		})
+
+		It("should fail to create a cluster with an empty nodepool array", func() {
+			updateFunc := func(aksConfig *aks.ClusterConfig) {
+				aksConfig.NodePools = &[]aks.NodePool{}
+			}
+			var err error
+			_, err = helper.CreateAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, location, updateFunc)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("must have at least one nodepool"))
 		})
 
 		It("should fail to create cluster with Nodepool Max pods per node 9", func() {
@@ -373,7 +383,7 @@ var _ = Describe("P1Provisioning", func() {
 			originalNPMap := make(map[string][]string)
 			newAZ := []string{"3"}
 			updateFunc := func(cluster *management.Cluster) {
-				nodepools := cluster.AKSConfig.NodePools
+				nodepools := *cluster.AKSConfig.NodePools
 				for i := range nodepools {
 					originalNPMap[*nodepools[i].Name] = *nodepools[i].AvailabilityZones
 					nodepools[i].AvailabilityZones = &newAZ
@@ -382,7 +392,7 @@ var _ = Describe("P1Provisioning", func() {
 			var err error
 			cluster, err = helper.UpdateCluster(cluster, ctx.RancherAdminClient, updateFunc)
 			Expect(err).To(BeNil())
-			for _, np := range cluster.AKSConfig.NodePools {
+			for _, np := range *cluster.AKSConfig.NodePools {
 				Expect(*np.AvailabilityZones).To(Equal(newAZ))
 			}
 
@@ -621,7 +631,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(err).To(BeNil())
 
 		Expect(*cluster.AKSConfig.KubernetesVersion).To(Equal(cpK8sVersion))
-		for _, np := range cluster.AKSConfig.NodePools {
+		for _, np := range *cluster.AKSConfig.NodePools {
 			Expect(*np.OrchestratorVersion).To(Equal(cpK8sVersion))
 		}
 
@@ -636,7 +646,7 @@ var _ = Describe("P1Provisioning", func() {
 				return false
 			}
 
-			for _, np := range clusterState.AKSStatus.UpstreamSpec.NodePools {
+			for _, np := range *clusterState.AKSStatus.UpstreamSpec.NodePools {
 				if *np.OrchestratorVersion != cpK8sVersion {
 					return false
 				}
@@ -702,8 +712,8 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 189
 			helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
 
-			Expect(len(cluster.AKSConfig.NodePools)).To(Equal(2))
-			Expect(len(cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(2))
+			Expect(len(*cluster.AKSConfig.NodePools)).To(Equal(2))
+			Expect(len(*cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(2))
 		})
 
 		XIt("should to able to delete a nodepool and add a new one with different availability zone", func() {

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -74,12 +74,12 @@ func updateAutoScaling(cluster *management.Cluster, client *rancher.Client) {
 func removeSystemNpCheck(cluster *management.Cluster, client *rancher.Client) {
 	updateFunc := func(cluster *management.Cluster) {
 		var updatedNodePools []management.AKSNodePool
-		for _, np := range cluster.AKSConfig.NodePools {
+		for _, np := range *cluster.AKSConfig.NodePools {
 			if np.Mode == "User" {
 				updatedNodePools = append(updatedNodePools, np)
 			}
 		}
-		cluster.AKSConfig.NodePools = updatedNodePools
+		cluster.AKSConfig.NodePools = &updatedNodePools
 	}
 	var err error
 	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
@@ -93,14 +93,14 @@ func removeSystemNpCheck(cluster *management.Cluster, client *rancher.Client) {
 
 // Qase ID: 194, 190, and 268
 func deleteAndAddNpCheck(cluster *management.Cluster, client *rancher.Client) {
-	originalLen := len(cluster.AKSConfig.NodePools)
+	originalLen := len(*cluster.AKSConfig.NodePools)
 	var npToBeDeleted management.AKSNodePool
 	newPoolName := fmt.Sprintf("newpool%s", namegen.RandStringLower(3))
 	newPoolAZ := []string{"2", "3"}
 
 	updateFunc := func(cluster *management.Cluster) {
 		var updatedNodePools []management.AKSNodePool
-		for _, np := range cluster.AKSConfig.NodePools {
+		for _, np := range *cluster.AKSConfig.NodePools {
 			if np.Mode == "User" {
 				// We do not want to delete one of the 'System' mode nodepool; since at least one is required
 				npToBeDeleted = np
@@ -113,7 +113,7 @@ func deleteAndAddNpCheck(cluster *management.Cluster, client *rancher.Client) {
 		newNodePool.AvailabilityZones = &newPoolAZ
 		// testCaseID = 194
 		updatedNodePools = append(updatedNodePools, newNodePool)
-		cluster.AKSConfig.NodePools = updatedNodePools
+		cluster.AKSConfig.NodePools = &updatedNodePools
 	}
 	var err error
 	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
@@ -122,7 +122,7 @@ func deleteAndAddNpCheck(cluster *management.Cluster, client *rancher.Client) {
 		npDeleted = true
 		npAdded   = false
 	)
-	for _, np := range cluster.AKSConfig.NodePools {
+	for _, np := range *cluster.AKSConfig.NodePools {
 		if *np.Name == *npToBeDeleted.Name {
 			npDeleted = false
 		}
@@ -133,21 +133,21 @@ func deleteAndAddNpCheck(cluster *management.Cluster, client *rancher.Client) {
 	}
 	Expect(npAdded).To(BeTrue())
 	Expect(npDeleted).To(BeTrue())
-	Expect(len(cluster.AKSConfig.NodePools)).To(BeEquivalentTo(originalLen))
+	Expect(len(*cluster.AKSConfig.NodePools)).To(BeEquivalentTo(originalLen))
 	err = clusters.WaitClusterToBeUpgraded(client, cluster.ID)
 	Expect(err).To(BeNil())
 
 	Eventually(func() bool {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(BeNil())
-		if len(cluster.AKSStatus.UpstreamSpec.NodePools) != originalLen {
+		if len(*cluster.AKSStatus.UpstreamSpec.NodePools) != originalLen {
 			return false
 		}
 		var (
 			npDeletedFromUpstream = true
 			npAddedToUpstream     = false
 		)
-		for _, np := range cluster.AKSConfig.NodePools {
+		for _, np := range *cluster.AKSConfig.NodePools {
 			if *np.Name == newPoolName {
 				npAddedToUpstream = true
 				// testCaseID = 194
@@ -293,13 +293,13 @@ func updateMonitoringCheck(cluster *management.Cluster, client *rancher.Client) 
 // Qase ID: 202 and 290
 func updateSystemNodePoolCountToZeroCheck(cluster *management.Cluster, client *rancher.Client) {
 	updateFunc := func(cluster *management.Cluster) {
-		nodepools := cluster.AKSConfig.NodePools
+		nodepools := *cluster.AKSConfig.NodePools
 		for i, nodepool := range nodepools {
 			if nodepool.Mode == "System" {
 				nodepools[i].Count = pointer.Int64(0)
 			}
 		}
-		cluster.AKSConfig.NodePools = nodepools
+		cluster.AKSConfig.NodePools = &nodepools
 	}
 	var err error
 	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
@@ -321,7 +321,7 @@ func updateSystemNodePoolCheck(cluster *management.Cluster, client *rancher.Clie
 	)
 	const systemMode = "System"
 	updateFunc := func(cluster *management.Cluster) {
-		nodepools := cluster.AKSConfig.NodePools
+		nodepools := *cluster.AKSConfig.NodePools
 		for i := range nodepools {
 			if nodepools[i].Mode == systemMode {
 				nodepools[i].Count = &count
@@ -330,13 +330,13 @@ func updateSystemNodePoolCheck(cluster *management.Cluster, client *rancher.Clie
 				nodepools[i].MaxCount = &maxCount
 			}
 		}
-		cluster.AKSConfig.NodePools = nodepools
+		cluster.AKSConfig.NodePools = &nodepools
 	}
 	var err error
 	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 	Expect(err).To(BeNil())
 
-	for _, np := range cluster.AKSConfig.NodePools {
+	for _, np := range *cluster.AKSConfig.NodePools {
 		if np.Mode == systemMode {
 			Expect(*np.EnableAutoScaling).To(BeTrue())
 			Expect(*np.MinCount).To(BeNumerically("==", minCount))
@@ -348,7 +348,7 @@ func updateSystemNodePoolCheck(cluster *management.Cluster, client *rancher.Clie
 	Eventually(func() bool {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(BeNil())
-		for _, np := range cluster.AKSStatus.UpstreamSpec.NodePools {
+		for _, np := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 			if np.Mode == systemMode {
 				if !((np.EnableAutoScaling != nil && *np.EnableAutoScaling == true) && (*np.MaxCount == maxCount) && (*np.MinCount == minCount) && (*np.Count == count)) {
 					return false
@@ -363,7 +363,7 @@ func updateSystemNodePoolCheck(cluster *management.Cluster, client *rancher.Clie
 func updateNodePoolModeCheck(cluster *management.Cluster, client *rancher.Client) {
 	var originalModeMap = make(map[string]string)
 	updateFunc := func(cluster *management.Cluster) {
-		nodepools := cluster.AKSConfig.NodePools
+		nodepools := *cluster.AKSConfig.NodePools
 		for i := range nodepools {
 			originalModeMap[*nodepools[i].Name] = nodepools[i].Mode
 			if nodepools[i].Mode == "User" {
@@ -376,7 +376,7 @@ func updateNodePoolModeCheck(cluster *management.Cluster, client *rancher.Client
 	var err error
 	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 	Expect(err).To(BeNil())
-	for _, np := range cluster.AKSConfig.NodePools {
+	for _, np := range *cluster.AKSConfig.NodePools {
 		Expect(np.Mode).ToNot(Equal(originalModeMap[*np.Name]))
 	}
 	err = clusters.WaitClusterUntilUpgrade(client, cluster.ID)
@@ -385,7 +385,7 @@ func updateNodePoolModeCheck(cluster *management.Cluster, client *rancher.Client
 	Eventually(func() bool {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).NotTo(HaveOccurred())
-		for _, np := range cluster.AKSStatus.UpstreamSpec.NodePools {
+		for _, np := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 			if np.Mode == originalModeMap[*np.Name] {
 				return false
 			}
@@ -416,7 +416,7 @@ func updateCloudCredentialsCheck(cluster *management.Cluster, client *rancher.Cl
 
 // Qase ID: 224 and 293
 func syncAddNodePoolFromAzureAndRancher(cluster *management.Cluster, client *rancher.Client) {
-	initialNPCount := len(cluster.AKSConfig.NodePools)
+	initialNPCount := len(*cluster.AKSConfig.NodePools)
 	const npAzure = "npazure"
 	By("adding nodepool from Azure", func() {
 		err := helper.AddNodePoolOnAzure(npAzure, cluster.AKSConfig.ClusterName, cluster.AKSConfig.ResourceGroup, "2")
@@ -425,7 +425,7 @@ func syncAddNodePoolFromAzureAndRancher(cluster *management.Cluster, client *ran
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).NotTo(HaveOccurred())
-			for _, nodePool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+			for _, nodePool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 				if *nodePool.Name == npAzure {
 					return true
 				}
@@ -461,7 +461,7 @@ func upgradeCPK8sFromAzureAndNPFromRancherCheck(cluster *management.Cluster, cli
 			return *cluster.AKSStatus.UpstreamSpec.KubernetesVersion == upgradeToVersion
 		}, "5m", "5s").Should(BeTrue(), "Timed out while waiting for upgrade to appear in UpstreamSpec")
 
-		for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+		for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 			// NodePool version must remain the same
 			Expect(*nodepool.OrchestratorVersion).To(Equal(k8sVersion))
 		}
@@ -469,7 +469,7 @@ func upgradeCPK8sFromAzureAndNPFromRancherCheck(cluster *management.Cluster, cli
 		if !helpers.IsImport {
 			// skip this check if the cluster is imported since the AKSConfig value will not be updated
 			Expect(*cluster.AKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
-			for _, nodepool := range cluster.AKSConfig.NodePools {
+			for _, nodepool := range *cluster.AKSConfig.NodePools {
 				// NodePool version must remain the same
 				Expect(*nodepool.OrchestratorVersion).To(Equal(k8sVersion))
 			}
@@ -491,11 +491,11 @@ func upgradeCPK8sFromAzureAndNPFromRancherCheck(cluster *management.Cluster, cli
 func noAvailabilityZoneP0Checks(cluster *management.Cluster, client *rancher.Client) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
 
-	for _, nodepool := range cluster.AKSConfig.NodePools {
+	for _, nodepool := range *cluster.AKSConfig.NodePools {
 		Expect(nodepool.AvailabilityZones).To(BeNil())
 	}
 
-	for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+	for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 		Expect(nodepool.AvailabilityZones).To(BeNil())
 	}
 
@@ -516,25 +516,25 @@ func noAvailabilityZoneP0Checks(cluster *management.Cluster, client *rancher.Cli
 	})
 
 	By("Adding a nodepool", func() {
-		initialNPCount := len(cluster.AKSConfig.NodePools)
+		initialNPCount := len(*cluster.AKSConfig.NodePools)
 		newNPName := fmt.Sprintf("newpool%s", namegen.RandStringLower(3))
 		updateFunc := func(cluster *management.Cluster) {
-			nodepools := cluster.AKSConfig.NodePools
+			nodepools := *cluster.AKSConfig.NodePools
 			npTemplate := nodepools[0]
 			newNP := npTemplate
 			newNP.Name = &newNPName
 			nodepools = append(nodepools, newNP)
-			cluster.AKSConfig.NodePools = nodepools
+			cluster.AKSConfig.NodePools = &nodepools
 		}
 		cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 		Expect(err).To(BeNil())
-		Expect(len(cluster.AKSConfig.NodePools)).Should(BeNumerically("==", initialNPCount+1))
+		Expect(len(*cluster.AKSConfig.NodePools)).Should(BeNumerically("==", initialNPCount+1))
 		err = clusters.WaitClusterToBeUpgraded(client, cluster.ID)
 		Expect(err).To(BeNil())
 		Eventually(func() int {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return len(cluster.AKSStatus.UpstreamSpec.NodePools)
+			return len(*cluster.AKSStatus.UpstreamSpec.NodePools)
 		}, "5m", "5s").Should(BeNumerically("==", initialNPCount+1))
 	})
 
@@ -583,7 +583,7 @@ func invalidateCloudCredentialsCheck(cluster *management.Cluster, client *ranche
 		return cluster.AKSStatus.UpstreamSpec.AzureCredentialSecret == newCCID
 	}, "5m", "5s").Should(BeTrue())
 
-	for _, nodepool := range cluster.AKSConfig.NodePools {
+	for _, nodepool := range *cluster.AKSConfig.NodePools {
 		Expect(*nodepool.Count).To(Equal(scaleCount))
 	}
 
@@ -591,7 +591,7 @@ func invalidateCloudCredentialsCheck(cluster *management.Cluster, client *ranche
 	Eventually(func() bool {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).NotTo(HaveOccurred())
-		for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+		for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 			if *nodepool.Count != scaleCount {
 				return false
 			}
@@ -618,7 +618,7 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 				// Return early
 				return false
 			}
-			for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+			for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 				if *nodepool.OrchestratorVersion != upgradeToVersion {
 					allUpgraded = false
 				}
@@ -629,7 +629,7 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 		// Check AKSConfig if the cluster is Rancher-provisioned
 		if !helpers.IsImport {
 			Expect(*cluster.AKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
-			for _, nodepool := range cluster.AKSConfig.NodePools {
+			for _, nodepool := range *cluster.AKSConfig.NodePools {
 				Expect(*nodepool.OrchestratorVersion).To(Equal(upgradeToVersion))
 			}
 		}
@@ -640,18 +640,18 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 		nodeCount int64 = 1
 	)
 	// Using upstreamSpec so that it also works with import tests
-	currentNPCount := len(cluster.AKSStatus.UpstreamSpec.NodePools)
+	currentNPCount := len(*cluster.AKSStatus.UpstreamSpec.NodePools)
 	By("Adding a nodepool", func() {
 		err := helper.AddNodePoolOnAzure(npName, cluster.AKSConfig.ClusterName, cluster.AKSConfig.ResourceGroup, fmt.Sprint(nodeCount))
 		Expect(err).To(BeNil())
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).NotTo(HaveOccurred())
-			if len(cluster.AKSStatus.UpstreamSpec.NodePools) == currentNPCount {
+			if len(*cluster.AKSStatus.UpstreamSpec.NodePools) == currentNPCount {
 				// Return early if the nodepool count hasn't changed.
 				return false
 			}
-			for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+			for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 				if *nodepool.Name == npName {
 					return true
 				}
@@ -672,7 +672,7 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).NotTo(HaveOccurred())
-			for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+			for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 				if *nodepool.Name == npName {
 					return *nodepool.Count == scaleCount
 				}
@@ -682,7 +682,7 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 
 		// Check AKSConfig if the cluster is Rancher-provisioned
 		if !helpers.IsImport {
-			for _, nodepool := range cluster.AKSConfig.NodePools {
+			for _, nodepool := range *cluster.AKSConfig.NodePools {
 				if *nodepool.Name == npName {
 					Expect(*nodepool.Count).To(Equal(scaleCount))
 				}
@@ -696,11 +696,11 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).NotTo(HaveOccurred())
-			if len(cluster.AKSStatus.UpstreamSpec.NodePools) != currentNPCount {
+			if len(*cluster.AKSStatus.UpstreamSpec.NodePools) != currentNPCount {
 				// Return early if the nodepool count is not back to its original state
 				return false
 			}
-			for _, nodepool := range cluster.AKSStatus.UpstreamSpec.NodePools {
+			for _, nodepool := range *cluster.AKSStatus.UpstreamSpec.NodePools {
 				if *nodepool.Name == npName {
 					return false
 				}

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -435,7 +435,7 @@ func syncAddNodePoolFromAzureAndRancher(cluster *management.Cluster, client *ran
 
 		if !helpers.IsImport {
 			// skip this check if the cluster is imported since the AKSConfig value will not be updated
-			Expect(cluster.AKSConfig.NodePools).To(HaveLen(initialNPCount + 1))
+			Expect(*cluster.AKSConfig.NodePools).To(HaveLen(initialNPCount + 1))
 		}
 	})
 
@@ -661,7 +661,7 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 
 		// Check AKSConfig if the cluster is Rancher-provisioned
 		if !helpers.IsImport {
-			Expect(cluster.AKSConfig.NodePools).To(HaveLen(currentNPCount + 1))
+			Expect(*cluster.AKSConfig.NodePools).To(HaveLen(currentNPCount + 1))
 		}
 	})
 
@@ -710,7 +710,7 @@ func azureSyncCheck(cluster *management.Cluster, client *rancher.Client, upgrade
 
 		// Check AKSConfig if the cluster is Rancher-provisioned
 		if !helpers.IsImport {
-			Expect(cluster.AKSConfig.NodePools).To(HaveLen(currentNPCount))
+			Expect(*cluster.AKSConfig.NodePools).To(HaveLen(currentNPCount))
 		}
 	})
 

--- a/hosted/aks/p1/p1_suite_test.go
+++ b/hosted/aks/p1/p1_suite_test.go
@@ -179,7 +179,7 @@ func npUpgradeToVersionGTCPCheck(cluster *management.Cluster, client *rancher.Cl
 // Qase ID: 223 and 303
 func updateClusterWhenUpdating(cluster *management.Cluster, client *rancher.Client, upgradeK8sVersion string) {
 	var err error
-	initialNPLength := len(cluster.AKSConfig.NodePools)
+	initialNPLength := len(*cluster.AKSConfig.NodePools)
 	cluster, err = helper.AddNodePool(cluster, 1, client, false, false)
 	Expect(err).To(BeNil())
 
@@ -194,7 +194,7 @@ func updateClusterWhenUpdating(cluster *management.Cluster, client *rancher.Clie
 	Eventually(func() int {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).NotTo(HaveOccurred())
-		return len(cluster.AKSStatus.UpstreamSpec.NodePools)
+		return len(*cluster.AKSStatus.UpstreamSpec.NodePools)
 	}, "10m", "5s").Should(BeEquivalentTo(initialNPLength + 1))
 }
 

--- a/hosted/aks/p1/sync_import_test.go
+++ b/hosted/aks/p1/sync_import_test.go
@@ -13,6 +13,10 @@ import (
 var _ = Describe("SyncImport", func() {
 	var k8sVersion string
 	BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
+
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, false)
 		Expect(err).NotTo(HaveOccurred())

--- a/hosted/aks/p1/sync_provisioning_test.go
+++ b/hosted/aks/p1/sync_provisioning_test.go
@@ -13,6 +13,10 @@ import (
 var _ = Describe("SyncProvisioning", func() {
 	var k8sVersion string
 	BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
+
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, false)
 		Expect(err).NotTo(HaveOccurred())

--- a/hosted/eks/backup_restore/backup_restore_suite_test.go
+++ b/hosted/eks/backup_restore/backup_restore_suite_test.go
@@ -101,7 +101,8 @@ var _ = AfterEach(func() {
 
 func restoreNodesChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
-	initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
+	configNodeGroups := *cluster.EKSConfig.NodeGroups
+	initialNodeCount := *configNodeGroups[0].DesiredSize
 
 	By("scaling up the NodeGroup", func() {
 		var err error

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -80,7 +80,7 @@ func UpgradeClusterKubernetesVersion(cluster *management.Cluster, upgradeToVersi
 		// Check if the desired config is set correctly
 		Expect(*cluster.EKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
 		// ensure nodegroup version is still the same when config is applied
-		for _, ng := range cluster.EKSConfig.NodeGroups {
+		for _, ng := range *cluster.EKSConfig.NodeGroups {
 			Expect(*ng.Version).To(Equal(currentVersion))
 		}
 
@@ -94,7 +94,7 @@ func UpgradeClusterKubernetesVersion(cluster *management.Cluster, upgradeToVersi
 		}, tools.SetTimeout(15*time.Minute), 30*time.Second).Should(BeTrue())
 
 		// ensure nodegroup version is same in Rancher
-		for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+		for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 			Expect(*ng.Version).To(Equal(currentVersion))
 		}
 	}
@@ -110,8 +110,9 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 
 	if !useEksctl {
 		upgradedCluster := cluster
-		for i := range upgradedCluster.EKSConfig.NodeGroups {
-			upgradedCluster.EKSConfig.NodeGroups[i].Version = &upgradeToVersion
+		configNodeGroups := *upgradedCluster.EKSConfig.NodeGroups
+		for i := range configNodeGroups {
+			configNodeGroups[i].Version = &upgradeToVersion
 		}
 
 		cluster, err = client.Management.Cluster.Update(cluster, &upgradedCluster)
@@ -123,7 +124,7 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 		}
 	} else {
 		// Upgrade Nodegroup using eksctl due to custom Launch template
-		for _, ng := range cluster.EKSConfig.NodeGroups {
+		for _, ng := range *cluster.EKSConfig.NodeGroups {
 			err = UpgradeEKSNodegroupOnAWS(helpers.GetEKSRegion(), cluster.EKSConfig.DisplayName, *ng.NodegroupName, upgradeToVersion)
 			Expect(err).To(BeNil())
 		}
@@ -135,7 +136,7 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 			ginkgo.GinkgoLogr.Info("waiting for the nodegroup upgrade to appear in EKSStatus.UpstreamSpec ...")
-			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+			for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 				if ng.Version == nil || *ng.Version != upgradeToVersion {
 					return false
 				}
@@ -145,7 +146,7 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 	}
 
 	// Ensure nodegroup version is correct in Rancher after upgrade
-	for _, ng := range cluster.EKSConfig.NodeGroups {
+	for _, ng := range *cluster.EKSConfig.NodeGroups {
 		Expect(*ng.Version).To(Equal(upgradeToVersion))
 	}
 
@@ -156,15 +157,16 @@ func UpgradeNodeKubernetesVersion(cluster *management.Cluster, upgradeToVersion 
 // if checkClusterConfig is set to true, it will validate that nodegroup has been added successfully
 func AddNodeGroup(cluster *management.Cluster, increaseBy int, client *rancher.Client, wait, checkClusterConfig bool) (*management.Cluster, error) {
 	upgradedCluster := cluster
-	currentNodeGroupNumber := len(cluster.EKSConfig.NodeGroups)
+	currentNodeGroupNumber := len(*cluster.EKSConfig.NodeGroups)
 
 	// Workaround for eks-operator/issues/406
 	// We use management.EKSClusterConfigSpec instead of the usual eks.ClusterConfig to unmarshal the data without the need of a lot of post-processing.
 	var eksClusterConfig management.EKSClusterConfigSpec
 	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
-	ngTemplate := eksClusterConfig.NodeGroups[0]
+	nodeGroups := *eksClusterConfig.NodeGroups
+	ngTemplate := nodeGroups[0]
 
-	updateNodeGroupsList := cluster.EKSConfig.NodeGroups
+	updateNodeGroupsList := *cluster.EKSConfig.NodeGroups
 	for i := 1; i <= increaseBy; i++ {
 		newNodeGroup := management.NodeGroup{
 			NodegroupName: pointer.String(namegen.AppendRandomString("ng")),
@@ -176,15 +178,15 @@ func AddNodeGroup(cluster *management.Cluster, increaseBy int, client *rancher.C
 		}
 		updateNodeGroupsList = append([]management.NodeGroup{newNodeGroup}, updateNodeGroupsList...)
 	}
-	upgradedCluster.EKSConfig.NodeGroups = updateNodeGroupsList
+	upgradedCluster.EKSConfig.NodeGroups = &updateNodeGroupsList
 
 	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
 	Expect(err).To(BeNil())
 
 	if checkClusterConfig {
 		// Check if the desired config is set correctly
-		Expect(len(cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber+increaseBy))
-		for i, ng := range cluster.EKSConfig.NodeGroups {
+		Expect(len(*cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber+increaseBy))
+		for i, ng := range *cluster.EKSConfig.NodeGroups {
 			Expect(ng.NodegroupName).To(Equal(updateNodeGroupsList[i].NodegroupName))
 		}
 	}
@@ -200,10 +202,10 @@ func AddNodeGroup(cluster *management.Cluster, increaseBy int, client *rancher.C
 			ginkgo.GinkgoLogr.Info("Waiting for the total nodegroup count to increase in EKSStatus.UpstreamSpec ...")
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return len(cluster.EKSStatus.UpstreamSpec.NodeGroups)
+			return len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(BeNumerically("==", currentNodeGroupNumber+increaseBy))
 
-		for i, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+		for i, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 			Expect(ng.NodegroupName).To(Equal(updateNodeGroupsList[i].NodegroupName))
 		}
 	}
@@ -232,17 +234,18 @@ func AddNodeGroupToConfig(eksClusterConfig eks.ClusterConfig, ngCount int) (eks.
 // TODO: Modify this method to delete a custom qty of DeleteNodeGroup, perhaps by adding an `decreaseBy int` arg
 func DeleteNodeGroup(cluster *management.Cluster, client *rancher.Client, wait, checkClusterConfig bool) (*management.Cluster, error) {
 	upgradedCluster := cluster
-	currentNodeGroupNumber := len(cluster.EKSConfig.NodeGroups)
-	updateNodeGroupsList := cluster.EKSConfig.NodeGroups[:1]
-	upgradedCluster.EKSConfig.NodeGroups = updateNodeGroupsList
+	currentNodeGroupNumber := len(*cluster.EKSConfig.NodeGroups)
+	configNodeGroups := *cluster.EKSConfig.NodeGroups
+	updateNodeGroupsList := configNodeGroups[:1]
+	upgradedCluster.EKSConfig.NodeGroups = &updateNodeGroupsList
 
 	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
 	Expect(err).To(BeNil())
 
 	if checkClusterConfig {
 		// Check if the desired config is set correctly
-		Expect(len(cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber-1))
-		for i, ng := range cluster.EKSConfig.NodeGroups {
+		Expect(len(*cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber-1))
+		for i, ng := range *cluster.EKSConfig.NodeGroups {
 			Expect(ng.NodegroupName).To(Equal(updateNodeGroupsList[i].NodegroupName))
 		}
 	}
@@ -257,9 +260,9 @@ func DeleteNodeGroup(cluster *management.Cluster, client *rancher.Client, wait, 
 			ginkgo.GinkgoLogr.Info("Waiting for the total nodegroup count to decrease in EKSStatus.UpstreamSpec ...")
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return len(cluster.EKSStatus.UpstreamSpec.NodeGroups)
+			return len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(BeNumerically("==", currentNodeGroupNumber-1))
-		for i, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+		for i, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 			Expect(ng.NodegroupName).To(Equal(updateNodeGroupsList[i].NodegroupName))
 		}
 	}
@@ -271,9 +274,10 @@ func DeleteNodeGroup(cluster *management.Cluster, client *rancher.Client, wait, 
 // if checkClusterConfig is set to true, it will validate that nodegroup has been scaled successfully
 func ScaleNodeGroup(cluster *management.Cluster, client *rancher.Client, nodeCount int64, wait, checkClusterConfig bool) (*management.Cluster, error) {
 	upgradedCluster := cluster
-	for i := range upgradedCluster.EKSConfig.NodeGroups {
-		upgradedCluster.EKSConfig.NodeGroups[i].DesiredSize = pointer.Int64(nodeCount)
-		upgradedCluster.EKSConfig.NodeGroups[i].MaxSize = pointer.Int64(nodeCount)
+	configNodeGroups := *upgradedCluster.EKSConfig.NodeGroups
+	for i := range configNodeGroups {
+		configNodeGroups[i].DesiredSize = pointer.Int64(nodeCount)
+		configNodeGroups[i].MaxSize = pointer.Int64(nodeCount)
 	}
 
 	cluster, err := client.Management.Cluster.Update(cluster, &upgradedCluster)
@@ -281,8 +285,9 @@ func ScaleNodeGroup(cluster *management.Cluster, client *rancher.Client, nodeCou
 
 	if checkClusterConfig {
 		// Check if the desired config is set correctly
-		for i := range cluster.EKSConfig.NodeGroups {
-			Expect(*cluster.EKSConfig.NodeGroups[i].DesiredSize).To(BeNumerically("==", nodeCount))
+		configNodeGroups = *cluster.EKSConfig.NodeGroups
+		for i := range configNodeGroups {
+			Expect(*configNodeGroups[i].DesiredSize).To(BeNumerically("==", nodeCount))
 		}
 	}
 
@@ -297,8 +302,9 @@ func ScaleNodeGroup(cluster *management.Cluster, client *rancher.Client, nodeCou
 			ginkgo.GinkgoLogr.Info("Waiting for the node count change to appear in EKSStatus.UpstreamSpec ...")
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			for i := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
-				if ng := cluster.EKSStatus.UpstreamSpec.NodeGroups[i]; *ng.DesiredSize != nodeCount {
+			upstreamNodeGroups := *cluster.EKSStatus.UpstreamSpec.NodeGroups
+			for i := range upstreamNodeGroups {
+				if ng := upstreamNodeGroups[i]; *ng.DesiredSize != nodeCount {
 					return false
 				}
 			}
@@ -407,9 +413,10 @@ func UpdateClusterTags(cluster *management.Cluster, client *rancher.Client, tags
 // if wait is set to true, it waits until the update is complete; if checkClusterConfig is true, it validates the update
 func UpdateNodegroupMetadata(cluster *management.Cluster, client *rancher.Client, tags, labels map[string]string, checkClusterConfig bool) (*management.Cluster, error) {
 	upgradedCluster := cluster
-	for i := range upgradedCluster.EKSConfig.NodeGroups {
-		*upgradedCluster.EKSConfig.NodeGroups[i].Tags = tags
-		*upgradedCluster.EKSConfig.NodeGroups[i].Labels = labels
+	configNodeGroups := *upgradedCluster.EKSConfig.NodeGroups
+	for i := range configNodeGroups {
+		*configNodeGroups[i].Tags = tags
+		*configNodeGroups[i].Labels = labels
 	}
 
 	var err error
@@ -418,7 +425,7 @@ func UpdateNodegroupMetadata(cluster *management.Cluster, client *rancher.Client
 
 	if checkClusterConfig {
 		// Check if the desired config is set correctly
-		for _, ng := range cluster.EKSConfig.NodeGroups {
+		for _, ng := range *cluster.EKSConfig.NodeGroups {
 			for key, value := range tags {
 				Expect(*ng.Tags).Should(HaveKeyWithValue(key, value))
 			}
@@ -432,7 +439,7 @@ func UpdateNodegroupMetadata(cluster *management.Cluster, client *rancher.Client
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 
-			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+			for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 				if maps.Equal(tags, *ng.Tags) && maps.Equal(labels, *ng.Labels) {
 					return true
 				}

--- a/hosted/eks/k8s_chart_support/k8s_chart_support_suite_test.go
+++ b/hosted/eks/k8s_chart_support/k8s_chart_support_suite_test.go
@@ -94,23 +94,14 @@ func commonchecks(client *rancher.Client, cluster *management.Cluster) {
 	By("downgrading the chart version", func() {
 		helpers.DowngradeProviderChart(downgradedVersion)
 	})
+
 	configNodeGroups := *cluster.EKSConfig.NodeGroups
 	initialNodeCount := *configNodeGroups[0].DesiredSize
-	var upgradeSuccessful bool
 
 	By("making a change(scaling nodegroup up) to the cluster to validate functionality after chart downgrade", func() {
 		var err error
-		cluster, err = helper.ScaleNodeGroup(cluster, client, initialNodeCount+increaseBy, false, true)
+		cluster, err = helper.ScaleNodeGroup(cluster, client, initialNodeCount+increaseBy, true, true)
 		Expect(err).To(BeNil())
-
-		// We do not use WaitClusterToBeUpgraded because it has been flaky here and times out
-		Eventually(func() bool {
-			configNodeGroups = *cluster.EKSConfig.NodeGroups
-			for i := range configNodeGroups {
-				upgradeSuccessful = *configNodeGroups[i].DesiredSize == initialNodeCount+increaseBy
-			}
-			return upgradeSuccessful
-		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(BeTrue())
 	})
 
 	By("uninstalling the operator chart", func() {
@@ -134,11 +125,14 @@ func commonchecks(client *rancher.Client, cluster *management.Cluster) {
 		Eventually(func() bool {
 			GinkgoLogr.Info("Waiting for the node count change to appear in EKSStatus.UpstreamSpec ...")
 			Expect(err).To(BeNil())
-			upstreamNodeGroups := *cluster.EKSStatus.UpstreamSpec.NodeGroups
-			for i := range upstreamNodeGroups {
-				upgradeSuccessful = *upstreamNodeGroups[i].DesiredSize == initialNodeCount
+			cluster, err = client.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
+				if *ng.DesiredSize != initialNodeCount {
+					return false
+				}
 			}
-			return upgradeSuccessful
+			return true
 		}, tools.SetTimeout(15*time.Minute), 10*time.Second).Should(BeTrue())
 
 	})

--- a/hosted/eks/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
+++ b/hosted/eks/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
@@ -194,7 +194,8 @@ func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clus
 
 	By("making a change to the cluster (scaling the node up) to validate functionality after chart downgrade", func() {
 		var err error
-		initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
+		configNodeGroups := *cluster.EKSConfig.NodeGroups
+		initialNodeCount := *configNodeGroups[0].DesiredSize
 		cluster, err = helper.ScaleNodeGroup(cluster, ctx.RancherAdminClient, initialNodeCount+1, true, true)
 		Expect(err).To(BeNil())
 	})
@@ -204,7 +205,7 @@ func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clus
 	})
 
 	By("making a change(adding a nodepool) to the cluster to re-install the operator and validating it is re-installed to the latest/upgraded version", func() {
-		currentNodeGroupNumber := len(cluster.EKSConfig.NodeGroups)
+		currentNodeGroupNumber := len(*cluster.EKSConfig.NodeGroups)
 		var err error
 		cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, false)
 		Expect(err).To(BeNil())
@@ -219,7 +220,7 @@ func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clus
 		Eventually(func() int {
 			cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return len(cluster.EKSStatus.UpstreamSpec.NodeGroups)
+			return len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 		}, tools.SetTimeout(20*time.Minute), 10*time.Second).Should(BeNumerically("==", currentNodeGroupNumber+1))
 	})
 

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -91,7 +91,8 @@ func p0upgradeK8sVersionChecks(cluster *management.Cluster, client *rancher.Clie
 
 func p0NodesChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
-	initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
+	configNodeGroups := *cluster.EKSConfig.NodeGroups
+	initialNodeCount := *configNodeGroups[0].DesiredSize
 
 	By("scaling up the NodeGroup", func() {
 		var err error

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -172,7 +172,7 @@ var _ = Describe("P1Import", func() {
 			updateTagsAndLabels(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("Add a nodegroup in EKS -> Syncs to Rancher -> Update cluster, the nodegroup is intact", func() {
+		It("Add a nodegroup in EKS -> Syncs to Rancher -> Update cluster, the nodegroup is intact", func() {
 			testCaseID = 87
 			nodepoolcount := len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 			err := helper.AddNodeGroupOnAWS(namegen.AppendRandomString("ng"), clusterName, region)
@@ -204,7 +204,7 @@ var _ = Describe("P1Import", func() {
 				Expect(err).To(MatchError(ContainSubstring("cluster already exists for EKS cluster")))
 			})
 
-			FIt("Add node groups to the control-plane only cluster", func() {
+			It("Add node groups to the control-plane only cluster", func() {
 				testCaseID = 95
 
 				var err error

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -172,7 +172,7 @@ var _ = Describe("P1Import", func() {
 			updateTagsAndLabels(cluster, ctx.RancherAdminClient)
 		})
 
-		It("Add a nodegroup in EKS -> Syncs to Rancher -> Update cluster, the nodegroup is intact", func() {
+		FIt("Add a nodegroup in EKS -> Syncs to Rancher -> Update cluster, the nodegroup is intact", func() {
 			testCaseID = 87
 			nodepoolcount := len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 			err := helper.AddNodeGroupOnAWS(namegen.AppendRandomString("ng"), clusterName, region)
@@ -204,7 +204,7 @@ var _ = Describe("P1Import", func() {
 				Expect(err).To(MatchError(ContainSubstring("cluster already exists for EKS cluster")))
 			})
 
-			It("Add node groups to the control-plane only cluster", func() {
+			FIt("Add node groups to the control-plane only cluster", func() {
 				testCaseID = 95
 
 				var err error

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -14,6 +14,10 @@ import (
 var _ = Describe("P1Import", func() {
 	var k8sVersion string
 	BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
+
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
 		Expect(err).To(BeNil())

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -174,13 +174,13 @@ var _ = Describe("P1Import", func() {
 
 		It("Add a nodegroup in EKS -> Syncs to Rancher -> Update cluster, the nodegroup is intact", func() {
 			testCaseID = 87
-			nodepoolcount := len(cluster.EKSStatus.UpstreamSpec.NodeGroups)
+			nodepoolcount := len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 			err := helper.AddNodeGroupOnAWS(namegen.AppendRandomString("ng"), clusterName, region)
 			Expect(err).To(BeNil())
 			Eventually(func() bool {
 				cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
-				return len(cluster.EKSStatus.UpstreamSpec.NodeGroups) == nodepoolcount+1
+				return len(*cluster.EKSStatus.UpstreamSpec.NodeGroups) == nodepoolcount+1
 			}, "10m", "7s").Should(BeTrue(), "Timed out while waiting for rancher to sync")
 			cluster, err = helper.UpdateLogging(cluster, ctx.RancherAdminClient, []string{"authenticator"}, true)
 			Expect(err).To(BeNil())

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -186,7 +186,7 @@ var _ = Describe("P1Import", func() {
 			Expect(err).To(BeNil())
 
 			// verify that the nodegroups are intact
-			Expect(cluster.EKSStatus.UpstreamSpec.NodeGroups).To(HaveLen(nodepoolcount + 1))
+			Expect(*cluster.EKSStatus.UpstreamSpec.NodeGroups).To(HaveLen(nodepoolcount + 1))
 		})
 
 		It("Update the cloud creds", func() {
@@ -220,6 +220,8 @@ var _ = Describe("P1Import", func() {
 					Expect(err).To(BeNil())
 					return cluster.State == "waiting"
 				}, "5m", "15s").Should(BeTrue())
+
+				cluster.EKSConfig = cluster.EKSStatus.UpstreamSpec
 
 				By("adding a NodeGroup", func() {
 					cluster, err = helper.AddNodeGroup(cluster, 1, ctx.RancherAdminClient, false, true)

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -284,7 +284,7 @@ var _ = Describe("P1Provisioning", func() {
 
 				// upgrade 2 nodegroups simultaneously
 				updateFunc := func(cluster *management.Cluster) {
-					nodeGroups := cluster.EKSConfig.NodeGroups
+					nodeGroups := *cluster.EKSConfig.NodeGroups
 					for i := 0; i <= 1; i++ {
 						nodeGroups[i].Version = &upgradeToVersion
 					}
@@ -296,7 +296,7 @@ var _ = Describe("P1Provisioning", func() {
 				Eventually(func() bool {
 					cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 					Expect(err).To(BeNil())
-					nodeGroups := cluster.EKSStatus.UpstreamSpec.NodeGroups
+					nodeGroups := *cluster.EKSStatus.UpstreamSpec.NodeGroups
 					for i := 0; i <= 1; i++ {
 						if nodeGroups[i].Version == nil || *nodeGroups[i].Version != upgradeToVersion {
 							return false

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -21,6 +21,10 @@ import (
 var _ = Describe("P1Provisioning", func() {
 	var k8sVersion string
 	var _ = BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
+
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
 		Expect(err).To(BeNil())

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -414,10 +414,10 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 			return true
 		}, "10m", "5s").Should(BeTrue(), "Timed out waiting for EKS nodegroup labels to be added")
 
-		configNodeGroups := *cluster.EKSConfig.NodeGroups
 		upstreamNodeGroups = *cluster.EKSStatus.UpstreamSpec.NodeGroups
 		for key, value := range addLabels {
 			if !helpers.IsImport {
+				configNodeGroups := *cluster.EKSConfig.NodeGroups
 				Expect(*configNodeGroups[ngIndex].Labels).To(HaveKeyWithValue(key, value))
 			}
 			Expect(*upstreamNodeGroups[ngIndex].Labels).To(HaveKeyWithValue(key, value))

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -124,7 +124,7 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 
 		if !helpers.IsImport {
 			// For imported clusters, EKSConfig always has null values; so we check EKSConfig only when testing provisioned clusters
-			for _, ng := range cluster.EKSConfig.NodeGroups {
+			for _, ng := range *cluster.EKSConfig.NodeGroups {
 				Expect(*ng.Version).To(BeEquivalentTo(k8sVersion), "EKSConfig.NodePools check failed")
 			}
 		}
@@ -133,7 +133,7 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 	if upgradeNodeGroup {
 		By("upgrading the nodegroup", func() {
 			GinkgoLogr.Info(fmt.Sprintf("Upgrading Nodegroup's EKS version to %s", upgradeToVersion))
-			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+			for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 				err = helper.UpgradeEKSNodegroupOnAWS(region, clusterName, *ng.NodegroupName, upgradeToVersion)
 				Expect(err).To(BeNil())
 			}
@@ -142,7 +142,7 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 				GinkgoLogr.Info("Waiting for the nodegroup upgrade to appear in EKSStatus.UpstreamSpec ...")
 				cluster, err = client.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
-				for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+				for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 					if ng.Version == nil || *ng.Version != upgradeToVersion {
 						return false
 					}
@@ -153,7 +153,7 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 			if !helpers.IsImport {
 				// For imported clusters, EKSConfig always has null values; so we check EKSConfig only when testing provisioned clusters
 				Expect(*cluster.EKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
-				for _, ng := range cluster.EKSConfig.NodeGroups {
+				for _, ng := range *cluster.EKSConfig.NodeGroups {
 					Expect(ng.Version).ToNot(BeNil())
 					Expect(*ng.Version).To(BeEquivalentTo(upgradeToVersion), "EKSConfig.NodePools upgrade check failed")
 				}
@@ -231,7 +231,8 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 	})
 
 	By("scaling up the NodeGroup", func() {
-		ng := cluster.EKSStatus.UpstreamSpec.NodeGroups[0]
+		upstreamNodeGroups := *cluster.EKSStatus.UpstreamSpec.NodeGroups
+		ng := upstreamNodeGroups[0]
 		var nodeCount int64 = 2
 		if ng.DesiredSize != nil {
 			nodeCount = *ng.DesiredSize + 2
@@ -241,16 +242,18 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			updated := *cluster.EKSStatus.UpstreamSpec.NodeGroups[0].DesiredSize == nodeCount
+			upstreamNodeGroups = *cluster.EKSStatus.UpstreamSpec.NodeGroups
+			updated := *upstreamNodeGroups[0].DesiredSize == nodeCount
 			if !helpers.IsImport {
-				updated = updated && *cluster.EKSConfig.NodeGroups[0].DesiredSize == nodeCount
+				configNodeGroups := *cluster.EKSConfig.NodeGroups
+				updated = updated && *configNodeGroups[0].DesiredSize == nodeCount
 			}
 			return updated
 		}, "10m", "7s").Should(BeTrue(), "Timed out waiting for NodeGroup scale to show in Rancher")
 	})
 
 	var nodeName = namegen.AppendRandomString("ng")
-	ngCount := len(cluster.EKSStatus.UpstreamSpec.NodeGroups)
+	ngCount := len(*cluster.EKSStatus.UpstreamSpec.NodeGroups)
 	if helpers.IsImport {
 		// The following error is encountered when adding nodegroup to a non-eksctl managed i.e. rancher provisioned cluster; so we skip it for now
 		// Error: loading VPC spec for cluster "auto-eks-hp-ci-atiia": VPC configuration required for creating nodegroups on clusters not owned by eksctl: vpc.subnets, vpc.id, vpc.securityGroup
@@ -262,10 +265,10 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 			Eventually(func() bool {
 				cluster, err = client.Management.Cluster.ByID(cluster.ID)
 				Expect(err).To(BeNil())
-				if len(cluster.EKSStatus.UpstreamSpec.NodeGroups) != ngCount+1 {
+				if len(*cluster.EKSStatus.UpstreamSpec.NodeGroups) != ngCount+1 {
 					return false
 				}
-				for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+				for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 					if *ng.NodegroupName == nodeName {
 						return true
 					}
@@ -282,29 +285,30 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 			var err error
 			cluster, err = helper.AddNodeGroup(cluster, 1, client, true, true)
 			Expect(err).To(BeNil())
-			nodeName = *cluster.EKSConfig.NodeGroups[1].NodegroupName
+			configNodeGroups := *cluster.EKSConfig.NodeGroups
+			nodeName = *configNodeGroups[1].NodegroupName
 		}
 		err := helper.ModifyEKSNodegroupOnAWS(region, clusterName, nodeName, "delete", "--wait")
 		Expect(err).To(BeNil())
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			updated := len(cluster.EKSStatus.UpstreamSpec.NodeGroups) != ngCount
+			updated := len(*cluster.EKSStatus.UpstreamSpec.NodeGroups) != ngCount
 			if !helpers.IsImport {
-				updated = updated && len(cluster.EKSConfig.NodeGroups) != ngCount
+				updated = updated && len(*cluster.EKSConfig.NodeGroups) != ngCount
 			}
 			if updated {
 				return false
 			}
 			var nodeGroupPresentInUpstream, nodeGroupPresentInConfig bool
-			for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+			for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 				if *ng.NodegroupName == nodeName {
 					nodeGroupPresentInUpstream = true
 					break
 				}
 			}
 			if !helpers.IsImport {
-				for _, ng := range cluster.EKSConfig.NodeGroups {
+				for _, ng := range *cluster.EKSConfig.NodeGroups {
 					if *ng.NodegroupName == nodeName {
 						nodeGroupPresentInConfig = true
 						break
@@ -382,18 +386,21 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 	addLabels := map[string]string{"foo": "bar", "updated": "via-cli"}
 	const ngIndex = 0
 	By("add labels to Nodegroup", func() {
-		err := helper.UpdateNodeGroupLabelsOnAWS(clusterName, *cluster.EKSStatus.UpstreamSpec.NodeGroups[ngIndex].NodegroupName, region, addLabels, nil)
+		upstreamNodeGroups := *cluster.EKSStatus.UpstreamSpec.NodeGroups
+		err := helper.UpdateNodeGroupLabelsOnAWS(clusterName, *upstreamNodeGroups[ngIndex].NodegroupName, region, addLabels, nil)
 		Expect(err).To(BeNil())
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			upstreamLabels := *cluster.EKSStatus.UpstreamSpec.NodeGroups[ngIndex].Labels
+			upstreamNodeGroups = *cluster.EKSStatus.UpstreamSpec.NodeGroups
+			upstreamLabels := *upstreamNodeGroups[ngIndex].Labels
 
 			for key := range addLabels {
 				_, existUpstream := upstreamLabels[key]
 				var existConfig bool
 				if !helpers.IsImport {
-					configTags := *cluster.EKSConfig.NodeGroups[ngIndex].Labels
+					configNodeGroups := *cluster.EKSConfig.NodeGroups
+					configTags := *configNodeGroups[ngIndex].Labels
 					_, existConfig = configTags[key]
 				} else {
 					// if the cluster is imported, Config will be null, so we assign this variable to true to do easy check
@@ -407,11 +414,13 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 			return true
 		}, "10m", "5s").Should(BeTrue(), "Timed out waiting for EKS nodegroup labels to be added")
 
+		configNodeGroups := *cluster.EKSConfig.NodeGroups
+		upstreamNodeGroups = *cluster.EKSStatus.UpstreamSpec.NodeGroups
 		for key, value := range addLabels {
 			if !helpers.IsImport {
-				Expect(*cluster.EKSConfig.NodeGroups[ngIndex].Labels).To(HaveKeyWithValue(key, value))
+				Expect(*configNodeGroups[ngIndex].Labels).To(HaveKeyWithValue(key, value))
 			}
-			Expect(*cluster.EKSStatus.UpstreamSpec.NodeGroups[ngIndex].Labels).To(HaveKeyWithValue(key, value))
+			Expect(*upstreamNodeGroups[ngIndex].Labels).To(HaveKeyWithValue(key, value))
 		}
 	})
 
@@ -420,17 +429,20 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 		for key := range addLabels {
 			removeLabels = append(removeLabels, key)
 		}
-		err := helper.UpdateNodeGroupLabelsOnAWS(clusterName, *cluster.EKSStatus.UpstreamSpec.NodeGroups[ngIndex].NodegroupName, region, nil, removeLabels)
+		upstreamNodeGroups := *cluster.EKSStatus.UpstreamSpec.NodeGroups
+		err := helper.UpdateNodeGroupLabelsOnAWS(clusterName, *upstreamNodeGroups[ngIndex].NodegroupName, region, nil, removeLabels)
 		Expect(err).To(BeNil())
 		Eventually(func() bool {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			upstreamLabels := *cluster.EKSStatus.UpstreamSpec.NodeGroups[ngIndex].Labels
+			upstreamNodeGroups = *cluster.EKSStatus.UpstreamSpec.NodeGroups
+			upstreamLabels := *upstreamNodeGroups[ngIndex].Labels
 			for _, key := range removeLabels {
 				_, existsUpstream := upstreamLabels[key]
 				var existsConfig bool
 				if !helpers.IsImport {
-					configTags := *cluster.EKSConfig.NodeGroups[ngIndex].Labels
+					configNodeGroups := *cluster.EKSConfig.NodeGroups
+					configTags := *configNodeGroups[ngIndex].Labels
 					_, existsConfig = configTags[key]
 				}
 				if existsConfig || existsUpstream {
@@ -441,11 +453,13 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 			return true
 		}, "10m", "5s").Should(BeTrue(), "Timed out waiting for EKS nodegroup labels to be deleted")
 
+		configNodeGroups := *cluster.EKSConfig.NodeGroups
+		upstreamNodeGroups = *cluster.EKSStatus.UpstreamSpec.NodeGroups
 		for key, value := range addLabels {
 			if !helpers.IsImport {
-				Expect(*cluster.EKSConfig.NodeGroups[ngIndex].Labels).ToNot(HaveKeyWithValue(key, value))
+				Expect(*configNodeGroups[ngIndex].Labels).ToNot(HaveKeyWithValue(key, value))
 			}
-			Expect(*cluster.EKSStatus.UpstreamSpec.NodeGroups[ngIndex].Labels).ToNot(HaveKeyWithValue(key, value))
+			Expect(*upstreamNodeGroups[ngIndex].Labels).ToNot(HaveKeyWithValue(key, value))
 		}
 	})
 }
@@ -453,8 +467,9 @@ func syncAWSToRancherCheck(cluster *management.Cluster, client *rancher.Client, 
 func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client, k8sVersion, upgradeToVersion string) {
 	var err error
 	loggingTypes := []string{"api", "audit", "authenticator", "controllerManager", "scheduler"}
-	currentNodeGroupNumber := len(cluster.EKSConfig.NodeGroups)
-	initialNodeCount := *cluster.EKSConfig.NodeGroups[0].DesiredSize
+	currentNodeGroupNumber := len(*cluster.EKSConfig.NodeGroups)
+	configNodeGroups := *cluster.EKSConfig.NodeGroups
+	initialNodeCount := *configNodeGroups[0].DesiredSize
 
 	By("upgrading control plane", func() {
 		syncK8sVersionUpgradeCheck(cluster, client, false, k8sVersion, upgradeToVersion)
@@ -465,9 +480,9 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client, 
 		Expect(err).To(BeNil())
 
 		// Verify the existing details do NOT change in Rancher
-		for _, ng := range cluster.EKSConfig.NodeGroups {
+		for _, ng := range *cluster.EKSConfig.NodeGroups {
 			Expect(*ng.Version).To(BeEquivalentTo(k8sVersion))
-			Expect(len(cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber))
+			Expect(len(*cluster.EKSConfig.NodeGroups)).Should(BeNumerically("==", currentNodeGroupNumber))
 		}
 
 		// Verify the new edits reflect in AWS and existing details do NOT change
@@ -510,7 +525,7 @@ func syncRancherToAWSCheck(cluster *management.Cluster, client *rancher.Client, 
 
 		// Verify the existing details do NOT change in Rancher
 		Expect(*cluster.EKSConfig.KubernetesVersion).To(Equal(upgradeToVersion))
-		Expect(len(cluster.EKSConfig.NodeGroups)).To(Equal(currentNodeGroupNumber + 1))
+		Expect(len(*cluster.EKSConfig.NodeGroups)).To(Equal(currentNodeGroupNumber + 1))
 
 		// Verify the new edits reflect in AWS console and existing details do NOT change
 		var out string
@@ -564,7 +579,7 @@ func invalidAccessValuesCheck(cluster *management.Cluster, client *rancher.Clien
 
 func upgradeCPAndAddNgCheck(cluster *management.Cluster, client *rancher.Client, upgradeToVersion string) {
 	var err error
-	originalLen := len(cluster.EKSConfig.NodeGroups)
+	originalLen := len(*cluster.EKSConfig.NodeGroups)
 	newNodeGroupName := pointer.String(namegen.AppendRandomString("ng"))
 	GinkgoLogr.Info("Upgrading control plane to version:" + upgradeToVersion)
 
@@ -577,17 +592,18 @@ func upgradeCPAndAddNgCheck(cluster *management.Cluster, client *rancher.Client,
 	config.LoadConfig(eks.EKSClusterConfigConfigurationFileKey, &eksClusterConfig)
 
 	updateFunc := func(cluster *management.Cluster) {
-		var updatedNodeGroupsList []management.NodeGroup
-		newNodeGroup := eksClusterConfig.NodeGroups[0]
+		var updatedNodeGroupsList = make([]management.NodeGroup, 0)
+		nodeGroups := *eksClusterConfig.NodeGroups
+		newNodeGroup := nodeGroups[0]
 		newNodeGroup.NodegroupName = newNodeGroupName
 		updatedNodeGroupsList = append(updatedNodeGroupsList, newNodeGroup)
-		cluster.EKSConfig.NodeGroups = updatedNodeGroupsList
+		cluster.EKSConfig.NodeGroups = &updatedNodeGroupsList
 	}
 
 	cluster, err = helper.UpdateCluster(cluster, client, updateFunc)
 	Expect(err).To(BeNil())
-	Expect(len(cluster.EKSConfig.NodeGroups)).To(BeEquivalentTo(originalLen))
-	for _, ng := range cluster.EKSConfig.NodeGroups {
+	Expect(len(*cluster.EKSConfig.NodeGroups)).To(BeEquivalentTo(originalLen))
+	for _, ng := range *cluster.EKSConfig.NodeGroups {
 		Expect(ng.NodegroupName).To(Equal(newNodeGroupName))
 	}
 
@@ -599,7 +615,7 @@ func upgradeCPAndAddNgCheck(cluster *management.Cluster, client *rancher.Client,
 		GinkgoLogr.Info("Waiting for the version of new nodegroup to appear in EKSStatus.UpstreamSpec ...")
 		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(BeNil())
-		for _, ng := range cluster.EKSStatus.UpstreamSpec.NodeGroups {
+		for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
 			if ng.Version == nil || *ng.Version != upgradeToVersion {
 				return false
 			}
@@ -638,13 +654,14 @@ func updateTagsAndLabels(cluster *management.Cluster, client *rancher.Client) {
 		}
 	})
 
-	originalNGLabels := *cluster.EKSConfig.NodeGroups[0].Labels
+	configNodeGroups := *cluster.EKSConfig.NodeGroups
+	originalNGLabels := *configNodeGroups[0].Labels
 	// updatedNGLabels must contain both the original and the new tags
 	updatedNGLabels := make(map[string]string)
 	maps.Copy(updatedNGLabels, originalNGLabels)
 	maps.Copy(updatedNGLabels, labels)
 
-	originalNGTags := *cluster.EKSConfig.NodeGroups[0].Tags
+	originalNGTags := *configNodeGroups[0].Tags
 	// updatedNGTags must contain both the original and the new tags
 	updatedNGTags := make(map[string]string)
 	maps.Copy(updatedNGTags, originalNGTags)
@@ -657,7 +674,7 @@ func updateTagsAndLabels(cluster *management.Cluster, client *rancher.Client) {
 
 	By("Removing Nodegroup tags & labels", func() {
 		cluster, err = helper.UpdateNodegroupMetadata(cluster, client, originalNGTags, originalNGLabels, true)
-		for _, ng := range cluster.EKSConfig.NodeGroups {
+		for _, ng := range *cluster.EKSConfig.NodeGroups {
 			for key, value := range tags {
 				Expect(*ng.Tags).ToNot(HaveKeyWithValue(key, value))
 			}
@@ -701,4 +718,21 @@ func updateCloudCredentialsCheck(cluster *management.Cluster, client *rancher.Cl
 
 	cluster, err = helper.ScaleNodeGroup(cluster, client, 3, true, true)
 	Expect(err).To(BeNil())
+}
+
+// Automates Qase: 134 and
+func deleteAllNodeGroupsCheck(cluster *management.Cluster, client *rancher.Client) {
+	updateFunc := func(cluster *management.Cluster) {
+		// setting this to nil will do nothing, so we set it to empty array
+		cluster.EKSConfig.NodeGroups = &[]management.NodeGroup{}
+	}
+
+	var err error
+	_, err = helper.UpdateCluster(cluster, client, updateFunc)
+	Expect(err).ToNot(BeNil())
+	Expect(err.Error()).To(ContainSubstring("must have at least one nodegroup"))
+
+	updateFunc = func(cluster *management.Cluster) {
+		cluster.EKSConfig.NodeGroups = nil
+	}
 }

--- a/hosted/gke/backup_restore/backup_restore_suite_test.go
+++ b/hosted/gke/backup_restore/backup_restore_suite_test.go
@@ -102,7 +102,8 @@ var _ = AfterEach(func() {
 
 func restoreNodesChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
-	initialNodeCount := *cluster.GKEConfig.NodePools[0].InitialNodeCount
+	configNodePools := *cluster.GKEConfig.NodePools
+	initialNodeCount := *configNodePools[0].InitialNodeCount
 
 	By("scaling up the nodepool", func() {
 		var err error

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -96,8 +96,8 @@ func p0upgradeK8sVersionChecks(cluster *management.Cluster, client *rancher.Clie
 
 func p0NodesChecks(cluster *management.Cluster, client *rancher.Client, clusterName string) {
 	helpers.ClusterIsReadyChecks(cluster, client, clusterName)
-
-	initialNodeCount := *cluster.GKEConfig.NodePools[0].InitialNodeCount
+	configNodePools := *cluster.GKEConfig.NodePools
+	initialNodeCount := *configNodePools[0].InitialNodeCount
 
 	By("scaling up the nodepool", func() {
 		var err error

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -155,10 +155,10 @@ var _ = Describe("P1Import", func() {
 			testCaseID = 55
 			var err error
 			cluster, err = helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
-				updateNodePoolsList := cluster.GKEConfig.NodePools
+				updateNodePoolsList := *cluster.GKEConfig.NodePools
 				updateNodePoolsList[0].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
 
-				upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+				upgradedCluster.GKEConfig.NodePools = &updateNodePoolsList
 			})
 			Expect(err).To(BeNil())
 

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -14,6 +14,10 @@ import (
 
 var _ = Describe("P1Import", func() {
 	var _ = BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
+
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", false)
 		Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -117,12 +117,12 @@ var _ = Describe("P1Import", func() {
 			It("updating a cluster to all windows nodepool should fail", func() {
 				testCaseID = 264
 				_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
-					updateNodePoolsList := cluster.GKEConfig.NodePools
+					updateNodePoolsList := *cluster.GKEConfig.NodePools
 					for i := 0; i < len(updateNodePoolsList); i++ {
 						updateNodePoolsList[i].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
 					}
 
-					upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+					upgradedCluster.GKEConfig.NodePools = &updateNodePoolsList
 				})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("at least 1 Linux node pool is required"))

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -19,6 +19,10 @@ import (
 
 var _ = Describe("P1Provisioning", func() {
 	var _ = BeforeEach(func() {
+		// assigning cluster nil value so that every new test has a fresh value of the variable
+		// this is to avoid using residual value of a cluster in a test that does not use it
+		cluster = nil
+
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", false)
 		Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -82,7 +82,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		})
 
-		FIt("should fail to provision a cluster nodepools is nil", func() {
+		It("should fail to provision a cluster nodepools is nil", func() {
 			testCaseID = 27
 
 			updateFunc := func(clusterConfig *gke.ClusterConfig) {

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -78,7 +78,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		})
 
-		It("should fail to provision a cluster with no nodepools", func() {
+		FIt("should fail to provision a cluster nodepools is nil", func() {
 			testCaseID = 27
 
 			updateFunc := func(clusterConfig *gke.ClusterConfig) {
@@ -95,6 +95,17 @@ var _ = Describe("P1Provisioning", func() {
 				return clusterState.Transitioning == "error" && strings.Contains(clusterState.TransitioningMessage, "Cluster.initial_node_count must be greater than zero")
 			}, "60s", "2s").Should(BeTrue())
 
+		})
+
+		It("should fail to provision a cluster when nodepools is an empty array", func() {
+			updateFunc := func(clusterConfig *gke.ClusterConfig) {
+				clusterConfig.NodePools = []gke.NodePool{}
+			}
+
+			var err error
+			_, err = helper.CreateGKEHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, zone, "", project, updateFunc)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("must have at least one node pool"))
 		})
 	})
 
@@ -149,7 +160,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(err).To(BeNil())
 
 		Expect(*cluster.GKEConfig.KubernetesVersion).To(Equal(cpK8sVersion))
-		for _, np := range cluster.GKEConfig.NodePools {
+		for _, np := range *cluster.GKEConfig.NodePools {
 			Expect(*np.Version).To(Equal(cpK8sVersion))
 		}
 
@@ -164,7 +175,7 @@ var _ = Describe("P1Provisioning", func() {
 				return false
 			}
 
-			for _, np := range clusterState.GKEStatus.UpstreamSpec.NodePools {
+			for _, np := range *clusterState.GKEStatus.UpstreamSpec.NodePools {
 				if *np.Version != cpK8sVersion {
 					return false
 				}
@@ -245,12 +256,12 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 263
 
 			_, err := helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
-				updateNodePoolsList := cluster.GKEConfig.NodePools
+				updateNodePoolsList := *cluster.GKEConfig.NodePools
 				for i := 0; i < len(updateNodePoolsList); i++ {
 					updateNodePoolsList[i].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
 				}
 
-				upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+				upgradedCluster.GKEConfig.NodePools = &updateNodePoolsList
 			})
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("at least 1 Linux node pool is required"))
@@ -298,10 +309,10 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 34
 			var err error
 			cluster, err = helper.UpdateCluster(cluster, ctx.RancherAdminClient, func(upgradedCluster *management.Cluster) {
-				updateNodePoolsList := cluster.GKEConfig.NodePools
+				updateNodePoolsList := *cluster.GKEConfig.NodePools
 				updateNodePoolsList[0].Config.ImageType = "WINDOWS_LTSC_CONTAINERD"
 
-				upgradedCluster.GKEConfig.NodePools = updateNodePoolsList
+				upgradedCluster.GKEConfig.NodePools = &updateNodePoolsList
 			})
 
 			Eventually(func() bool {


### PR DESCRIPTION
### What does this PR do?
This PR upgrades r/shepherd which has breaking changes, so it also adds fixes.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable)
    - [P0 All :green_circle: except GKE Import ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13110476323)
    - [P1](https://github.com/rancher/hosted-providers-e2e/actions/runs/13112324904), [P1 GKE :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13120743928), [P1 AKS failed tests from the first run :green_circle:](https://github.com/rancher/hosted-providers-e2e/actions/runs/13130651287/job/36634972571), [P1 EKS import failed tests from first run :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13130645654/job/36634952053)
    - [Sync :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13154142147)
    - [K8s Chart Support and Support Matrix :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13162300806), [Run#2GKE#SupportMatrix :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13183540527), [Run#2EKS#K8s Chart Support :green_circle: (failure at adding summary) ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13183531975)
    - [GKE Sync Prov](https://github.com/rancher/hosted-providers-e2e/actions/runs/13196101175/job/36837727482)
    - [EKS P0 :green_circle:](https://github.com/rancher/hosted-providers-e2e/actions/runs/13195445409/job/36835842173)
    - [K8s Chart Support Upgrade Matrix :green_circle: (failure in Add summary step)](https://github.com/rancher/hosted-providers-e2e/actions/runs/13198274042)

### Special notes for your reviewer:
