### PR TITLE
Refactor main branch to run tests on multiple Rancher versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -441,6 +441,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Add summary
+        shell: bash
         if: ${{ always() && steps.prepare-rancher.outcome == 'success' }}
         run: |
           # Add summary
@@ -450,7 +451,7 @@ jobs:
           echo "Tests run: ${{ inputs.tests_to_run }}" >> ${GITHUB_STEP_SUMMARY}
           OPERATOR_HELM_VERSION=$(helm get metadata rancher-${{ inputs.hosted_provider }}-operator -n cattle-system -o json | jq -r .version)
           echo "Installed rancher-${{ inputs.hosted_provider }}-operator chart version: $OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}
-          if [ ${{ inputs.tests_to_run }} =~ "backup_restore" ]; then
+          if [[ ${{ inputs.tests_to_run }} =~ "backup_restore" ]]; then
             BR_OPERATOR_HELM_VERSION=$(helm get metadata rancher-backup -n cattle-resources-system -o json | jq -r .version)
             echo "Installed backup-restore operator chart version: $BR_OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}
           fi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -123,6 +123,9 @@ jobs:
     env:
       # For some reason the go doesn't link by default against system libresolv library
       CGO_LDFLAGS: -O2 -g -lresolv
+      KUBECONFIG: /etc/rancher/k3s/k3s.yaml
+      INSTALL_K3S_VERSION: ${{ inputs.k3s_version }}
+      RANCHER_VERSION: ${{ inputs.rancher_version }}
     outputs:
       PUBLIC_IP: ${{ steps.runner-ip.outputs.PUBLIC_IP }}
     steps:
@@ -213,9 +216,6 @@ jobs:
         id: prepare-rancher
         if: ${{ inputs.rancher_installed == 'hostname/password' }}
         env:
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-          INSTALL_K3S_VERSION: ${{ inputs.k3s_version }}
-          RANCHER_VERSION: ${{ inputs.rancher_version }}
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           PROXY_HOST: ${{ env.PROXY_HOST }}
@@ -256,7 +256,7 @@ jobs:
           rm -rf awscliv2.zip aws/
 
       - name: Provisioning cluster tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p0_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p0_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -266,7 +266,7 @@ jobs:
           make e2e-provisioning-tests
 
       - name: Import cluster tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p0_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p0_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -276,7 +276,7 @@ jobs:
           make e2e-import-tests
 
       - name: Provisioning cluster P1 tests
-        if:  ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p1_provisioning') }}
+        if:  ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p1_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -286,7 +286,7 @@ jobs:
           make e2e-p1-provisioning-tests
 
       - name: Import cluster P1 tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'p1_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'p1_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -296,7 +296,7 @@ jobs:
           make e2e-p1-import-tests
 
       - name: Support matrix provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'support_matrix_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'support_matrix_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -306,7 +306,7 @@ jobs:
           make e2e-support-matrix-provisioning-tests
 
       - name: Support matrix import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'support_matrix_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'support_matrix_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -316,29 +316,27 @@ jobs:
           make e2e-support-matrix-import-tests
 
       - name: K8s Chart Support provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'k8s_chart_support_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'k8s_chart_support_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
           make e2e-k8s-chart-support-provisioning-tests
 
       - name: K8s Chart Support import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'k8s_chart_support_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'k8s_chart_support_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
           make e2e-k8s-chart-support-import-tests
 
       - name: Sync provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'sync_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'sync_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -348,7 +346,7 @@ jobs:
           make e2e-sync-provisioning-tests
 
       - name: Sync import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'sync_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'sync_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
@@ -358,54 +356,46 @@ jobs:
           make e2e-sync-import-tests
 
       - name: Backup/Restore provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'backup_restore_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'backup_restore_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
-          RANCHER_VERSION: ${{ inputs.rancher_version }}
           BACKUP_OPERATOR_VERSION: ${{ inputs.backup_operator_version }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
           make e2e-backup-restore-provisioning-tests
 
       - name: Backup/Restore import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'backup_restore_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'backup_restore_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
-          RANCHER_VERSION: ${{ inputs.rancher_version }}
           BACKUP_OPERATOR_VERSION: ${{ inputs.backup_operator_version }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         run: |
           make e2e-backup-restore-import-tests
 
       - name: K8s Chart Support Upgrade provisioning tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'k8s_chart_support_upgrade_provisioning') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'k8s_chart_support_upgrade_provisioning') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-          RANCHER_VERSION: ${{ inputs.rancher_version }}
           RANCHER_UPGRADE_VERSION: ${{ inputs.rancher_upgrade_version }}
           K8S_UPGRADE_MINOR_VERSION: ${{ inputs.k8s_upgrade_minor_version }}
         run: |
           make e2e-k8s-chart-support-provisioning-tests-upgrade
 
       - name: K8s Chart Support Upgrade import tests
-        if: ${{ !cancelled() && steps.prepare-rancher.outcome != 'failure' && contains(inputs.tests_to_run, 'k8s_chart_support_upgrade_import') }}
+        if: ${{ !cancelled() && steps.prepare-rancher.outcome == 'success' && contains(inputs.tests_to_run, 'k8s_chart_support_upgrade_import') }}
         env:
           RANCHER_HOSTNAME: ${{ env.RANCHER_HOSTNAME }}
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
-          RANCHER_VERSION: ${{ inputs.rancher_version }}
           RANCHER_UPGRADE_VERSION: ${{ inputs.rancher_upgrade_version }}
           K8S_UPGRADE_MINOR_VERSION: ${{ inputs.k8s_upgrade_minor_version }}
         run: |
@@ -451,8 +441,6 @@ jobs:
           if-no-files-found: ignore
 
       - name: Add summary
-        env:
-          KUBECONFIG: /etc/rancher/k3s/k3s.yaml
         if: ${{ always() && steps.prepare-rancher.outcome == 'success' }}
         run: |
           # Add summary
