### PR TITLE
Use static EKS versions

### DIFF
--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -348,6 +348,7 @@ func CheckMapKeys(map1, map2 map[string]string) (exists bool) {
 // DefaultK8sVersion receives a list of version sorted in descending order (1.29, 1.28, 1.27, etc.);
 // it returns the k8s version to be used by the test depending on forUpgrade param
 func DefaultK8sVersion(descVersions []string, forUpgrade bool) (string, error) {
+	fmt.Printf("List of versions: %v\n", descVersions)
 	if !forUpgrade {
 		return descVersions[0], nil
 	}

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -414,3 +414,12 @@ func GetRancherVersions() (string, string, string) {
 	}
 	return rancherChannel, rancherVersion, rancherHeadVersion
 }
+
+// GetRancherServerVersion returns the value of `server-version` Setting
+func GetRancherServerVersion(client *rancher.Client) (string, error) {
+	serverVersion, err := client.Management.Setting.ByID("server-version")
+	if err != nil {
+		return "", err
+	}
+	return serverVersion.Value, nil
+}


### PR DESCRIPTION
### What does this PR do?
- This PR modifies `ListEKSAllVersions` to use a static version list in the same way the UI team does.
- `ListEKSAvailableVersions` has also been modified to use local `ListEKSAllVersions`.
- Add `GetRancherServerVersion` function to fetch the rancher server version via rancher API endpoint `/v3/settings`.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) 
    - [latest/devel/head P0 Prov k8sVersion: 1.30, upgradeK8sVersion: 1.31 (highest UI supported version) :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13070673133)
    - [latest/2.9.3 P0 Prov](https://github.com/rancher/hosted-providers-e2e/actions/runs/13070681264)
    - [latest/devel/2.10 P0 Prov :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/13070691743)

### Special notes for your reviewer:
