### PR TITLE
use AliConfig.ClusterID for SDK calls instead of Rancher cluster.ID

### DIFF
--- a/cattle-config-import.yaml
+++ b/cattle-config-import.yaml
@@ -14,7 +14,7 @@ aliClusterConfig:
       encrypted: "false"
       size: 40
     desiredSize: 2
-    imageId: aliyun_3_x64_20G_alibase_20241218.vhd
+    imageId: aliyun_3_x64_20G_container_optimized_alibase_20251215.vhd
     imageType: AliyunLinux3
     instanceTypes:
     - ecs.c7.xlarge

--- a/hosted/alibaba/helper/helper_cluster.go
+++ b/hosted/alibaba/helper/helper_cluster.go
@@ -26,6 +26,20 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+// GetAlibabaClusterID returns the Alibaba cluster ID from the cluster object.
+// For imported clusters, it returns AliConfig.ClusterID.
+// For provisioned clusters, after sync, AliConfig.ClusterID should be populated.
+func GetAlibabaClusterID(cluster *management.Cluster) (string, error) {
+	if cluster.AliConfig != nil && cluster.AliConfig.ClusterID != "" {
+		return cluster.AliConfig.ClusterID, nil
+	}
+	// Fallback: try to get from UpstreamSpec if available
+	if cluster.AliStatus != nil && cluster.AliStatus.UpstreamSpec != nil && cluster.AliStatus.UpstreamSpec.ClusterID != "" {
+		return cluster.AliStatus.UpstreamSpec.ClusterID, nil
+	}
+	return "", fmt.Errorf("no Alibaba cluster ID found for cluster %s (Rancher ID: %s)", cluster.Name, cluster.ID)
+}
+
 // CreateACKHostedCluster creates an ACK hosted cluster
 func CreateAlibabaHostedCluster(client *rancher.Client, displayName, cloudCredentialID, kubernetesVersion, region string, updateFunc func(clusterConfig *ali.ClusterConfig)) (*management.Cluster, error) {
 	// Load aliClusterConfig from YAML config

--- a/hosted/alibaba/p1/p1_suite_test.go
+++ b/hosted/alibaba/p1/p1_suite_test.go
@@ -79,7 +79,11 @@ func syncK8sVersionUpgradeFromRancher(cluster *management.Cluster, csClient *cs.
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
-			clusterResp, err := helper.CheckClusterK8sVersionOnAlibaba(csClient, cluster.ID)
+			aliClusterID, err := helper.GetAlibabaClusterID(cluster)
+			if err != nil {
+				return false
+			}
+			clusterResp, err := helper.CheckClusterK8sVersionOnAlibaba(csClient, aliClusterID)
 			Expect(err).NotTo(HaveOccurred())
 			current := clusterResp
 			GinkgoLogr.Info("Waiting for upgraded k8s version to sync on alibaba...")
@@ -98,7 +102,9 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, csClient *cs.Client
 			return
 		}
 		GinkgoLogr.Info(fmt.Sprintf("Upgrading cluster on alibaba console to K8s version %s", upgradeToVersion))
-		err = helper.UpgradeACKOnAlibaba(csClient, cluster.ID, upgradeToVersion)
+		aliClusterID, err := helper.GetAlibabaClusterID(cluster)
+		Expect(err).To(BeNil())
+		err = helper.UpgradeACKOnAlibaba(csClient, aliClusterID, upgradeToVersion)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
@@ -114,8 +120,8 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, csClient *cs.Client
 
 func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, rancherClient *rancher.Client, upgradeToVersion string) {
 	GinkgoLogr.Info(fmt.Sprintf("Syncing nodepool changes from Alibaba to Rancher for cluster %s", cluster.Name))
-	clusterID := cluster.ID
-	var err error
+	aliClusterID, err := helper.GetAlibabaClusterID(cluster)
+	Expect(err).To(BeNil())
 
 	if upgradeToVersion != "" {
 		By("upgrading the control plane k8s version", func() {
@@ -126,7 +132,7 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 				GinkgoLogr.Info("Cluster already at target version " + upgradeToVersion + ", skipping upgrade")
 				return
 			}
-			err = helper.UpgradeACKOnAlibaba(csClient, clusterID, upgradeToVersion)
+			err = helper.UpgradeACKOnAlibaba(csClient, aliClusterID, upgradeToVersion)
 			Expect(err).To(BeNil())
 
 			Eventually(func() bool {
@@ -146,7 +152,7 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 	currentNPCount := len(cluster.AliStatus.UpstreamSpec.NodePools)
 
 	By("Adding a nodepool", func() {
-		_, err := helper.AddNodePoolOnAlibaba(csClient, npName, clusterID, nodeCount, cluster.AliStatus.UpstreamSpec.ResourceGroupID, cluster.AliStatus.UpstreamSpec.VSwitchIDs)
+		_, err := helper.AddNodePoolOnAlibaba(csClient, npName, aliClusterID, nodeCount, cluster.AliStatus.UpstreamSpec.ResourceGroupID, cluster.AliStatus.UpstreamSpec.VSwitchIDs)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
@@ -167,13 +173,13 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 	})
 
 	var npID string
-	npID, err = helper.GetNodePoolIDByName(csClient, clusterID, npName)
+	npID, err = helper.GetNodePoolIDByName(csClient, aliClusterID, npName)
 	Expect(err).To(BeNil())
 	Expect(npID).ToNot(BeEmpty(), "Could not find ID for new nodepool")
 
 	By("Scaling the nodepool", func() {
 		const scaleCount = nodeCount + 1
-		err := helper.ScaleNodePoolOnAlibaba(csClient, clusterID, scaleCount, npID)
+		err := helper.ScaleNodePoolOnAlibaba(csClient, aliClusterID, scaleCount, npID)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
@@ -191,12 +197,12 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 
 		// Wait for nodepool to be active on Alibaba before proceeding
 		Eventually(func() bool {
-			return helper.IsNodePoolActive(csClient, clusterID, npID)
+			return helper.IsNodePoolActive(csClient, aliClusterID, npID)
 		}, "10m", "10s").Should(BeTrue(), "Timed out waiting for nodepool to become active after scaling")
 	})
 
 	By("Deleting a nodepool", func() {
-		err := helper.DeleteNodePoolOnAlibaba(csClient, clusterID, npID)
+		err := helper.DeleteNodePoolOnAlibaba(csClient, aliClusterID, npID)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {


### PR DESCRIPTION
### What does this PR do?
Fixes the problem with sync_provisioning and sync_import alibaba tests.
github action [job](https://github.com/rancher/hosted-providers-e2e/actions/runs/24333534155/job/71044836141#:~:text=280-,errMsg%3A%20%22SDKError%3A%5Cn%20%20%20StatusCode%3A%20404%5Cn%20%20%20Code%3A%20ErrorClusterNotFound%5Cn%20%20%20Message%3A%20code,281,-Description%3A%20%22%3Cnil%3E%22%2C) that fails 

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [X] GitHub Actions (if applicable) https://github.com/rancher/hosted-providers-e2e/actions/runs/24335370868

### Special notes for your reviewer:
