### PR TITLE
Bump testhelpers to support new rancher head repos

### DIFF
--- a/.github/workflows/aks.yaml
+++ b/.github/workflows/aks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: AKS-E2E
-run-name: AKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
+run-name: AKS on Rancher ${{ inputs.rancher_version || 'head/2.12' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
 
 on:
   schedule:
@@ -12,7 +12,7 @@ on:
         description: Rancher version channel/version/head_version latest/latest, latest/2.9.3[-rc2], prime/2.9.3, prime/devel/2.9, prime-optimus/2.9.3-rc2
         required: true
         type: string
-        default: latest/devel/head
+        default: head/2.12
       k3s_version:
         description: k3s version of local cluster
         required: true
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       hosted_provider: aks
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
       k3s_version: ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 * * 1,4' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}

--- a/.github/workflows/eks.yaml
+++ b/.github/workflows/eks.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: EKS-E2E
-run-name: EKS on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
+run-name: EKS on Rancher ${{ inputs.rancher_version || 'head/2.12' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
 
 on:
   schedule:
@@ -12,7 +12,7 @@ on:
         description: Rancher version channel/version/head_version latest/latest, latest/2.9.3[-rc2], prime/2.9.3, prime/devel/2.9, prime-optimus/2.9.3-rc2
         required: true
         type: string
-        default: latest/devel/head
+        default: head/2.12
       k3s_version:
         description: k3s version of local cluster
         required: true
@@ -60,7 +60,7 @@ jobs:
     secrets: inherit
     with:
       hosted_provider: eks
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
       k3s_version: ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 * * 1,4' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}

--- a/.github/workflows/gke.yaml
+++ b/.github/workflows/gke.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: GKE-E2E
-run-name: GKE on Rancher ${{ inputs.rancher_version || 'latest/devel/head' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
+run-name: GKE on Rancher ${{ inputs.rancher_version || 'head/2.12' }} deployed on ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
 
 on:
   schedule:
@@ -12,7 +12,7 @@ on:
         description: Rancher version channel/version/head_version latest/latest, latest/2.9.3[-rc2], prime/2.9.3, prime/devel/2.9, prime-optimus/2.9.3-rc2
         required: true
         type: string
-        default: latest/devel/head
+        default: head/2.12
       k3s_version:
         description: k3s version of local cluster
         required: true
@@ -59,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       hosted_provider: gke
-      rancher_version: ${{ inputs.rancher_version || 'latest/devel/head' }}
+      rancher_version: ${{ inputs.rancher_version || 'head/2.12' }}
       k3s_version: ${{ inputs.k3s_version || 'v1.32.1+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 * * 1,4' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 * * 0' && 'p1_provisioning/p1_import/sync_provisioning/sync_import') }}

--- a/.github/workflows/k8s-chart-upgrade-matrix.yaml
+++ b/.github/workflows/k8s-chart-upgrade-matrix.yaml
@@ -8,15 +8,15 @@ on:
         description: Rancher version channel/version. This must be a released stable rancher version.
         required: true
         type: string
-        default: latest/2.9.3
+        default: latest/2.11.3
       rancher_upgrade_version:
         description: Rancher upgrade version
         required: true
         type: string
-        default: head/2.10
+        default: head/2.12
       k8s_upgrade_minor_version:
         description: K8s minor version to test
-        default: "1.31"
+        default: "1.33"
         required: true
         type: string
       k3s_version:

--- a/.github/workflows/k8s-chart-upgrade-matrix.yaml
+++ b/.github/workflows/k8s-chart-upgrade-matrix.yaml
@@ -13,7 +13,7 @@ on:
         description: Rancher upgrade version
         required: true
         type: string
-        default: latest/devel/2.10
+        default: head/2.10
       k8s_upgrade_minor_version:
         description: K8s minor version to test
         default: "1.31"

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -8,7 +8,7 @@ on:
         description: Rancher version channel/version/head_version
         required: true
         type: string
-        default: latest/devel/2.10
+        default: head/2.10
       k3s_version:
         description: k3s version of local cluster
         required: true

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -8,7 +8,7 @@ on:
         description: Rancher version channel/version/head_version
         required: true
         type: string
-        default: head/2.10
+        default: head/2.12
       k3s_version:
         description: k3s version of local cluster
         required: true

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
 	github.com/rancher/shepherd v0.0.0-20250205140852-ba6d2793aaff // rancher/shepherd main commit

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793 h1:NIioaBqH1VA1NbAqWRG+SjxSW7z/EOU8jcEIFbDW8lc=
-github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250415062725-efdf8e57c793/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a h1:s/tYg69rbYbIa93r4oZcZKU445rfH4mbhHQM/jafm4w=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20250711071119-c33617a1af7a/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/aks-operator v1.10.0 h1:9PGJUyzso2Tg9o64sYI6++mCke9ToRchvN5uZqPV+kY=


### PR DESCRIPTION
### What does this PR do?
ref. https://github.com/rancher-sandbox/ele-testhelpers/pull/72

bump of testhelpers to support new "official" head repos & RANCHER_VERSION env updated in workflows

### Checklist:
- [ ] GitHub Actions (if applicable) AKS p0_prov on `head/2.12` https://github.com/rancher/hosted-providers-e2e/actions/runs/16220987775, AKS K8s Upgrade test https://github.com/rancher/hosted-providers-e2e/actions/runs/16221507436
