### PR TITLE
Unblock previously blocked tests

### DIFF
--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -217,7 +217,7 @@ var _ = Describe("P1Import", func() {
 			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		XIt("should to able to delete a nodepool and add a new one", func() {
+		FIt("should to able to delete a nodepool and add a new one", func() {
 			// Blocked by: https://github.com/rancher/aks-operator/issues/667#issuecomment-2370798904
 			testCaseID = 268
 			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)

--- a/hosted/aks/p1/p1_import_test.go
+++ b/hosted/aks/p1/p1_import_test.go
@@ -217,7 +217,7 @@ var _ = Describe("P1Import", func() {
 			removeSystemNpCheck(cluster, ctx.RancherAdminClient)
 		})
 
-		FIt("should to able to delete a nodepool and add a new one", func() {
+		It("should to able to delete a nodepool and add a new one", func() {
 			// Blocked by: https://github.com/rancher/aks-operator/issues/667#issuecomment-2370798904
 			testCaseID = 268
 			deleteAndAddNpCheck(cluster, ctx.RancherAdminClient)

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -155,7 +155,7 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	// TODO: Discuss why only one nodepool is taken into account
-	XIt("updating a cluster while it is still provisioning", func() {
+	FIt("updating a cluster while it is still provisioning", func() {
 		// Blocked by: https://github.com/rancher/aks-operator/issues/667
 		testCaseID = 222
 		var err error
@@ -557,7 +557,7 @@ var _ = Describe("P1Provisioning", func() {
 			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient, upgradeK8sVersion)
 		})
 
-		XIt("should Update a cluster when a cluster is in Updating State", func() {
+		FIt("should Update a cluster when a cluster is in Updating State", func() {
 			// Ref: https://github.com/rancher/aks-operator/issues/826
 			testCaseID = 223
 			updateClusterWhenUpdating(cluster, ctx.RancherAdminClient, upgradeK8sVersion)
@@ -718,7 +718,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(len(*cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(2))
 		})
 
-		XIt("should to able to delete a nodepool and add a new one with different availability zone", func() {
+		FIt("should to able to delete a nodepool and add a new one with different availability zone", func() {
 			// Blocked by: https://github.com/rancher/aks-operator/issues/667#issuecomment-2370798904
 			testCaseID = 190
 			// also covers testCaseID = 194

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -155,7 +155,7 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	// TODO: Discuss why only one nodepool is taken into account
-	FIt("updating a cluster while it is still provisioning", func() {
+	XIt("updating a cluster while it is still provisioning", func() {
 		// Blocked by: https://github.com/rancher/aks-operator/issues/667
 		testCaseID = 222
 		var err error
@@ -718,7 +718,7 @@ var _ = Describe("P1Provisioning", func() {
 			Expect(len(*cluster.AKSStatus.UpstreamSpec.NodePools)).To(Equal(2))
 		})
 
-		FIt("should to able to delete a nodepool and add a new one with different availability zone", func() {
+		It("should to able to delete a nodepool and add a new one with different availability zone", func() {
 			// Blocked by: https://github.com/rancher/aks-operator/issues/667#issuecomment-2370798904
 			testCaseID = 190
 			// also covers testCaseID = 194

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -806,7 +806,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	Context("Private Cluster", func() {
+	FContext("Private Cluster", func() {
 		// Previously blocked on: https://github.com/rancher/rancher/issues/43772
 		BeforeEach(func() {
 			var err error

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -806,10 +806,15 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	XContext("Private Cluster", func() {
-		// Blocked on: https://github.com/rancher/rancher/issues/43772
+	Context("Private Cluster", func() {
+		// Previously blocked on: https://github.com/rancher/rancher/issues/43772
 		BeforeEach(func() {
 			var err error
+			serverVersion, err := helpers.GetRancherServerVersion(ctx.RancherAdminClient)
+			Expect(err).NotTo(HaveOccurred())
+			if !strings.Contains(serverVersion, "2.12") {
+				Skip("Not supported on version < 2.12")
+			}
 			k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, ctx.CloudCredID, location, true)
 			Expect(err).NotTo(HaveOccurred())
 			GinkgoLogr.Info(fmt.Sprintf("Using K8s version %s for cluster %s", k8sVersion, clusterName))

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -209,7 +209,7 @@ var _ = Describe("P1Provisioning", func() {
 		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(*cluster.AKSStatus.UpstreamSpec.NodePools).To(HaveLen(initialNPCount + 3))
-		Expect(cluster.AKSStatus.UpstreamSpec.KubernetesVersion).To(Equal(upgradeK8sVersion))
+		Expect(*cluster.AKSStatus.UpstreamSpec.KubernetesVersion).To(Equal(upgradeK8sVersion))
 	})
 
 	It("create cluster with network policy: calico and plugin: kubenet", func() {

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -155,7 +155,7 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	// TODO: Discuss why only one nodepool is taken into account
-	FIt("updating a cluster while it is still provisioning", func() {
+	It("updating a cluster while it is still provisioning", func() {
 		// Blocked by: https://github.com/rancher/aks-operator/issues/667
 		testCaseID = 222
 		var err error
@@ -557,7 +557,7 @@ var _ = Describe("P1Provisioning", func() {
 			npUpgradeToVersionGTCPCheck(cluster, ctx.RancherAdminClient, upgradeK8sVersion)
 		})
 
-		FIt("should Update a cluster when a cluster is in Updating State", func() {
+		It("should Update a cluster when a cluster is in Updating State", func() {
 			// Ref: https://github.com/rancher/aks-operator/issues/826
 			testCaseID = 223
 			updateClusterWhenUpdating(cluster, ctx.RancherAdminClient, upgradeK8sVersion)

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -155,7 +155,7 @@ var _ = Describe("P1Provisioning", func() {
 	})
 
 	// TODO: Discuss why only one nodepool is taken into account
-	It("updating a cluster while it is still provisioning", func() {
+	FIt("updating a cluster while it is still provisioning", func() {
 		// Blocked by: https://github.com/rancher/aks-operator/issues/667
 		testCaseID = 222
 		var err error
@@ -806,7 +806,7 @@ var _ = Describe("P1Provisioning", func() {
 		}
 	})
 
-	FContext("Private Cluster", func() {
+	Context("Private Cluster", func() {
 		// Previously blocked on: https://github.com/rancher/rancher/issues/43772
 		BeforeEach(func() {
 			var err error

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -71,7 +71,7 @@ var _ = Describe("P1Import", func() {
 			})
 
 			// eks-operator/issues/752
-			FIt("should successfully update a cluster while it is still in updating state", func() {
+			It("should successfully update a cluster while it is still in updating state", func() {
 				testCaseID = 104
 				updateClusterInUpdatingState(cluster, ctx.RancherAdminClient, upgradeToVersion)
 			})

--- a/hosted/eks/p1/p1_import_test.go
+++ b/hosted/eks/p1/p1_import_test.go
@@ -71,7 +71,7 @@ var _ = Describe("P1Import", func() {
 			})
 
 			// eks-operator/issues/752
-			XIt("should successfully update a cluster while it is still in updating state", func() {
+			FIt("should successfully update a cluster while it is still in updating state", func() {
 				testCaseID = 104
 				updateClusterInUpdatingState(cluster, ctx.RancherAdminClient, upgradeToVersion)
 			})

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -257,7 +257,7 @@ var _ = Describe("P1Provisioning", func() {
 			})
 
 			// eks-operator/issues/752
-			FIt("should successfully update a cluster while it is still in updating state", func() {
+			XIt("should successfully update a cluster while it is still in updating state", func() {
 				testCaseID = 148
 				updateClusterInUpdatingState(cluster, ctx.RancherAdminClient, upgradeToVersion)
 			})

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -201,7 +201,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(amiID).To(Or(Equal("AL2_x86_64_GPU"), Equal("AL2023_x86_64_NVIDIA")))
 	})
 
-	FIt("Deploy a cluster with Public/Priv access then disable Public access", func() {
+	XIt("Deploy a cluster with Public/Priv access then disable Public access", func() {
 		// https://github.com/rancher/eks-operator/issues/752#issuecomment-2609144199
 		testCaseID = 151
 		createFunc := func(clusterConfig *eks.ClusterConfig) {

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -201,7 +201,7 @@ var _ = Describe("P1Provisioning", func() {
 		Expect(amiID).To(Or(Equal("AL2_x86_64_GPU"), Equal("AL2023_x86_64_NVIDIA")))
 	})
 
-	XIt("Deploy a cluster with Public/Priv access then disable Public access", func() {
+	FIt("Deploy a cluster with Public/Priv access then disable Public access", func() {
 		// https://github.com/rancher/eks-operator/issues/752#issuecomment-2609144199
 		testCaseID = 151
 		createFunc := func(clusterConfig *eks.ClusterConfig) {
@@ -257,7 +257,7 @@ var _ = Describe("P1Provisioning", func() {
 			})
 
 			// eks-operator/issues/752
-			XIt("should successfully update a cluster while it is still in updating state", func() {
+			FIt("should successfully update a cluster while it is still in updating state", func() {
 				testCaseID = 148
 				updateClusterInUpdatingState(cluster, ctx.RancherAdminClient, upgradeToVersion)
 			})


### PR DESCRIPTION
### What does this PR do?
- The testCaseID 240 was blocked due to https://github.com/rancher/rancher/issues/43772; this bug has now been fixed on 2.12; since it won't be backported to previous versions, the test will be skipped for version < 2.12.
- Other tests (except caseID: 222, 151, and 148) that are no longer blocked by an issue have also been unblocked.
### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable)- :green_circle:  [AKS P1 :green_circle: except 22](https://github.com/rancher/hosted-providers-e2e/actions/runs/16162238765/job/45616035722), [AKS Private on 2.11 is skipped as expected](https://github.com/rancher/hosted-providers-e2e/actions/runs/16164188516/job/45622115140#step:18:118), [EKS P1 Import :green_circle: ](https://github.com/rancher/hosted-providers-e2e/actions/runs/16164469235/job/45623018246)

### Special notes for your reviewer:
