### PR TITLE
local k3s cluster version bump

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
-run-name: AKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.31.5+k3s1' }}
+run-name: AKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
 
 on:
   schedule:
@@ -17,7 +17,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.31.5+k3s1
+        default: v1.32.1+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -60,7 +60,7 @@ jobs:
     with:
       hosted_provider: aks
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.31.5+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner == true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
-run-name: EKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.31.5+k3s1' }}
+run-name: EKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
 
 on:
   schedule:
@@ -17,7 +17,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.31.5+k3s1
+        default: v1.32.1+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -61,7 +61,7 @@ jobs:
     with:
       hosted_provider: eks
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.31.5+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
-run-name: GKE on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.31.5+k3s1' }}
+run-name: GKE on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
 
 on:
   schedule:
@@ -17,7 +17,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.31.5+k3s1
+        default: v1.32.1+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -60,7 +60,7 @@ jobs:
     with:
       hosted_provider: gke
       rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.31.5+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 * * 1-6' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}

--- a/.github/workflows/k8s-chart-upgrade-matrix.yaml
+++ b/.github/workflows/k8s-chart-upgrade-matrix.yaml
@@ -23,7 +23,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.31.5+k3s1
+        default: v1.32.1+k3s1
       qase_run_id:
         description: Qase run ID where the results will be reported (auto|none|existing_run_id)
         default: none

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -13,7 +13,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.31.5+k3s1
+        default: v1.32.1+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: false


### PR DESCRIPTION
### What does this PR do?
This PR bumps the version of local cluster to latest supported version (v1.32.1+k3s1).

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - https://github.com/rancher/hosted-providers-e2e/actions/runs/14707136735

### Special notes for your reviewer:
