### PR TITLE
Fix test failures; use 'ui-k8s-supported-versions-range' instead of "ui-k8s-default-version-range" to fetch the highest UI supported k8s version

### DIFF
--- a/hosted/helpers/helper_charts.go
+++ b/hosted/helpers/helper_charts.go
@@ -131,6 +131,7 @@ func ListChartVersions(chartName string) (charts []HelmChart) {
 // 0 == v is equal to o
 // 1 == v is greater than o
 func VersionCompare(v, o string) int {
+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Version %s vs %s", v, o))
 	latestVer, err := semver.ParseTolerant(v)
 	Expect(err).To(BeNil())
 	oldVer, err := semver.ParseTolerant(o)

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -314,9 +314,11 @@ func SetTempKubeConfig(clusterName string) {
 // HighestK8sMinorVersionSupportedByUI returns the highest k8s version supported by UI
 // TODO(pvala): Use this by default when fetching a list of k8s version for all the downstream providers.
 func HighestK8sMinorVersionSupportedByUI(client *rancher.Client) (value string) {
-	uiValue, err := client.Management.Setting.ByID("ui-k8s-default-version-range")
+	uiValue, err := client.Management.Setting.ByID("ui-k8s-supported-versions-range")
 	Expect(err).To(BeNil())
-	value = uiValue.Value
+	// example value: >=v1.31.x <=v1.33.x
+	values := strings.Split(uiValue.Value, " ")
+	value = values[len(values)-1]
 	Expect(value).ToNot(BeEmpty())
 	value = strings.TrimPrefix(value, "<=v")
 	value = strings.TrimSuffix(value, ".x")


### PR DESCRIPTION
### What does this PR do?
The problem comes from [here](https://github.com/rancher/hosted-providers-e2e/blob/main/hosted/helpers/helper_common.go#L314-L324):
// HighestK8sMinorVersionSupportedByUI returns the highest k8s version supported by UI
// TODO(pvala): Use this by default when fetching a list of k8s version for all the downstream providers.
func HighestK8sMinorVersionSupportedByUI(client *rancher.Client) (value string) {
    uiValue, err := client.Management.Setting.ByID("ui-k8s-default-version-range")
    Expect(err).To(BeNil())
    value = uiValue.Value
    Expect(value).ToNot(BeEmpty())
    value = strings.TrimPrefix(value, "<=v")
    value = strings.TrimSuffix(value, ".x")
    return value
}
The value returned by this is `<=1.14`, which is the default value of the setting ui-k8s-default-version-range if no value is set for it, see [here](https://github.com/rancher/rancher/blob/main/pkg/settings/setting.go#L297).
`latest/devel/head` rancher instance has value `<=1.14x`.
{

    "baseType": "setting",
    "created": "2025-06-30T09:23:00Z",
    "createdTS": 1751275380000,
    "creatorId": null,
    "customized": false,
    "default": "<=1.14.x",
    "id": "ui-k8s-default-version-range",
    "links": {
        "remove": "…/v3/settings/ui-k8s-default-version-range",
        "self": "…/v3/settings/ui-k8s-default-version-range",
        "update": "…/v3/settings/ui-k8s-default-version-range"
    },
    "name": "ui-k8s-default-version-range",
    "source": "default",
    "type": "setting",
    "uuid": "778bbb18-65ad-4597-b697-da1d70eeab8c",
    "value": "<=1.14.x"

}
`latest/2.11.3` has value `<=v1.32x`.
{

    "baseType": "setting",
    "created": "2025-06-30T11:21:34Z",
    "createdTS": 1751282494000,
    "creatorId": null,
    "customized": true,
    "default": "<=1.14.x",
    "id": "ui-k8s-default-version-range",
    "links": {
        "remove": "…/v3/settings/ui-k8s-default-version-range",
        "self": "…/v3/settings/ui-k8s-default-version-range",
        "update": "…/v3/settings/ui-k8s-default-version-range"
    },
    "name": "ui-k8s-default-version-range",
    "source": "db",
    "type": "setting",
    "uuid": "a61a6e29-e28c-470f-899e-a8aee563c5e5",
    "value": "<=v1.32.x"

}
I ran the test against 2.11.3, and it correctly fetched the versions, and the tests are running.
I think the issue has something to do with head tag not using the correct rancher chart version. I need to do a bit more research on this to understand this exactly. But so far I can see that latest/devel/head uses rancher chart version rancher:2.12.0-rc1, which is not correct. While latest/2.11.3 uses version rancher:2.11.3 , which seems okay.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) - [AKS P0 Prov :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/15972147406)

### Special notes for your reviewer:
