### PR TITLE
Qase reporting improvements

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
-run-name: AKS ${{ inputs.downstream_k8s_minor_version }} on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.30.5+k3s1' }}
+run-name: AKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.30.5+k3s1' }}
 
 on:
   schedule:
@@ -35,8 +35,6 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
-      downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g. 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -63,7 +61,6 @@ jobs:
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 4 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 4 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
-      downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}

--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -35,6 +35,10 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -44,10 +48,10 @@ on:
         type: string
         required: true
         default: p0_provisioning/p0_import
-      proxy:
-        description: Install Rancher behind proxy
-        type: boolean
-        default: false
+      qase_run_id:
+        description: Qase run ID where the results will be reported (auto|none|existing_run_id)
+        default: none
+        type: string
 
 jobs:
   aks-e2e:
@@ -64,3 +68,4 @@ jobs:
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}
+      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -35,6 +35,10 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -44,10 +48,11 @@ on:
         type: string
         required: true
         default: p0_provisioning/p0_import
-      proxy:
-        description: Install Rancher behind proxy
-        type: boolean
-        default: false
+      qase_run_id:
+        description: Qase run ID where the results will be reported (auto|none|existing_run_id)
+        default: none
+        type: string
+
 
 jobs:
   eks-e2e:
@@ -64,3 +69,4 @@ jobs:
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}
+      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
-run-name: EKS ${{ inputs.downstream_k8s_minor_version }} on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.30.5+k3s1' }}
+run-name: EKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.30.5+k3s1' }}
 
 on:
   schedule:
@@ -35,8 +35,6 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
-      downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g. 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -63,7 +61,6 @@ jobs:
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 4 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 4 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
-      downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
-run-name: GKE ${{ inputs.downstream_k8s_minor_version }} on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.30.5+k3s1' }}
+run-name: GKE on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.30.5+k3s1' }}
 
 on:
   schedule:
@@ -35,8 +35,6 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
-      downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g. 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -63,7 +61,6 @@ jobs:
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 4 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 4 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
-      downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -35,6 +35,10 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -44,10 +48,10 @@ on:
         type: string
         required: true
         default: p0_provisioning/p0_import
-      proxy:
-        description: Install Rancher behind proxy
-        type: boolean
-        default: false
+      qase_run_id:
+        description: Qase run ID where the results will be reported (auto|none|existing_run_id)
+        default: none
+        type: string
 
 jobs:
   gke-e2e:
@@ -64,3 +68,4 @@ jobs:
       rancher_installed: ${{ inputs.rancher_installed || 'hostname/password' }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}
+      qase_run_id: ${{ inputs.qase_run_id || 'auto' }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,9 @@ on:
       backup_operator_version:
         description: Backup Restore operator version
         type: string
+      qase_run_id:
+        description: Qase run ID to use for reporting
+        type: string
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -161,6 +164,43 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Create/Export Qase Run
+        id: qase
+        env:
+          QASE_RUN_NAME: ${{ github.event_name == 'workflow_dispatch' && inputs.rancher_version || github.workflow }}
+        run: |
+          case ${{ inputs.qase_run_id }} in
+            'auto')
+              # Define and export URL of GH test run in Qase run description
+              GH_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              export QASE_RUN_DESCRIPTION="${GH_RUN_URL}"
+              # Use full rancher version
+              QASE_RUN_NAME=$(echo $QASE_RUN_NAME | grep -P '[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+[0-9]+)?' || true)
+              # Or workflow name if the full rancher version is not found
+              if [ -z "$QASE_RUN_NAME" ]; then
+                QASE_RUN_NAME="${{ github.workflow }}"
+              fi
+              # Create a Qase run, get its ID
+              ID=$(go run ${{ env.QASE_HELPER }} -create)
+              # Export outputs for future use
+              echo "qase_run_description=${QASE_RUN_DESCRIPTION}" >> ${GITHUB_OUTPUT}
+              echo "qase_run_id=${ID}" >> ${GITHUB_OUTPUT}
+              echo "qase_run_name=${QASE_RUN_NAME}" >> ${GITHUB_OUTPUT}
+              # Just an info for debugging purposes
+              echo -e "Exported values:\nQASE_RUN_ID=${ID}\nQASE_RUN_DESCRIPTION=${QASE_RUN_DESCRIPTION}\nQASE_RUN_NAME=${QASE_RUN_NAME}"
+              ;;
+            'none')
+              echo "qase_run_id=" >> ${GITHUB_OUTPUT}
+              echo "### Test not reported in QASE!" >> ${GITHUB_STEP_SUMMARY}
+              unset QASE_REPORT
+              unset QASE_API_TOKEN
+              ;;
+            [0-9]*)
+              # If the run ID has been specified
+              echo "qase_run_id=${{ inputs.qase_run_id }}" >> ${GITHUB_OUTPUT}
+              ;;
+          esac
+
       - name: Install k3s / Helm / CertManager / Rancher
         id: prepare-rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
@@ -205,22 +245,6 @@ jobs:
           unzip awscliv2.zip
           sudo ./aws/install
           rm -rf awscliv2.zip aws/
-
-      - name: Create/Export Qase Run
-        id: qase
-        run: |
-          # Define and export URL of GH test run in Qase run description
-          GH_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          export QASE_RUN_DESCRIPTION="${GH_RUN_URL}"
-          export QASE_RUN_NAME="${{ env.PROVIDER }}-p0-${{ inputs.rancher_version }}"
-    
-          # Create a Qase run, get its ID
-          ID=$(go run ${{ env.QASE_HELPER }} -create)
-          # Export outputs for future use
-          echo "qase_run_id=${ID}" >> ${GITHUB_OUTPUT}
-
-          # Just an info for debugging purposes
-          echo -e "Exported values:\nQASE_RUN_ID=${ID}\nQASE_RUN_DESCRIPTION=${QASE_RUN_DESCRIPTION}\nQASE_RUN_NAME=${QASE_RUN_NAME}"
 
       - name: Provisioning cluster tests
         if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p0_provisioning') }}
@@ -340,16 +364,24 @@ jobs:
       - name: Finalize Qase Run and publish Results
         env:
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.qase.outcome == 'success' }}
         run: |
           REPORT=$(go run ${{ env.QASE_HELPER }} -publish)
           echo "${REPORT}"
+
+          # Extract report URL and put it in summary
+          REPORT_URL=$(awk '/available:/ { print $NF }' <<<${REPORT})
+          if [[ -n "${REPORT_URL}" ]]; then
+            echo "## QASE Reporting" >> ${GITHUB_STEP_SUMMARY}
+            echo "Public Qase report: ${REPORT_URL}" >> ${GITHUB_STEP_SUMMARY}
+          fi
   
-      - name: Delete Qase Run if job has been cancelled
+      - name: Delete Qase Run if job cancelled or not using existing id
         env:
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-        if: ${{ cancelled() }}
-        run: go run ${{ env.QASE_HELPER }} -delete
+        if: ${{ cancelled() && steps.qase.outcome == 'success' && inputs.qase_run_id == 'auto' }}
+        run: |
+          go run ${{ env.QASE_HELPER }} -delete
 
       - name: Collect logs
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,9 +33,6 @@ on:
         description: Runner template to use
         required: true
         type: string
-      downstream_k8s_minor_version:
-        description: Downstream cluster K8s version to test
-        type: string
       downstream_cluster_cleanup:
         description: Cleanup downstream clusters after test
         type: boolean
@@ -66,7 +63,6 @@ env:
   QASE_RUN_COMPLETE: 1
   RANCHER_LOG_COLLECTOR: ${{ github.workspace }}/.github/scripts/collect-rancher-logs.sh
   GCP_RUNNER_ZONE: asia-south2-c
-  DOWNSTREAM_K8S_MINOR_VERSION: ${{ inputs.downstream_k8s_minor_version }}
   DOWNSTREAM_CLUSTER_CLEANUP: ${{ inputs.downstream_cluster_cleanup }}
   QASE_HELPER: ${{ github.workspace }}/hosted/helpers/qase/helper_qase.go
 jobs:
@@ -294,7 +290,6 @@ jobs:
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-          DOWNSTREAM_K8S_MINOR_VERSION: ${{ env.DOWNSTREAM_K8S_MINOR_VERSION }}
         run: |
           make e2e-k8s-chart-support-provisioning-tests
 