@@ -462,7 +450,7 @@ jobs:
           echo "Tests run: ${{ inputs.tests_to_run }}" >> ${GITHUB_STEP_SUMMARY}
           OPERATOR_HELM_VERSION=$(helm get metadata rancher-${{ inputs.hosted_provider }}-operator -n cattle-system -o json | jq -r .version)
           echo "Installed rancher-${{ inputs.hosted_provider }}-operator chart version: $OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}
-          if [ ${{ inputs.tests_to_run }} == "backup_restore" ]; then
+          if [ ${{ inputs.tests_to_run }} =~ "backup_restore" ]; then
             BR_OPERATOR_HELM_VERSION=$(helm get metadata rancher-backup -n cattle-resources-system -o json | jq -r .version)
             echo "Installed backup-restore operator chart version: $BR_OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}
           fi

--- a/hosted/aks/helper/helper_cluster.go
+++ b/hosted/aks/helper/helper_cluster.go
@@ -448,7 +448,7 @@ func UpdateAutoScaling(cluster *management.Cluster, client *rancher.Client, enab
 				}
 			}
 			return true
-		}, tools.SetTimeout(7*time.Minute), 5*time.Second).Should(BeTrue())
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(BeTrue())
 	}
 	return cluster, nil
 }

--- a/hosted/aks/p0/p0_import_test.go
+++ b/hosted/aks/p0/p0_import_test.go
@@ -66,10 +66,13 @@ var _ = Describe("P0Import", func() {
 			})
 
 			AfterEach(func() {
-				if ctx.ClusterCleanup && cluster != nil {
-					err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
-					err = helper.DeleteAKSClusteronAzure(clusterName)
+				if ctx.ClusterCleanup {
+					if cluster != nil && cluster.ID != "" {
+						GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+						err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+						Expect(err).To(BeNil())
+					}
+					err := helper.DeleteAKSClusteronAzure(clusterName)
 					Expect(err).To(BeNil())
 				} else {
 					fmt.Println("Skipping downstream cluster deletion: ", clusterName)

--- a/hosted/aks/p0/p0_import_test.go
+++ b/hosted/aks/p0/p0_import_test.go
@@ -48,9 +48,10 @@ var _ = Describe("P0Import", func() {
 	} {
 		testData := testData
 		When("a cluster is imported", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping upgrade tests ...")
+				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/aks/p0/p0_provisioning_test.go
+++ b/hosted/aks/p0/p0_provisioning_test.go
@@ -63,9 +63,12 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).To(BeNil())
 			})
 			AfterEach(func() {
-				if ctx.ClusterCleanup && cluster != nil {
-					err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
+				if ctx.ClusterCleanup {
+					if cluster != nil && cluster.ID != "" {
+						GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+						err := helper.DeleteAKSHostCluster(cluster, ctx.RancherAdminClient)
+						Expect(err).To(BeNil())
+					}
 				} else {
 					fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 				}

--- a/hosted/aks/p0/p0_provisioning_test.go
+++ b/hosted/aks/p0/p0_provisioning_test.go
@@ -49,9 +49,10 @@ var _ = Describe("P0Provisioning", func() {
 	} {
 		testData := testData
 		When("a cluster is created", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping upgrade tests ...")
+				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/aks/p0/p0_suite_test.go
+++ b/hosted/aks/p0/p0_suite_test.go
@@ -35,6 +35,7 @@ const (
 
 var (
 	ctx         helpers.RancherContext
+	cluster     *management.Cluster
 	clusterName string
 	testCaseID  int64
 	location    = helpers.GetAKSLocation()
@@ -53,6 +54,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
+	// Setting this to nil ensures we do not use the `cluster` variable value from another test running in parallel with this one.
+	cluster = nil
 	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 })
 

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -6,17 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
 var _ = Describe("P1Import", func() {
-	var (
-		cluster    *management.Cluster
-		k8sVersion string
-	)
+	var k8sVersion string
 	BeforeEach(func() {
 		GinkgoLogr.Info(fmt.Sprintf("Running on process: %d", GinkgoParallelProcess()))
 
@@ -78,6 +74,9 @@ var _ = Describe("P1Import", func() {
 		})
 
 		It("should be able to update cluster monitoring", func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			testCaseID = 271
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
@@ -99,7 +98,7 @@ var _ = Describe("P1Import", func() {
 				// Wait until the cluster no longer exists
 				_, err := ctx.RancherAdminClient.Management.Cluster.ByID(clusterID)
 				return err
-			}, "10s", "1s").ShouldNot(BeNil())
+			}, "30s", "3s").ShouldNot(BeNil())
 			cluster, err = helper.ImportAKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, location, helpers.GetCommonMetadataLabels())
 			Expect(err).To(BeNil())
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
@@ -108,6 +107,9 @@ var _ = Describe("P1Import", func() {
 	})
 
 	It("should successfully Import a cluster in Region without AZ", func() {
+		if helpers.SkipUpgradeTests {
+			Skip("Skipping test for v2.8 ...")
+		}
 		location = "ukwest"
 		testCaseID = 276
 
@@ -142,6 +144,10 @@ var _ = Describe("P1Import", func() {
 	When("a cluster with custom kubelet and os config is created and imported for upgrade", func() {
 		var upgradeToVersion string
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			kubeletConfigJsonData := `{"cpuManagerPolicy": "static", "cpuCfsQuota": true, "cpuCfsQuotaPeriod": "200ms", "imageGcHighThreshold": 90, "imageGcLowThreshold": 70, "topologyManagerPolicy": "best-effort", "allowedUnsafeSysctls": ["kernel.msg*","net.*"], "failSwapOn": false}`
 			kubeletConfigDotJson, err := os.CreateTemp("", "custom-kubelet-*.json")
 			Expect(err).ToNot(HaveOccurred())
@@ -201,6 +207,9 @@ var _ = Describe("P1Import", func() {
 		})
 
 		It("should not be able to remove system nodepool", func() {
+			if helpers.SkipTest {
+				Skip("Skipping test for v2.8, v2.9 ...")
+			}
 			testCaseID = 267
 			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
 		})
@@ -226,6 +235,10 @@ var _ = Describe("P1Import", func() {
 	When("a cluster is created and imported for upgrade", func() {
 		var upgradeK8sVersion string
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)
 			Expect(err).NotTo(HaveOccurred())
@@ -244,6 +257,9 @@ var _ = Describe("P1Import", func() {
 		})
 
 		It("NP cannot be upgraded to k8s version greater than CP k8s version", func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			testCaseID = 269
 			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient, upgradeK8sVersion)
 		})

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -75,7 +75,7 @@ var _ = Describe("P1Import", func() {
 
 		It("should be able to update cluster monitoring", func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			testCaseID = 271
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
@@ -108,7 +108,7 @@ var _ = Describe("P1Import", func() {
 
 	It("should successfully Import a cluster in Region without AZ", func() {
 		if helpers.SkipUpgradeTests {
-			Skip("Skipping test for v2.8 ...")
+			Skip(helpers.SkipUpgradeTestsLog)
 		}
 		location = "ukwest"
 		testCaseID = 276
@@ -145,7 +145,7 @@ var _ = Describe("P1Import", func() {
 		var upgradeToVersion string
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			kubeletConfigJsonData := `{"cpuManagerPolicy": "static", "cpuCfsQuota": true, "cpuCfsQuotaPeriod": "200ms", "imageGcHighThreshold": 90, "imageGcLowThreshold": 70, "topologyManagerPolicy": "best-effort", "allowedUnsafeSysctls": ["kernel.msg*","net.*"], "failSwapOn": false}`
@@ -236,7 +236,7 @@ var _ = Describe("P1Import", func() {
 		var upgradeK8sVersion string
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error
@@ -258,7 +258,7 @@ var _ = Describe("P1Import", func() {
 
 		It("NP cannot be upgraded to k8s version greater than CP k8s version", func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			testCaseID = 269
 			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient, upgradeK8sVersion)

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -45,7 +45,7 @@ var _ = Describe("P1Provisioning", func() {
 
 	It("should successfully Create a cluster in Region without AZ", func() {
 		if helpers.SkipUpgradeTests {
-			Skip("Skipping test for v2.8 ...")
+			Skip(helpers.SkipUpgradeTestsLog)
 		}
 		location = "ukwest"
 		testCaseID = 275
@@ -437,7 +437,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		It("should be able to update cluster monitoring", func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			testCaseID = 200
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
@@ -520,7 +520,7 @@ var _ = Describe("P1Provisioning", func() {
 		var upgradeK8sVersion string
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error
@@ -539,7 +539,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		It("NP cannot be upgraded to k8s version greater than CP k8s version", func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			testCaseID = 183
 			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient, upgradeK8sVersion)
@@ -596,7 +596,7 @@ var _ = Describe("P1Provisioning", func() {
 
 	It("should not be able to select NP K8s version; CP K8s version should take precedence", func() {
 		if helpers.SkipUpgradeTests {
-			Skip("Skipping test for v2.8 ...")
+			Skip(helpers.SkipUpgradeTestsLog)
 		}
 
 		testCaseID = 182

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 var _ = Describe("P1Provisioning", func() {
-	var cluster *management.Cluster
 	var k8sVersion string
 
 	BeforeEach(func() {
@@ -45,6 +44,9 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	It("should successfully Create a cluster in Region without AZ", func() {
+		if helpers.SkipUpgradeTests {
+			Skip("Skipping test for v2.8 ...")
+		}
 		location = "ukwest"
 		testCaseID = 275
 
@@ -362,6 +364,10 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		It("should not be able to edit availability zone of a nodepool", func() {
+			if helpers.SkipTest {
+				Skip("Skipping test for v2.8, v2.9 ...")
+			}
+
 			// Refer: https://github.com/rancher/aks-operator/issues/669
 			testCaseID = 195
 			originalNPMap := make(map[string][]string)
@@ -430,6 +436,9 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		It("should be able to update cluster monitoring", func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			testCaseID = 200
 			updateMonitoringCheck(cluster, ctx.RancherAdminClient)
 		})
@@ -510,6 +519,10 @@ var _ = Describe("P1Provisioning", func() {
 	When("a cluster is created for upgrade", func() {
 		var upgradeK8sVersion string
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)
 			Expect(err).NotTo(HaveOccurred())
@@ -525,6 +538,9 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		It("NP cannot be upgraded to k8s version greater than CP k8s version", func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			testCaseID = 183
 			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient, upgradeK8sVersion)
 		})
@@ -579,8 +595,11 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	It("should not be able to select NP K8s version; CP K8s version should take precedence", func() {
-		testCaseID = 182
+		if helpers.SkipUpgradeTests {
+			Skip("Skipping test for v2.8 ...")
+		}
 
+		testCaseID = 182
 		k8sVersions, err := helper.ListSingleVariantAKSAllVersions(ctx.RancherAdminClient, ctx.CloudCredID, location)
 		Expect(err).To(BeNil())
 		Expect(len(k8sVersions)).To(BeNumerically(">=", 2))
@@ -695,6 +714,9 @@ var _ = Describe("P1Provisioning", func() {
 		})
 
 		It("should not be able to remove system nodepool", func() {
+			if helpers.SkipTest {
+				Skip("Skipping test for v2.8, v2.9 ...")
+			}
 			testCaseID = 191
 			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
 		})

--- a/hosted/aks/p1/sync_import_test.go
+++ b/hosted/aks/p1/sync_import_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
@@ -13,7 +12,6 @@ import (
 
 var _ = Describe("SyncImport", func() {
 	var k8sVersion string
-	var cluster *management.Cluster
 	BeforeEach(func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, false)
@@ -56,7 +54,7 @@ var _ = Describe("SyncImport", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)

--- a/hosted/aks/p1/sync_import_test.go
+++ b/hosted/aks/p1/sync_import_test.go
@@ -55,6 +55,9 @@ var _ = Describe("SyncImport", func() {
 		var availableUpgradeVersions []string
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)
 			Expect(err).NotTo(HaveOccurred())

--- a/hosted/aks/p1/sync_provisioning_test.go
+++ b/hosted/aks/p1/sync_provisioning_test.go
@@ -48,6 +48,10 @@ var _ = Describe("SyncProvisioning", func() {
 		var availableUpgradeVersions []string
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)
 			Expect(err).NotTo(HaveOccurred())

--- a/hosted/aks/p1/sync_provisioning_test.go
+++ b/hosted/aks/p1/sync_provisioning_test.go
@@ -5,14 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/aks/helper"
 	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
 )
 
 var _ = Describe("SyncProvisioning", func() {
-	var cluster *management.Cluster
 	var k8sVersion string
 	BeforeEach(func() {
 		var err error
@@ -49,7 +47,7 @@ var _ = Describe("SyncProvisioning", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error

--- a/hosted/eks/p0/p0_import_test.go
+++ b/hosted/eks/p0/p0_import_test.go
@@ -49,9 +49,11 @@ var _ = Describe("P0Import", func() {
 	} {
 		testData := testData
 		When("a cluster is created", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping test for v2.8 ...")
+				}
+
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, testData.isUpgrade)
 				Expect(err).To(BeNil())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/eks/p0/p0_import_test.go
+++ b/hosted/eks/p0/p0_import_test.go
@@ -51,7 +51,7 @@ var _ = Describe("P0Import", func() {
 		When("a cluster is created", func() {
 			BeforeEach(func() {
 				if testData.isUpgrade && helpers.SkipUpgradeTests {
-					Skip("Skipping test for v2.8 ...")
+					Skip(helpers.SkipUpgradeTestsLog)
 				}
 
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, testData.isUpgrade)
@@ -66,10 +66,13 @@ var _ = Describe("P0Import", func() {
 				Expect(err).To(BeNil())
 			})
 			AfterEach(func() {
-				if ctx.ClusterCleanup && cluster != nil {
-					err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
-					err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+				if ctx.ClusterCleanup {
+					if cluster != nil && cluster.ID != "" {
+						GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+						err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+						Expect(err).To(BeNil())
+					}
+					err := helper.DeleteEKSClusterOnAWS(region, clusterName)
 					Expect(err).To(BeNil())
 				} else {
 					fmt.Println("Skipping downstream cluster deletion: ", clusterName)

--- a/hosted/eks/p0/p0_provisioning_test.go
+++ b/hosted/eks/p0/p0_provisioning_test.go
@@ -51,7 +51,7 @@ var _ = Describe("P0Provisioning", func() {
 		When("a cluster is created", func() {
 			BeforeEach(func() {
 				if testData.isUpgrade && helpers.SkipUpgradeTests {
-					Skip("Skipping test for v2.8 ...")
+					Skip(helpers.SkipUpgradeTestsLog)
 				}
 
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, testData.isUpgrade)
@@ -63,9 +63,12 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).To(BeNil())
 			})
 			AfterEach(func() {
-				if ctx.ClusterCleanup && cluster != nil {
-					err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
+				if ctx.ClusterCleanup {
+					if cluster != nil && cluster.ID != "" {
+						GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+						err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+						Expect(err).To(BeNil())
+					}
 				} else {
 					fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 				}

--- a/hosted/eks/p0/p0_provisioning_test.go
+++ b/hosted/eks/p0/p0_provisioning_test.go
@@ -49,9 +49,11 @@ var _ = Describe("P0Provisioning", func() {
 	} {
 		testData := testData
 		When("a cluster is created", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping test for v2.8 ...")
+				}
+
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, testData.isUpgrade)
 				Expect(err).To(BeNil())
 				GinkgoLogr.Info(fmt.Sprintf("While provisioning, using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/eks/p0/p0_suite_test.go
+++ b/hosted/eks/p0/p0_suite_test.go
@@ -36,6 +36,7 @@ const (
 
 var (
 	ctx         helpers.RancherContext
+	cluster     *management.Cluster
 	clusterName string
 	testCaseID  int64
 	region      = helpers.GetEKSRegion()
@@ -54,6 +55,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
+	// Setting this to nil ensures we do not use the `cluster` variable value from another test running in parallel with this one.
+	cluster = nil
 	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 })
 

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -21,13 +21,16 @@ var _ = Describe("P1Import", func() {
 	})
 
 	AfterEach(func() {
-		if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
-			err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
-			err = helper.DeleteEKSClusterOnAWS(region, clusterName)
+		if ctx.ClusterCleanup {
+			if cluster != nil && cluster.ID != "" {
+				GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+			}
+			err := helper.DeleteEKSClusterOnAWS(region, clusterName)
 			Expect(err).To(BeNil())
 		} else {
-			GinkgoLogr.Info(fmt.Sprintf("Skipping downstream cluster deletion: %s", clusterName))
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 		}
 	})
 
@@ -36,7 +39,7 @@ var _ = Describe("P1Import", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 
 	"github.com/rancher/hosted-providers-e2e/hosted/eks/helper"
@@ -13,11 +12,7 @@ import (
 )
 
 var _ = Describe("P1Import", func() {
-	var (
-		cluster    *management.Cluster
-		k8sVersion string
-	)
-
+	var k8sVersion string
 	BeforeEach(func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
@@ -40,6 +35,10 @@ var _ = Describe("P1Import", func() {
 		var upgradeToVersion string
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
 			Expect(err).To(BeNil())

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -28,11 +28,14 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	AfterEach(func() {
-		if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
-			err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
+		if ctx.ClusterCleanup {
+			if cluster != nil && cluster.ID != "" {
+				GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+				err := helper.DeleteEKSHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+			}
 		} else {
-			GinkgoLogr.Info(fmt.Sprintf("Skipping downstream cluster deletion: %s", clusterName))
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 		}
 	})
 
@@ -208,7 +211,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -19,11 +19,7 @@ import (
 )
 
 var _ = Describe("P1Provisioning", func() {
-	var (
-		cluster    *management.Cluster
-		k8sVersion string
-	)
-
+	var k8sVersion string
 	var _ = BeforeEach(func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
@@ -84,7 +80,7 @@ var _ = Describe("P1Provisioning", func() {
 				Expect(err).To(BeNil())
 				// checking for both the messages since different operator version shows different messages. To be removed once the message is updated.
 				// New Message: NodePool names must be unique within the [c-dnzzk] cluster to avoid duplication
-				return cluster.Transitioning == "error" && (strings.Contains(cluster.TransitioningMessage, "is not unique within the cluster") || strings.Contains(cluster.TransitioningMessage, "NodePool names must be unique"))
+				return cluster.Transitioning == "error" && (strings.Contains(cluster.TransitioningMessage, "is not unique within the cluster") || strings.Contains(cluster.TransitioningMessage, "names must be unique"))
 			}, "1m", "3s").Should(BeTrue())
 		})
 
@@ -158,6 +154,10 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	It("should successfully Provision EKS from Rancher with Enabled GPU feature", func() {
+		if helpers.SkipTest {
+			Skip("Skipping test for v2.8, v2.9 ...")
+		}
+
 		testCaseID = 274
 		var gpuNodeName = "gpuenabled"
 		createFunc := func(clusterConfig *eks.ClusterConfig) {
@@ -207,6 +207,10 @@ var _ = Describe("P1Provisioning", func() {
 		var upgradeToVersion string
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
 			Expect(err).To(BeNil())

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -40,6 +40,7 @@ import (
 
 var (
 	ctx         helpers.RancherContext
+	cluster     *management.Cluster
 	clusterName string
 	testCaseID  int64
 	region      = helpers.GetEKSRegion()
@@ -58,6 +59,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
+	// Setting this to nil ensures we do not use the `cluster` variable value from another test running in parallel with this one.
+	cluster = nil
 	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 })
 
@@ -548,7 +551,7 @@ func invalidEndpointCheck(cluster *management.Cluster, client *rancher.Client) {
 	Eventually(func() bool {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(BeNil())
-		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "InvalidParameterException: The following CIDRs are invalid in publicAccessCidrs")
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "The following CIDRs are invalid in publicAccessCidrs")
 	}, "2m", "3s").Should(BeTrue())
 }
 

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -32,7 +32,7 @@ var _ = Describe("SyncImport", func() {
 		var upgradeToVersion string
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)

--- a/hosted/eks/p1/sync_importing_test.go
+++ b/hosted/eks/p1/sync_importing_test.go
@@ -31,6 +31,9 @@ var _ = Describe("SyncImport", func() {
 	When("a cluster is imported for sync", func() {
 		var upgradeToVersion string
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
 			Expect(err).To(BeNil())

--- a/hosted/eks/p1/sync_provisioning_test.go
+++ b/hosted/eks/p1/sync_provisioning_test.go
@@ -30,6 +30,9 @@ var _ = Describe("SyncProvisioning", func() {
 		var upgradeToVersion string
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)
 			Expect(err).To(BeNil())

--- a/hosted/eks/p1/sync_provisioning_test.go
+++ b/hosted/eks/p1/sync_provisioning_test.go
@@ -31,7 +31,7 @@ var _ = Describe("SyncProvisioning", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, true)

--- a/hosted/gke/helper/helper_cluster.go
+++ b/hosted/gke/helper/helper_cluster.go
@@ -524,7 +524,7 @@ func AddNodePoolOnGCloud(clusterName, zone, project, npName string, extraArgs ..
 	}
 
 	fmt.Println("Adding nodepool to the GKE cluster ...")
-	args := []string{"container", "node-pools", "create", npName, "--cluster", clusterName, "--project", project, "--zone", zone, "--num-nodes", "1"}
+	args := []string{"container", "node-pools", "create", npName, "--cluster", clusterName, "--project", project, "--zone", zone, "--num-nodes", "1", "--enable-autoscaling", "--max-nodes", "1", "--min-nodes", "0"}
 
 	args = append(args, extraArgs...)
 	fmt.Printf("Running command: gcloud %v\n", args)

--- a/hosted/gke/p0/p0_import_test.go
+++ b/hosted/gke/p0/p0_import_test.go
@@ -51,7 +51,7 @@ var _ = Describe("P0Import", func() {
 		When("a cluster is import", func() {
 			BeforeEach(func() {
 				if testData.isUpgrade && helpers.SkipUpgradeTests {
-					Skip("Skipping test for v2.8 ...")
+					Skip(helpers.SkipUpgradeTestsLog)
 				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())
@@ -66,10 +66,13 @@ var _ = Describe("P0Import", func() {
 				Expect(err).To(BeNil())
 			})
 			AfterEach(func() {
-				if ctx.ClusterCleanup && cluster != nil {
-					err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
-					err = helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
+				if ctx.ClusterCleanup {
+					if cluster != nil && cluster.ID != "" {
+						GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+						err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
+						Expect(err).To(BeNil())
+					}
+					err := helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
 					Expect(err).To(BeNil())
 				} else {
 					fmt.Println("Skipping downstream cluster deletion: ", clusterName)

--- a/hosted/gke/p0/p0_import_test.go
+++ b/hosted/gke/p0/p0_import_test.go
@@ -49,9 +49,10 @@ var _ = Describe("P0Import", func() {
 	} {
 		testData := testData
 		When("a cluster is import", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping test for v2.8 ...")
+				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -65,7 +65,7 @@ var _ = Describe("P0Provisioning", func() {
 		When("a cluster is created", func() {
 			BeforeEach(func() {
 				if testData.isUpgrade && helpers.SkipUpgradeTests {
-					Skip("Skipping test for v2.8 ...")
+					Skip(helpers.SkipUpgradeTestsLog)
 				}
 
 				if strings.Contains(testData.testTitle, "regional") {
@@ -87,9 +87,12 @@ var _ = Describe("P0Provisioning", func() {
 				Expect(err).To(BeNil())
 			})
 			AfterEach(func() {
-				if ctx.ClusterCleanup && cluster != nil {
-					err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
-					Expect(err).To(BeNil())
+				if ctx.ClusterCleanup {
+					if cluster != nil && cluster.ID != "" {
+						GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+						err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
+						Expect(err).To(BeNil())
+					}
 				} else {
 					fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 				}

--- a/hosted/gke/p0/p0_provisioning_test.go
+++ b/hosted/gke/p0/p0_provisioning_test.go
@@ -63,9 +63,11 @@ var _ = Describe("P0Provisioning", func() {
 	} {
 		testData := testData
 		When("a cluster is created", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping test for v2.8 ...")
+				}
+
 				if strings.Contains(testData.testTitle, "regional") {
 					zone = ""
 					updateFunc = func(clusterConfig *gke.ClusterConfig) {

--- a/hosted/gke/p0/p0_suite_test.go
+++ b/hosted/gke/p0/p0_suite_test.go
@@ -36,6 +36,7 @@ const (
 
 var (
 	ctx                                helpers.RancherContext
+	cluster                            *management.Cluster
 	clusterName, zone, region, project string
 	testCaseID                         int64
 	updateFunc                         func(clusterConfig *gke.ClusterConfig)
@@ -54,6 +55,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
+	// Setting this to nil ensures we do not use the `cluster` variable value from another test running in parallel with this one.
+	cluster = nil
 	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 	zone = helpers.GetGKEZone()
 	region = helpers.GetGKERegion()

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 var _ = Describe("P1Import", func() {
-	var cluster *management.Cluster
-
 	var _ = BeforeEach(func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", false)
@@ -23,11 +21,15 @@ var _ = Describe("P1Import", func() {
 	})
 
 	AfterEach(func() {
-		if ctx.ClusterCleanup && cluster != nil {
-			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
+		if ctx.ClusterCleanup {
+			if cluster != nil && cluster.ID != "" {
+				GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+				err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+			}
+			err := helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
 			Expect(err).To(BeNil())
-			err = helper.DeleteGKEClusterOnGCloud(zone, project, clusterName)
-			Expect(err).To(BeNil())
+
 		} else {
 			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 		}
@@ -171,6 +173,10 @@ var _ = Describe("P1Import", func() {
 	When("a cluster is created for upgrade scenario", func() {
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", true)
 			Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_import_test.go
+++ b/hosted/gke/p1/p1_import_test.go
@@ -174,7 +174,7 @@ var _ = Describe("P1Import", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -129,7 +129,7 @@ var _ = Describe("P1Provisioning", func() {
 
 	It("should be able to create a cluster with CP K8s version v-XX-1 and NP K8s version v-XX should use v-XX-1 for both CP and NP", func() {
 		if helpers.SkipUpgradeTests {
-			Skip("Skipping test for v2.8 ...")
+			Skip(helpers.SkipUpgradeTestsLog)
 		}
 		testCaseID = 33
 
@@ -234,7 +234,7 @@ var _ = Describe("P1Provisioning", func() {
 			testCaseID = 30
 			var err error
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			_, err = helper.AddNodePool(cluster, ctx.RancherAdminClient, 1, "WINDOWS_LTSC_CONTAINERD", true, true)
@@ -316,7 +316,7 @@ var _ = Describe("P1Provisioning", func() {
 
 		BeforeEach(func() {
 			if helpers.SkipUpgradeTests {
-				Skip("Skipping test for v2.8 ...")
+				Skip(helpers.SkipUpgradeTestsLog)
 			}
 
 			var err error

--- a/hosted/gke/p1/p1_provisioning_test.go
+++ b/hosted/gke/p1/p1_provisioning_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 var _ = Describe("P1Provisioning", func() {
-	var cluster *management.Cluster
-
 	var _ = BeforeEach(func() {
 		var err error
 		k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", false)
@@ -28,9 +26,12 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	AfterEach(func() {
-		if ctx.ClusterCleanup && (cluster != nil && cluster.ID != "") {
-			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
-			Expect(err).To(BeNil())
+		if ctx.ClusterCleanup {
+			if cluster != nil && cluster.ID != "" {
+				GinkgoLogr.Info(fmt.Sprintf("Cleaning up resource cluster: %s %s", cluster.Name, cluster.ID))
+				err := helper.DeleteGKEHostCluster(cluster, ctx.RancherAdminClient)
+				Expect(err).To(BeNil())
+			}
 		} else {
 			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
 		}
@@ -127,6 +128,9 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	It("should be able to create a cluster with CP K8s version v-XX-1 and NP K8s version v-XX should use v-XX-1 for both CP and NP", func() {
+		if helpers.SkipUpgradeTests {
+			Skip("Skipping test for v2.8 ...")
+		}
 		testCaseID = 33
 
 		k8sVersions, err := helper.ListSingleVariantGKEAvailableVersions(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "")
@@ -229,6 +233,10 @@ var _ = Describe("P1Provisioning", func() {
 		It("should successfully add a windows nodepool", func() {
 			testCaseID = 30
 			var err error
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			_, err = helper.AddNodePool(cluster, ctx.RancherAdminClient, 1, "WINDOWS_LTSC_CONTAINERD", true, true)
 			Expect(err).To(BeNil())
 		})
@@ -307,6 +315,10 @@ var _ = Describe("P1Provisioning", func() {
 	When("a cluster is created for upgrade scenarios", func() {
 
 		BeforeEach(func() {
+			if helpers.SkipUpgradeTests {
+				Skip("Skipping test for v2.8 ...")
+			}
+
 			var err error
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", true)
 			Expect(err).To(BeNil())

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -39,6 +39,7 @@ import (
 
 var (
 	ctx                     helpers.RancherContext
+	cluster                 *management.Cluster
 	clusterName, k8sVersion string
 	testCaseID              int64
 	zone                    = helpers.GetGKEZone()
@@ -58,6 +59,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = BeforeEach(func() {
+	// Setting this to nil ensures we do not use the `cluster` variable value from another test running in parallel with this one.
+	cluster = nil
 	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
 })
 
@@ -74,7 +77,7 @@ var _ = ReportAfterEach(func(report SpecReport) {
 // updateLoggingAndMonitoringServiceCheck tests updating `loggingService` and `monitoringService`
 func updateLoggingAndMonitoringServiceCheck(cluster *management.Cluster, client *rancher.Client, updateMonitoringValue, updateLoggingValue string) {
 	var err error
-	cluster, err = helper.UpdateMonitoringAndLoggingService(cluster, client, updateMonitoringValue, updateLoggingValue, true, true)
+	_, err = helper.UpdateMonitoringAndLoggingService(cluster, client, updateMonitoringValue, updateLoggingValue, true, true)
 	Expect(err).To(BeNil())
 }
 
@@ -110,7 +113,7 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 			return *cluster.GKEStatus.UpstreamSpec.KubernetesVersion
-		}, tools.SetTimeout(7*time.Minute), 10*time.Second).Should(Equal(upgradeToVersion), "Failed while waiting for k8s upgrade to appear in GKEStatus.UpstreamSpec")
+		}, tools.SetTimeout(10*time.Minute), 10*time.Second).Should(Equal(upgradeToVersion), "Failed while waiting for k8s upgrade to appear in GKEStatus.UpstreamSpec")
 
 		// Ensure nodepool version is still the same.
 		for _, np := range cluster.GKEStatus.UpstreamSpec.NodePools {
@@ -120,11 +123,10 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 		if !helpers.IsImport {
 			// For imported clusters, GKEConfig always has null values; so we check GKEConfig only when testing provisioned clusters
 			// Refer: github.com/rancher/gke-operator/issues/702
-			Expect(strings.Contains(cluster.TransitioningMessage, "downgrades of minor versions are not supported in GKE, consider updating spec version to match upstream version")).To(BeTrue())
+			Expect(strings.Contains(cluster.TransitioningMessage, "downgrades of minor versions are not supported in GKE, consider updating spec version to match upstream version") || strings.Contains(cluster.TransitioningMessage, "specified version is not newer than the current version")).To(BeTrue())
 			// Updating controlplane version via Rancher
 			cluster, err = helper.UpgradeKubernetesVersion(cluster, upgradeToVersion, client, false, true, false)
 			Expect(err).To(BeNil())
-
 			Expect(*cluster.GKEConfig.KubernetesVersion).To(Equal(upgradeToVersion))
 			for _, np := range cluster.GKEConfig.NodePools {
 				Expect(np.Version).To(BeEquivalentTo(currentVersion), "GKEConfig.NodePools check failed")
@@ -134,8 +136,8 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 
 	By("upgrading the node pool", func() {
 		for _, np := range cluster.GKEStatus.UpstreamSpec.NodePools {
-			err = helper.UpgradeGKEClusterOnGCloud(zone, clusterName, project, upgradeToVersion, true, *np.Name)
-			Expect(err).To(BeNil())
+			// The cluster errors out and becomes unavailable at some point due to the upgrade , so we wait until the cluster is ready
+			_ = helper.UpgradeGKEClusterOnGCloud(zone, clusterName, project, upgradeToVersion, true, *np.Name)
 		}
 
 		Eventually(func() bool {
@@ -149,7 +151,7 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, client *rancher.Cli
 				}
 			}
 			return true
-		}, tools.SetTimeout(5*time.Minute), 10*time.Second).Should(BeTrue(), "GKEStatus.UpstreamSpec.NodePools upgrade check failed")
+		}, tools.SetTimeout(15*time.Minute), 15*time.Second).Should(BeTrue(), "GKEStatus.UpstreamSpec.NodePools upgrade check failed")
 
 		if !helpers.IsImport {
 			// For imported clusters, GKEConfig always has null values; so we check GKEConfig only when testing provisioned clusters
@@ -176,7 +178,7 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 			return len(cluster.GKEStatus.UpstreamSpec.NodePools)
-		}, tools.SetTimeout(5*time.Minute), 5*time.Second).Should(Equal(currentNodeCount + 1))
+		}, tools.SetTimeout(10*time.Minute), 15*time.Second).Should(Equal(currentNodeCount + 1))
 
 		// check that the new node pool has been added
 		Expect(func() bool {
@@ -213,7 +215,7 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
 			return len(cluster.GKEStatus.UpstreamSpec.NodePools)
-		}, tools.SetTimeout(5*time.Minute), 2*time.Second).Should(Equal(currentNodeCount))
+		}, tools.SetTimeout(15*time.Minute), 15*time.Second).Should(Equal(currentNodeCount))
 
 		// check that the new node pool has been deleted
 		Expect(func() bool {
@@ -244,6 +246,9 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 
 // updateClusterInUpdatingState runs checks to ensure cluster in an updating state can be updated
 func updateClusterInUpdatingState(cluster *management.Cluster, client *rancher.Client) {
+	if helpers.SkipUpgradeTests {
+		Skip("Skipping test for v2.8 ...")
+	}
 	availableVersions, err := helper.ListGKEAvailableVersions(client, cluster.ID)
 	Expect(err).To(BeNil())
 	upgradeK8sVersion := availableVersions[0]
@@ -424,6 +429,6 @@ func expiredCredCheck(cluster *management.Cluster, client *rancher.Client) {
 	Eventually(func() bool {
 		cluster, err = client.Management.Cluster.ByID(cluster.ID)
 		Expect(err).To(BeNil())
-		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "cannot fetch token")
+		return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "cannot fetch token") || strings.Contains(cluster.TransitioningMessage, "unexpected end of JSON input")
 	}, "2m", "3s").Should(BeTrue())
 }

--- a/hosted/gke/p1/p1_suite_test.go
+++ b/hosted/gke/p1/p1_suite_test.go
@@ -247,7 +247,7 @@ func syncNodepoolsCheck(cluster *management.Cluster, client *rancher.Client) {
 // updateClusterInUpdatingState runs checks to ensure cluster in an updating state can be updated
 func updateClusterInUpdatingState(cluster *management.Cluster, client *rancher.Client) {
 	if helpers.SkipUpgradeTests {
-		Skip("Skipping test for v2.8 ...")
+		Skip(helpers.SkipUpgradeTestsLog)
 	}
 	availableVersions, err := helper.ListGKEAvailableVersions(client, cluster.ID)
 	Expect(err).To(BeNil())

--- a/hosted/gke/p1/sync_import_test.go
+++ b/hosted/gke/p1/sync_import_test.go
@@ -34,11 +34,9 @@ var _ = Describe("SyncImport", func() {
 	} {
 		testData := testData
 		When("a cluster is import", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
 				if testData.isUpgrade && helpers.SkipUpgradeTests {
-					Skip("Skipping test for v2.8 ...")
+					Skip(helpers.SkipUpgradeTestsLog)
 				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())

--- a/hosted/gke/p1/sync_import_test.go
+++ b/hosted/gke/p1/sync_import_test.go
@@ -37,6 +37,9 @@ var _ = Describe("SyncImport", func() {
 			var cluster *management.Cluster
 
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping test for v2.8 ...")
+				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/gke/p1/sync_provisioning_test.go
+++ b/hosted/gke/p1/sync_provisioning_test.go
@@ -34,11 +34,9 @@ var _ = Describe("SyncProvisioning", func() {
 	} {
 		testData := testData
 		When("a cluster is created", func() {
-			var cluster *management.Cluster
-
 			BeforeEach(func() {
 				if testData.isUpgrade && helpers.SkipUpgradeTests {
-					Skip("Skipping test for v2.8 ...")
+					Skip(helpers.SkipUpgradeTestsLog)
 				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())

--- a/hosted/gke/p1/sync_provisioning_test.go
+++ b/hosted/gke/p1/sync_provisioning_test.go
@@ -37,6 +37,9 @@ var _ = Describe("SyncProvisioning", func() {
 			var cluster *management.Cluster
 
 			BeforeEach(func() {
+				if testData.isUpgrade && helpers.SkipUpgradeTests {
+					Skip("Skipping test for v2.8 ...")
+				}
 				k8sVersion, err := helper.GetK8sVersion(ctx.RancherAdminClient, project, ctx.CloudCredID, zone, "", testData.isUpgrade)
 				Expect(err).NotTo(HaveOccurred())
 				GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -193,7 +193,7 @@ func ClusterIsReadyChecks(cluster *management.Cluster, client *rancher.Client, c
 	ginkgo.By("checking all pods are ready", func() {
 		Eventually(func() []error {
 			return pods.StatusPods(client, cluster.ID)
-		}, tools.SetTimeout(30*time.Second), Timeout).Should(BeEmpty(), "All pods are not running")
+		}, tools.SetTimeout(Timeout), 30*time.Second).Should(BeEmpty(), "All pods are not running")
 	})
 }
 

--- a/hosted/helpers/structs.go
+++ b/hosted/helpers/structs.go
@@ -44,6 +44,14 @@ var (
 		}
 		return false
 	}()
+	SkipUpgradeTests = func() bool {
+		// Skip upgrade tests since lowest k8s version not available
+		return strings.Contains((RancherFullVersion), "2.8")
+	}()
+	SkipTest = func() bool {
+		// Some features not available on v2.8, v2.9
+		return strings.Contains((RancherFullVersion), "2.8") || strings.Contains((RancherFullVersion), "2.9")
+	}()
 )
 
 type HelmChart struct {

--- a/hosted/helpers/structs.go
+++ b/hosted/helpers/structs.go
@@ -52,6 +52,7 @@ var (
 		// Some features not available on v2.8, v2.9
 		return strings.Contains((RancherFullVersion), "2.8") || strings.Contains((RancherFullVersion), "2.9")
 	}()
+	SkipUpgradeTestsLog = "Skipping upgrade tests since only one minor k8s version is supported by the current rancher version ..."
 )
 
 type HelmChart struct {


### PR DESCRIPTION
### What does this PR do?
- Refactor main branch to run tests on multiple Rancher versions
- Fixes P1 tests for the above and setting `cluster = nil` in `BeforeEach` 
- Skip upgrade tests for v2.8

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #243 

### Checklist:
- [x] GitHub Actions (Nightly=false):

v2.9: 
[p1_provisioning/p1_import](https://github.com/rancher/hosted-providers-e2e/actions/runs/13101626288)
[p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/sync_provisioning/sync_import](https://github.com/rancher/hosted-providers-e2e/actions/runs/13105919092)
Re-run of failed tests: [AKS P1](https://github.com/rancher/hosted-providers-e2e/actions/runs/13133526653), [EKS SyncImport](https://github.com/rancher/hosted-providers-e2e/actions/runs/13137326697), [GKE Sync](https://github.com/rancher/hosted-providers-e2e/actions/runs/13154165694)

v2.10: 
[p1_provisioning/p1_import](https://github.com/rancher/hosted-providers-e2e/actions/runs/13119412290)
[p0_provisioning/p0_import/support_matrix_provisioning/support_matrix_import/sync_provisioning/sync_import](https://github.com/rancher/hosted-providers-e2e/actions/runs/13128955564)
Re-run failed tests: [GKE Sync](https://github.com/rancher/hosted-providers-e2e/actions/runs/13154159411)
