### PR TITLE
Use nightly artifacts from ghcr.io instead of ttl.sh

### DIFF
--- a/install_test.go
+++ b/install_test.go
@@ -56,10 +56,10 @@ var _ = Describe("Provision k3s cluster and Rancher", Label("install"), func() {
 				buildDate := time.Now().Format("20060102")
 
 				RunHelmCmdWithRetry("upgrade", "--install", "rancher-"+providerOperator+"-operator-crds",
-					"oci://ttl.sh/"+providerOperator+"-operator/rancher-"+providerOperator+"-operator-crd",
+					"oci://ghcr.io/rancher/rancher-"+providerOperator+"-operator-crd-chart/rancher-"+providerOperator+"-operator-crd",
 					"--version", buildDate)
 				RunHelmCmdWithRetry("upgrade", "--install", "rancher-"+providerOperator+"-operator",
-					"oci://ttl.sh/"+providerOperator+"-operator/rancher-"+providerOperator+"-operator",
+					"oci://ghcr.io/rancher/rancher-"+providerOperator+"-operator-chart/rancher-"+providerOperator+"-operator",
 					"--version", buildDate, "--namespace", "cattle-system")
 			})
 		}


### PR DESCRIPTION
### What does this PR do?
Switching to new nightly operator (charts and images) location from ttl.sh -> ghcr.io

ttl.sh can be used by anybody anonymously even for pushing artifacts, Yiannis decided to use secure ghcr.io. The charts and images should be still building and available from ttl.sh but we should abandon it.

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable) AKS only https://github.com/rancher/hosted-providers-e2e/actions/runs/12806897053 (GKE and EKS tested locally)