@@ -306,7 +301,6 @@ jobs:
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
           KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-          DOWNSTREAM_K8S_MINOR_VERSION: ${{ env.DOWNSTREAM_K8S_MINOR_VERSION }}
         run: |
           make e2e-k8s-chart-support-import-tests
 
@@ -317,7 +311,6 @@ jobs:
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          DOWNSTREAM_K8S_MINOR_VERSION: ${{ env.DOWNSTREAM_K8S_MINOR_VERSION }}
         run: |
           make e2e-sync-provisioning-tests
 
@@ -328,7 +321,6 @@ jobs:
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          DOWNSTREAM_K8S_MINOR_VERSION: ${{ env.DOWNSTREAM_K8S_MINOR_VERSION }}
         run: |
           make e2e-sync-import-tests
 
@@ -385,7 +377,6 @@ jobs:
           echo "## General information" >> ${GITHUB_STEP_SUMMARY}
           echo "Rancher Manager Version: ${{ inputs.rancher_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "K3s on Rancher Manager: ${{ inputs.k3s_version }}" >> ${GITHUB_STEP_SUMMARY}
-          echo "Downstream ${{ inputs.hosted_provider }} minor version: ${{ inputs.downstream_k8s_minor_version }}" >> ${GITHUB_STEP_SUMMARY}
           echo "Tests run: ${{ inputs.tests_to_run }}" >> ${GITHUB_STEP_SUMMARY}
           OPERATOR_HELM_VERSION=$(helm get metadata rancher-${{ inputs.hosted_provider }}-operator -n cattle-system -o json | jq -r .version)
           echo "Installed rancher-${{ inputs.hosted_provider }}-operator chart version: $OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -31,8 +31,6 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
-      downstream_k8s_minor_version:
-        description: Downstream cluster minor K8s version to test (e.g., 1.30)
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -62,7 +60,6 @@ jobs:
       tests_to_run: ${{ inputs.tests_to_run }}
       destroy_runner: ${{ inputs.destroy_runner }}
       runner_template: ${{ inputs.runner_template }}
-      downstream_k8s_minor_version: ${{ inputs.downstream_k8s_minor_version }}
       rancher_installed: ${{ inputs.rancher_installed }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup }}
       proxy: ${{ inputs.proxy }}

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -31,6 +31,10 @@ on:
         description: Cleanup downstream clusters after test
         default: true
         type: boolean
+      proxy:
+        description: Install Rancher behind proxy
+        type: boolean
+        default: false
       rancher_installed:
         description: Rancher details if already installed
         default: 'hostname/password'
@@ -39,10 +43,9 @@ on:
         description: Tests to run
         required: true
         default: p0_provisioning/p0_import
-      proxy:
-        description: Install Rancher behind proxy
-        type: boolean
-        default: false
+      backup_operator_version:
+        description: Backup Restore operator version (eg. 6.0.0)
+        type: string
 
 jobs:
   e2e-tests:
@@ -63,3 +66,5 @@ jobs:
       rancher_installed: ${{ inputs.rancher_installed }}
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup }}
       proxy: ${{ inputs.proxy }}
+      backup_operator_version: ${{ inputs.backup_operator_version }}
+


### PR DESCRIPTION
### What does this PR do?
Mainly borrowed from https://github.com/rancher/rancher-turtles-e2e/pull/60

Brings new input field for github actions where you can enter auto (default), none or existing_qase_run_id.
`auto` ... uses next available qase_run_id
`none` ... no report created (default)
`run_id` ... overrides existing qase test run report

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #121 

### Checklist:
- [x] Squashed commits into logical changes
- [x] GitHub Actions:
Testruns:
https://github.com/rancher/hosted-providers-e2e/actions/runs/12912527860 for `auto`
https://github.com/rancher/hosted-providers-e2e/actions/runs/12912553702 for `none (and cancelled)`
https://github.com/rancher/hosted-providers-e2e/actions/runs/12912539030 for `existing_id=1884`
https://github.com/rancher/hosted-providers-e2e/actions/runs/12912547755 for `existing_id=1871 (and cancelled)`