### PR TITLE
add k8s chart support upgrade tests and auto-detect operator chart version

### DIFF
--- a/.github/workflows/alibaba.yaml
+++ b/.github/workflows/alibaba.yaml
@@ -1,6 +1,6 @@
 # This workflow calls the main workflow with custom variables
 name: Alibaba-E2E
-run-name: Alibaba on Rancher ${{ inputs.rancher_version || 'head/2.14' }} deployed on ${{ inputs.k3s_version || 'v1.35.1+k3s1' }}
+run-name: Alibaba on Rancher ${{ inputs.rancher_version || 'head/2.14' }} deployed on ${{ inputs.k3s_version || 'v1.35.4+k3s1' }}
 permissions:
   contents: read
 on:
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # Allow running manually on demand
     inputs:
       rancher_version:
-        description: Rancher version channel/version/head_version latest/latest, latest/2.9.3[-rc2], prime/2.9.3, prime/devel/2.9, prime-optimus/2.9.3-rc2
+        description: Rancher version channel/version/head_version (e.g., prime/2.13.3, head/2.14)
         required: true
         type: string
         default: head/2.14
@@ -18,7 +18,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.34.1+k3s1
+        default: v1.35.4+k3s1
       runner_template:
         description: Runner template to use
         default: hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3
@@ -28,11 +28,6 @@ on:
         default: true
         required: true
         type: boolean
-      chart_version:
-        description: Alibaba operator chart version
-        required: false
-        type: string
-        default: 108.2.0+up1.13.2-rc.1
       destroy_runner:
         description: Destroy the auto-generated self-hosted runner
         default: true
@@ -50,7 +45,7 @@ on:
         default: 'hostname/password'
         type: string
       tests_to_run:
-        description: Tests to run (p0_provisioning/p0_import/sync_provisioning/sync_import)
+        description: Tests to run (p0_provisioning/p0_import/p1_provisioning/p1_import/sync_provisioning/sync_import/k8s_chart_support_provisioning/k8s_chart_support_import/k8s_chart_support_upgrade_provisioning/k8s_chart_support_upgrade_import)
         type: string
         required: true
         default: p0_provisioning
@@ -58,6 +53,14 @@ on:
         description: Qase run ID where the results will be reported (auto|none|existing_run_id)
         default: none
         type: string
+      rancher_upgrade_version:
+        description: Rancher upgrade version (use head/<minor> for head versions)
+        type: string
+        default: head/2.14
+      k8s_upgrade_minor_version:
+        description: K8s minor version to test for upgrade
+        type: string
+        default: "1.35"
 
 jobs:
   alibaba-e2e:
@@ -66,9 +69,9 @@ jobs:
     with:
       hosted_provider: alibaba
       rancher_version: ${{ inputs.rancher_version || 'head/2.14' }}
-      k3s_version: ${{ inputs.k3s_version || 'v1.35.1+k3s1' }}
+      k3s_version: ${{ inputs.k3s_version || 'v1.35.4+k3s1' }}
       operator_nightly_chart: ${{ inputs.operator_nightly_chart == true || (github.event_name == 'schedule' && true) }}
-      chart_version: ${{ inputs.chart_version || '108.2.0+up1.13.2-rc.1' }}
+      chart_version: ${{ inputs.chart_version }}
       tests_to_run: ${{ inputs.tests_to_run || (github.event.schedule == '0 1 1,15 * *' && 'p0_provisioning/p0_import') || (github.event.schedule == '0 1 2,16 * *' && 'sync_provisioning/sync_import') }}
       destroy_runner: ${{ inputs.destroy_runner ==true || (github.event_name == 'schedule' && true) }}
       runner_template: ${{ inputs.runner_template || 'hosted-prov-e2e-ci-runner-spot-n2-highmem-16-gl-template-v3' }}
@@ -76,3 +79,5 @@ jobs:
       downstream_cluster_cleanup: ${{ inputs.downstream_cluster_cleanup == true || (github.event_name == 'schedule' && true) }}
       proxy: ${{ inputs.proxy == true }}
       qase_run_id: ${{ inputs.qase_run_id || 'auto' }}
+      rancher_upgrade_version: ${{ inputs.rancher_upgrade_version || 'head/2.14' }}
+      k8s_upgrade_minor_version: ${{ inputs.k8s_upgrade_minor_version || '1.35' }}

--- a/.github/workflows/k8s-chart-upgrade-matrix.yaml
+++ b/.github/workflows/k8s-chart-upgrade-matrix.yaml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       rancher_version:
-        description: Rancher version channel/version. This must be a released stable rancher version.
+        description: Rancher version channel/version. This must be a released stable rancher version (use prime for Alibaba).
         required: true
         type: string
-        default: latest/2.13.3
+        default: prime/2.13.5
       rancher_upgrade_version:
-        description: Rancher upgrade version
+        description: Rancher upgrade version (use head/<minor> for head versions)
         required: true
         type: string
         default: head/2.14
@@ -49,7 +49,7 @@ on:
         description: Providers to the run the test on
         required: true
         type: string
-        default: '["eks", "gke", "aks"]'
+        default: '["eks", "gke", "aks", "alibaba"]'
 
 jobs:
   e2e-tests:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -67,6 +67,8 @@ env:
   ALIBABA_ACCESS_KEY_ID: ${{ secrets.ALIBABA_ACCESS_KEY_ID }}
   ALIBABA_ACCESS_KEY_SECRET: ${{ secrets.ALIBABA_ACCESS_KEY_SECRET }}
   ALIBABA_OPERATOR_VERSION: ${{ inputs.chart_version }}
+  ALIBABA_OPERATOR_REGISTRY: ${{ secrets.ALIBABA_OPERATOR_REGISTRY }}
+  SYSTEM_DEFAULT_REGISTRY: ${{ secrets.SYSTEM_DEFAULT_REGISTRY }}
   ALIBABA_RESOURCE_GROUP_ID: ${{ secrets.ALIBABA_RESOURCE_GROUP_ID }}
   GCP_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
   AKS_CLIENT_ID: ${{ secrets.AKS_CLIENT_ID }}
@@ -230,7 +232,7 @@ jobs:
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           PROXY_HOST: ${{ env.PROXY_HOST }}
           RANCHER_BEHIND_PROXY: ${{ env.RANCHER_BEHIND_PROXY }}
-          SKIP_RANCHER_INSTALL: ${{ startsWith(inputs.tests_to_run, 'k8s_chart_support_upgrade') == true || inputs.rancher_installed != 'hostname/password' }}
+          SKIP_RANCHER_INSTALL: ${{ startsWith(inputs.tests_to_run, 'k8s_chart_support') == true || inputs.rancher_installed != 'hostname/password' }}
         run: |
           if [ ${{ inputs.operator_nightly_chart }} == true ]; then
             export NIGHTLY_CHART="enabled"
@@ -336,6 +338,8 @@ jobs:
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-provisioning.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
+          RANCHER_UPGRADE_VERSION: ${{ inputs.rancher_upgrade_version }}
+          K8S_UPGRADE_MINOR_VERSION: ${{ inputs.k8s_upgrade_minor_version }}
         run: |
           make e2e-k8s-chart-support-provisioning-tests
 
@@ -346,6 +350,8 @@ jobs:
           RANCHER_PASSWORD: ${{ env.RANCHER_PASSWORD }}
           CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config-import.yaml
           QASE_RUN_ID: ${{ steps.qase.outputs.qase_run_id }}
+          RANCHER_UPGRADE_VERSION: ${{ inputs.rancher_upgrade_version }}
+          K8S_UPGRADE_MINOR_VERSION: ${{ inputs.k8s_upgrade_minor_version }}
         run: |
           make e2e-k8s-chart-support-import-tests
 
@@ -471,11 +477,17 @@ jobs:
             OPERATOR_RELEASE_NAME="rancher-${{ inputs.hosted_provider }}-operator"
           fi
           
-          OPERATOR_HELM_VERSION=$(helm get metadata ${OPERATOR_RELEASE_NAME} -n cattle-system -o json 2>/dev/null | jq -r .version)
+          OPERATOR_HELM_VERSION=$(helm get metadata ${OPERATOR_RELEASE_NAME} -n cattle-system -o json 2>/dev/null | jq -r .version || true)
           if [[ -n "$OPERATOR_HELM_VERSION" && "$OPERATOR_HELM_VERSION" != "null" ]]; then
             echo "Installed ${OPERATOR_RELEASE_NAME} chart version: $OPERATOR_HELM_VERSION" >> ${GITHUB_STEP_SUMMARY}
           else
-            echo "Operator chart not found or not installed" >> ${GITHUB_STEP_SUMMARY}
+            # For upgrade tests, the operator is uninstalled during cleanup; check helm history for the last known version
+            OPERATOR_HELM_VERSION=$(helm history ${OPERATOR_RELEASE_NAME} -n cattle-system -o json 2>/dev/null | jq -r '.[-1].chart' || true)
+            if [[ -n "$OPERATOR_HELM_VERSION" && "$OPERATOR_HELM_VERSION" != "null" ]]; then
+              echo "Last known ${OPERATOR_RELEASE_NAME} chart: $OPERATOR_HELM_VERSION (uninstalled during test cleanup)" >> ${GITHUB_STEP_SUMMARY}
+            else
+              echo "Operator chart not found or not installed" >> ${GITHUB_STEP_SUMMARY}
+            fi
           fi
           
           if [[ ${{ inputs.tests_to_run }} =~ "backup_restore" ]]; then

--- a/.github/workflows/release-matrix.yaml
+++ b/.github/workflows/release-matrix.yaml
@@ -14,7 +14,7 @@ on:
         description: k3s version of local cluster
         required: true
         type: string
-        default: v1.35.1+k3s1
+        default: v1.35.4+k3s1
       operator_nightly_chart:
         description: Install hosted-provider nightly chart
         default: false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 .idea
 config
 *.test
+.claude

--- a/hosted/alibaba/helper/helper_cluster.go
+++ b/hosted/alibaba/helper/helper_cluster.go
@@ -500,7 +500,10 @@ func ScaleNodePool(cluster *management.Cluster, client *rancher.Client, nodeCoun
 		Eventually(func() bool {
 			ginkgo.GinkgoLogr.Info("Waiting for the node count change to appear in AliStatus.UpstreamSpec ...")
 			cluster, err = client.Management.Cluster.ByID(cluster.ID)
-			Expect(err).To(BeNil())
+			if err != nil {
+				ginkgo.GinkgoLogr.Info(fmt.Sprintf("Error fetching cluster: %v, retrying...", err))
+				return false
+			}
 			upstreamNodePools := cluster.AliStatus.UpstreamSpec.NodePools
 			for i := range upstreamNodePools {
 				if np := upstreamNodePools[i]; *np.DesiredSize != nodeCount {

--- a/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
+++ b/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_import_upgrade_test.go
@@ -1,0 +1,52 @@
+package k8s_chart_support_upgrade_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/alibaba/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("K8sChartSupportUpgradeImport", func() {
+	var cluster *management.Cluster
+	BeforeEach(func() {
+		csClient, err := helper.CreateAliClient(region)
+		Expect(err).To(BeNil())
+
+		alibabaClusterID, err := helper.CreateACKClusterOnAlibaba(csClient, region, clusterName, k8sVersion, "1", helpers.GetACKResourceGroupID(), helpers.GetCommonMetadataLabels())
+		Expect(err).To(BeNil())
+
+		cluster, err = helper.ImportACKHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, region, alibabaClusterID)
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+	})
+	AfterEach(func() {
+		if ctx.ClusterCleanup && cluster != nil {
+			err := helper.DeleteACKHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+
+			alibabaClusterID, err := helper.GetAlibabaClusterID(cluster)
+			if err == nil && alibabaClusterID != "" {
+				csClient, err := helper.CreateAliClient(region)
+				if err == nil {
+					err = helper.DeleteACKClusterOnAlibaba(csClient, alibabaClusterID)
+					Expect(err).To(BeNil())
+				}
+			}
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
+	It("should successfully test k8s chart support import in an upgrade scenario", func() {
+		GinkgoLogr.Info(fmt.Sprintf("Testing K8s %s chart support for import on Rancher upgraded from %s to %s", helpers.K8sUpgradedMinorVersion, helpers.RancherFullVersion, helpers.RancherUpgradeFullVersion))
+
+		testCaseID = 267
+		commonchecks(&ctx, cluster, clusterName, helpers.RancherUpgradeFullVersion, helpers.K8sUpgradedMinorVersion)
+	})
+
+})

--- a/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_provisioning_upgrade_test.go
+++ b/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_provisioning_upgrade_test.go
@@ -1,0 +1,38 @@
+package k8s_chart_support_upgrade_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/alibaba/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var _ = Describe("K8sChartSupportUpgradeProvisioning", func() {
+	var cluster *management.Cluster
+	BeforeEach(func() {
+		var err error
+		cluster, err = helper.CreateAlibabaHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, region, nil)
+		Expect(err).To(BeNil())
+		cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+	})
+	AfterEach(func() {
+		if ctx.ClusterCleanup && cluster != nil {
+			err := helper.DeleteACKHostCluster(cluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		} else {
+			fmt.Println("Skipping downstream cluster deletion: ", clusterName)
+		}
+	})
+	It("should successfully test k8s chart support provisioning in an upgrade scenario", func() {
+		GinkgoLogr.Info(fmt.Sprintf("Testing K8s %s chart support for provisioning on Rancher upgraded from %s to %s", helpers.K8sUpgradedMinorVersion, helpers.RancherFullVersion, helpers.RancherUpgradeFullVersion))
+
+		testCaseID = 265
+		commonchecks(&ctx, cluster, clusterName, helpers.RancherUpgradeFullVersion, helpers.K8sUpgradedMinorVersion)
+	})
+
+})

--- a/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
+++ b/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
@@ -196,19 +196,21 @@ func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clus
 		Expect(err).To(BeNil())
 	})
 
-	By("provisioning a new cluster to validate provisioning works after the upgrade", func() {
-		newClusterName := namegen.AppendRandomString(helpers.ClusterNamePrefix)
-		GinkgoLogr.Info(fmt.Sprintf("Provisioning new cluster %s with K8s version %s", newClusterName, *latestVersion))
+	if !helpers.IsImport {
+		By("provisioning a new cluster to validate provisioning works after the upgrade", func() {
+			newClusterName := namegen.AppendRandomString(helpers.ClusterNamePrefix)
+			GinkgoLogr.Info(fmt.Sprintf("Provisioning new cluster %s with K8s version %s", newClusterName, *latestVersion))
 
-		newCluster, err := helper.CreateAlibabaHostedCluster(ctx.RancherAdminClient, newClusterName, ctx.CloudCredID, *latestVersion, region, nil)
-		Expect(err).To(BeNil())
-		newCluster, err = helpers.WaitUntilClusterIsReady(newCluster, ctx.RancherAdminClient)
-		Expect(err).To(BeNil())
-		helpers.ClusterIsReadyChecks(newCluster, ctx.RancherAdminClient, newClusterName)
+			newCluster, err := helper.CreateAlibabaHostedCluster(ctx.RancherAdminClient, newClusterName, ctx.CloudCredID, *latestVersion, region, nil)
+			Expect(err).To(BeNil())
+			newCluster, err = helpers.WaitUntilClusterIsReady(newCluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+			helpers.ClusterIsReadyChecks(newCluster, ctx.RancherAdminClient, newClusterName)
 
-		err = helper.DeleteACKHostCluster(newCluster, ctx.RancherAdminClient)
-		Expect(err).To(BeNil())
-	})
+			err = helper.DeleteACKHostCluster(newCluster, ctx.RancherAdminClient)
+			Expect(err).To(BeNil())
+		})
+	}
 
 	var downgradeVersion string
 	By("fetching a value to downgrade to", func() {

--- a/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
+++ b/hosted/alibaba/k8s_chart_support/upgrade/k8s_chart_support_upgrade_suite_test.go
@@ -1,0 +1,263 @@
+package k8s_chart_support_upgrade_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+	. "github.com/rancher-sandbox/qase-ginkgo"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	nodestat "github.com/rancher/shepherd/extensions/nodes"
+	"github.com/rancher/shepherd/extensions/workloads/pods"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+
+	"github.com/rancher/hosted-providers-e2e/hosted/alibaba/helper"
+	"github.com/rancher/hosted-providers-e2e/hosted/helpers"
+)
+
+var (
+	ctx                     helpers.RancherContext
+	clusterName, k8sVersion string
+	region                  = helpers.GetACKRegion()
+	testCaseID              int64
+	k                       = kubectl.New()
+)
+
+func TestK8sChartSupportUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8sChartSupportUpgrade Suite")
+}
+
+var _ = BeforeEach(func() {
+	// For upgrade tests, the rancher version should not be an unreleased version (for e.g. 2.9-head)
+	Expect(helpers.RancherFullVersion).To(SatisfyAll(Not(BeEmpty()), Not(ContainSubstring("devel"))))
+	Expect(helpers.RancherUpgradeFullVersion).ToNot(BeEmpty())
+	Expect(helpers.K8sUpgradedMinorVersion).ToNot(BeEmpty())
+	Expect(helpers.Kubeconfig).ToNot(BeEmpty())
+
+	By("Adding the necessary chart repos", func() {
+		helpers.AddRancherCharts()
+	})
+
+	By(fmt.Sprintf("Installing Rancher Manager %s", helpers.RancherFullVersion), func() {
+		rancherChannel, rancherVersion, rancherHeadVersion := helpers.GetRancherVersions(helpers.RancherFullVersion)
+		helpers.InstallRancherManager(k, helpers.RancherHostname, rancherChannel, rancherVersion, rancherHeadVersion, "", "")
+		helpers.CheckRancherDeployments(k)
+	})
+
+	By("Installing Alibaba operator charts", func() {
+		helpers.InstallAlibabaOperatorCharts(k, os.Getenv("ALIBABA_OPERATOR_VERSION"), os.Getenv("ALIBABA_OPERATOR_REGISTRY"))
+	})
+
+	helpers.CommonSynchronizedBeforeSuite()
+	ctx = helpers.CommonBeforeSuite()
+
+	By("creating and using a more permanent token", func() {
+		token, err := ctx.RancherAdminClient.Management.Token.Create(&management.Token{})
+		Expect(err).NotTo(HaveOccurred())
+		rancherConfig := new(rancher.Config)
+		config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+		rancherConfig.AdminToken = token.Token
+		config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+		rancherAdminClient, err := rancher.NewClient(rancherConfig.AdminToken, ctx.Session)
+		Expect(err).To(BeNil())
+		ctx.RancherAdminClient = rancherAdminClient
+	})
+
+	var err error
+	clusterName = namegen.AppendRandomString(helpers.ClusterNamePrefix)
+	k8sVersion, err = helper.GetK8sVersion(ctx.RancherAdminClient, false)
+	Expect(err).To(BeNil())
+	Expect(k8sVersion).ToNot(BeEmpty())
+	GinkgoLogr.Info(fmt.Sprintf("Using ACK version %s for cluster %s", k8sVersion, clusterName))
+})
+
+var _ = AfterEach(func() {
+	// The test must restore the env to its original state, so we install rancher back to its original version and uninstall the operator charts
+	// Restoring rancher back to its original state is necessary because in case DOWNSTREAM_CLUSTER_CLEANUP is set to false; in which case clusters will be retained for the next test.
+	// Once the operator is uninstalled, it might be reinstalled since the cluster exists, and installing rancher back to its original state ensures that the version is not the one we want to test.
+	By(fmt.Sprintf("Installing Rancher back to its original version %s", helpers.RancherFullVersion), func() {
+		rancherChannel, rancherVersion, rancherHeadVersion := helpers.GetRancherVersions(helpers.RancherFullVersion)
+		helpers.InstallRancherManager(k, helpers.RancherHostname, rancherChannel, rancherVersion, rancherHeadVersion, "", "")
+		helpers.CheckRancherDeployments(k)
+	})
+
+	By("Uninstalling the existing operator charts", func() {
+		helpers.UninstallOperatorCharts()
+	})
+})
+
+var _ = ReportBeforeEach(func(report SpecReport) {
+	// Reset case ID
+	testCaseID = -1
+})
+
+var _ = ReportAfterEach(func(report SpecReport) {
+	// Add result in Qase if asked
+	Qase(testCaseID, report)
+})
+
+func commonchecks(ctx *helpers.RancherContext, cluster *management.Cluster, clusterName, rancherUpgradedVersion, k8sUpgradedVersion string) {
+
+	helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+
+	var originalChartVersion string
+	By("checking the chart version", func() {
+		originalChartVersion = helpers.GetCurrentOperatorChartVersion()
+		Expect(originalChartVersion).ToNot(BeEmpty())
+		GinkgoLogr.Info("Original chart version: " + originalChartVersion)
+	})
+
+	By(fmt.Sprintf("upgrading rancher to %v", rancherUpgradedVersion), func() {
+		rancherChannel, rancherVersion, rancherHeadVersion := helpers.GetRancherVersions(rancherUpgradedVersion)
+		helpers.InstallRancherManager(k, helpers.RancherHostname, rancherChannel, rancherVersion, rancherHeadVersion, "none", "none")
+		helpers.CheckRancherDeployments(k)
+
+		By("ensuring operator pods are also up", func() {
+			Eventually(func() error {
+				return k.WaitForNamespaceWithPod(helpers.CattleSystemNS, fmt.Sprintf("ke.cattle.io/operator=%s", helpers.Provider))
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		})
+
+		By("ensuring the rancher client is connected", func() {
+			Eventually(func() bool {
+				isConnected, err := ctx.RancherAdminClient.IsConnected()
+				if err != nil || !isConnected {
+					return false
+				}
+				return true
+			}, tools.SetTimeout(2*time.Minute), 10*time.Second).Should(BeTrue(), "Rancher client not connected after upgrade")
+		})
+	})
+
+	By("making sure the local cluster is ready", func() {
+		const localClusterID = "local"
+		By("checking all management nodes are ready", func() {
+			err := nodestat.AllManagementNodeReady(ctx.RancherAdminClient, localClusterID, helpers.Timeout)
+			Expect(err).To(BeNil())
+		})
+
+		By("checking all pods are ready", func() {
+			podErrors := pods.StatusPods(ctx.RancherAdminClient, localClusterID)
+			Expect(podErrors).To(BeEmpty())
+		})
+	})
+
+	var upgradedChartVersion string
+	By("upgrading the operator chart to match the new Rancher version", func() {
+		// Alibaba operator is installed from OCI registry and not auto-upgraded by Rancher,
+		// so we need to explicitly upgrade it after the Rancher upgrade.
+		chartVersions := helpers.ListChartVersions("rancher-ali-operator")
+		Expect(chartVersions).ToNot(BeEmpty(), "No chart versions found in the registry")
+		latestChartVersion := chartVersions[0].DerivedVersion
+		GinkgoLogr.Info(fmt.Sprintf("Upgrading operator chart from %s to %s", originalChartVersion, latestChartVersion))
+		if helpers.VersionCompare(latestChartVersion, originalChartVersion) == 1 {
+			helpers.UpdateOperatorChartsVersion(latestChartVersion)
+		}
+		upgradedChartVersion = helpers.GetCurrentOperatorChartVersion()
+		Expect(upgradedChartVersion).ToNot(BeEmpty())
+		Expect(helpers.VersionCompare(upgradedChartVersion, originalChartVersion)).To(BeNumerically(">=", 0))
+		GinkgoLogr.Info("Upgraded chart version: " + upgradedChartVersion)
+	})
+
+	By("making sure the downstream cluster is ready", func() {
+		var err error
+		cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+		Expect(err).To(BeNil())
+		helpers.ClusterIsReadyChecks(cluster, ctx.RancherAdminClient, clusterName)
+
+		// since no changes have been made to the cluster so far, we need reinstantiate AliConfig after fetching the cluster
+		if helpers.IsImport {
+			cluster.AliConfig = cluster.AliStatus.UpstreamSpec
+		}
+	})
+
+	var latestVersion *string
+	By(fmt.Sprintf("fetching a list of available k8s versions and ensure the v%s is present in the list and upgrading the cluster to it", k8sUpgradedVersion), func() {
+		versions, err := helper.ListALIAllVersions(ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+		Expect(versions).ToNot(BeEmpty())
+		GinkgoLogr.Info(fmt.Sprintf("Available ACK versions: %v", versions))
+
+		latestVersion = &versions[0]
+		Expect(*latestVersion).To(ContainSubstring(k8sUpgradedVersion))
+		Expect(helpers.VersionCompare(*latestVersion, cluster.Version.GitVersion)).To(BeNumerically("==", 1))
+
+		cluster, err = helper.UpgradeClusterKubernetesVersion(cluster, *latestVersion, ctx.RancherAdminClient, true, true, true)
+		Expect(err).To(BeNil())
+	})
+
+	By("provisioning a new cluster to validate provisioning works after the upgrade", func() {
+		newClusterName := namegen.AppendRandomString(helpers.ClusterNamePrefix)
+		GinkgoLogr.Info(fmt.Sprintf("Provisioning new cluster %s with K8s version %s", newClusterName, *latestVersion))
+
+		newCluster, err := helper.CreateAlibabaHostedCluster(ctx.RancherAdminClient, newClusterName, ctx.CloudCredID, *latestVersion, region, nil)
+		Expect(err).To(BeNil())
+		newCluster, err = helpers.WaitUntilClusterIsReady(newCluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+		helpers.ClusterIsReadyChecks(newCluster, ctx.RancherAdminClient, newClusterName)
+
+		err = helper.DeleteACKHostCluster(newCluster, ctx.RancherAdminClient)
+		Expect(err).To(BeNil())
+	})
+
+	var downgradeVersion string
+	By("fetching a value to downgrade to", func() {
+		downgradeVersion = helpers.GetDowngradeOperatorChartVersion(upgradedChartVersion)
+		Expect(downgradeVersion).ToNot(BeEmpty(), "No downgrade version found for chart version %s", upgradedChartVersion)
+		GinkgoLogr.Info("Downgrade version: " + downgradeVersion)
+	})
+
+	By("downgrading the chart version", func() {
+		helpers.DowngradeProviderChart(downgradeVersion)
+	})
+
+	By("making a change to the cluster (scaling the node pool) to validate functionality after chart downgrade", func() {
+		var err error
+		configNodePools := cluster.AliConfig.NodePools
+		initialNodeCount := *configNodePools[0].DesiredSize
+		cluster, err = helper.ScaleNodePool(cluster, ctx.RancherAdminClient, initialNodeCount+1, true, true)
+		Expect(err).To(BeNil())
+	})
+
+	By("uninstalling the operator chart", func() {
+		helpers.UninstallOperatorCharts()
+	})
+
+	By("re-installing the operator chart and validating it is at the latest/upgraded version", func() {
+		// Alibaba operator is not auto-managed by Rancher, so we explicitly re-install it.
+		// UpdateOperatorChartsVersion won't work here because it iterates over ListOperatorChart()
+		// which returns empty after uninstall.
+		helpers.InstallAlibabaOperatorCharts(k, upgradedChartVersion, os.Getenv("ALIBABA_OPERATOR_REGISTRY"))
+
+		By("ensuring that the chart is re-installed to the latest/upgraded version", func() {
+			helpers.WaitUntilOperatorChartInstallation(upgradedChartVersion, "", 0)
+		})
+	})
+
+	By("making a change(adding a nodepool) to the cluster to validate functionality after re-install", func() {
+		currentNodePoolNumber := len(cluster.AliConfig.NodePools)
+		var err error
+		cluster, err = helper.AddNodePool(cluster, ctx.RancherAdminClient, 1, "", false, false)
+		Expect(err).To(BeNil())
+
+		err = clusters.WaitClusterToBeUpgraded(ctx.RancherAdminClient, cluster.ID)
+		Expect(err).To(BeNil())
+
+		// Check if the desired config has been applied in Rancher
+		Eventually(func() int {
+			cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
+			Expect(err).To(BeNil())
+			return len(cluster.AliStatus.UpstreamSpec.NodePools)
+		}, tools.SetTimeout(20*time.Minute), 10*time.Second).Should(BeNumerically("==", currentNodePoolNumber+1))
+	})
+}

--- a/hosted/alibaba/p1/p1_suite_test.go
+++ b/hosted/alibaba/p1/p1_suite_test.go
@@ -80,7 +80,11 @@ func syncK8sVersionUpgradeFromRancher(cluster *management.Cluster, csClient *cs.
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
-			clusterResp, err := helper.CheckClusterK8sVersionOnAlibaba(csClient, cluster.ID)
+			aliClusterID, err := helper.GetAlibabaClusterID(cluster)
+			if err != nil {
+				return false
+			}
+			clusterResp, err := helper.CheckClusterK8sVersionOnAlibaba(csClient, aliClusterID)
 			Expect(err).NotTo(HaveOccurred())
 			current := clusterResp
 			GinkgoLogr.Info("Waiting for upgraded k8s version to sync on alibaba...")
@@ -99,7 +103,9 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, csClient *cs.Client
 			return
 		}
 		GinkgoLogr.Info(fmt.Sprintf("Upgrading cluster on alibaba console to K8s version %s", upgradeToVersion))
-		err = helper.UpgradeACKOnAlibaba(csClient, cluster.ID, upgradeToVersion)
+		aliClusterID, err := helper.GetAlibabaClusterID(cluster)
+		Expect(err).To(BeNil())
+		err = helper.UpgradeACKOnAlibaba(csClient, aliClusterID, upgradeToVersion)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
@@ -115,8 +121,8 @@ func syncK8sVersionUpgradeCheck(cluster *management.Cluster, csClient *cs.Client
 
 func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, rancherClient *rancher.Client, upgradeToVersion string) {
 	GinkgoLogr.Info(fmt.Sprintf("Syncing nodepool changes from Alibaba to Rancher for cluster %s", cluster.Name))
-	clusterID := cluster.ID
-	var err error
+	aliClusterID, err := helper.GetAlibabaClusterID(cluster)
+	Expect(err).To(BeNil())
 
 	if upgradeToVersion != "" {
 		By("upgrading the control plane k8s version", func() {
@@ -127,7 +133,7 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 				GinkgoLogr.Info("Cluster already at target version " + upgradeToVersion + ", skipping upgrade")
 				return
 			}
-			err = helper.UpgradeACKOnAlibaba(csClient, clusterID, upgradeToVersion)
+			err = helper.UpgradeACKOnAlibaba(csClient, aliClusterID, upgradeToVersion)
 			Expect(err).To(BeNil())
 
 			Eventually(func() bool {
@@ -147,7 +153,7 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 	currentNPCount := len(cluster.AliStatus.UpstreamSpec.NodePools)
 
 	By("Adding a nodepool", func() {
-		_, err := helper.AddNodePoolOnAlibaba(csClient, npName, clusterID, nodeCount, cluster.AliStatus.UpstreamSpec.ResourceGroupID, cluster.AliStatus.UpstreamSpec.VSwitchIDs)
+		_, err := helper.AddNodePoolOnAlibaba(csClient, npName, aliClusterID, nodeCount, cluster.AliStatus.UpstreamSpec.ResourceGroupID, cluster.AliStatus.UpstreamSpec.VSwitchIDs)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {
@@ -168,12 +174,12 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 	})
 
 	var npID string
-	npID, err = helper.GetNodePoolIDByName(csClient, clusterID, npName)
+	npID, err = helper.GetNodePoolIDByName(csClient, aliClusterID, npName)
 	Expect(err).To(BeNil())
 	Expect(npID).ToNot(BeEmpty(), "Could not find ID for new nodepool")
 	By("Scaling the nodepool", func() {
 		const scaleCount = nodeCount + 1
-		err := helper.ScaleNodePoolOnAlibaba(csClient, clusterID, scaleCount, npID)
+		err := helper.ScaleNodePoolOnAlibaba(csClient, aliClusterID, scaleCount, npID)
 		Expect(err).To(BeNil())
 		Eventually(func() bool {
 			cluster, err = rancherClient.Management.Cluster.ByID(cluster.ID)
@@ -190,12 +196,12 @@ func aliNodePoolSyncCheck(cluster *management.Cluster, csClient *cs.Client, ranc
 
 		// Wait for nodepool to be active on Alibaba before proceeding
 		Eventually(func() bool {
-			return helper.IsNodePoolActive(csClient, clusterID, npID)
+			return helper.IsNodePoolActive(csClient, aliClusterID, npID)
 		}, "10m", "10s").Should(BeTrue(), "Timed out waiting for nodepool to become active after scaling")
 	})
 
 	By("Deleting a nodepool", func() {
-		err := helper.DeleteNodePoolOnAlibaba(csClient, clusterID, npID)
+		err := helper.DeleteNodePoolOnAlibaba(csClient, aliClusterID, npID)
 		Expect(err).To(BeNil())
 
 		Eventually(func() bool {

--- a/hosted/helpers/helper_charts.go
+++ b/hosted/helpers/helper_charts.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -82,7 +83,15 @@ func WaitUntilOperatorChartInstallation(chartVersion, comparator string, compare
 // UpdateOperatorChartsVersion updates the operator charts to a given chart version and validates that the current version is same as provided
 func UpdateOperatorChartsVersion(updateChartVersion string) {
 	for _, chart := range ListOperatorChart() {
-		err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart.Name, fmt.Sprintf("%s/%s", catalog.RancherChartRepo, chart.Name), "--namespace", CattleSystemNS, "--version", updateChartVersion, "--wait")
+		var chartSource string
+		if Provider == "alibaba" {
+			registry := getAlibabaOCIRegistry()
+			Expect(registry).ToNot(BeEmpty(), "ALIBABA_OPERATOR_REGISTRY environment variable is not set")
+			chartSource = fmt.Sprintf("%s/%s", registry, chart.Name)
+		} else {
+			chartSource = fmt.Sprintf("%s/%s", catalog.RancherChartRepo, chart.Name)
+		}
+		err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart.Name, chartSource, "--namespace", CattleSystemNS, "--version", updateChartVersion, "--wait")
 		if err != nil {
 			Expect(err).To(BeNil(), "UpdateOperatorChartsVersion Failed")
 		}
@@ -103,7 +112,12 @@ func UninstallOperatorCharts() {
 
 // ListOperatorChart lists the installed provider charts for a provider in cattle-system; it fetches the provider value using Provider
 func ListOperatorChart() (operatorCharts []HelmChart) {
-	cmd := exec.Command("helm", "list", "--namespace", CattleSystemNS, "-o", "json", "--filter", fmt.Sprintf("%s-operator", Provider))
+	// The Alibaba chart is named rancher-ali-operator, not rancher-alibaba-operator
+	providerFilter := Provider
+	if Provider == "alibaba" {
+		providerFilter = "ali"
+	}
+	cmd := exec.Command("helm", "list", "--namespace", CattleSystemNS, "-o", "json", "--filter", fmt.Sprintf("%s-operator", providerFilter))
 	output, err := cmd.Output()
 	Expect(err).To(BeNil(), "Failed to list chart %s", Provider)
 	ginkgo.GinkgoLogr.Info(string(output))
@@ -117,12 +131,41 @@ func ListOperatorChart() (operatorCharts []HelmChart) {
 
 // ListChartVersions lists all the available the chart version for a given chart name
 func ListChartVersions(chartName string) (charts []HelmChart) {
+	if Provider == "alibaba" {
+		return listAlibabaChartVersions(chartName)
+	}
 	cmd := exec.Command("helm", "search", "repo", chartName, "--versions", "-ojson", "--devel")
 	output, err := cmd.Output()
 	Expect(err).To(BeNil())
 	ginkgo.GinkgoLogr.Info(string(output))
 	err = json.Unmarshal(output, &charts)
 	Expect(err).To(BeNil())
+	return
+}
+
+// listAlibabaChartVersions queries the OCI registry for available versions of an Alibaba chart.
+// It probes multiple major version ranges (based on Rancher minor versions) to find available versions.
+func listAlibabaChartVersions(chartName string) (charts []HelmChart) {
+	registry := getAlibabaOCIRegistry()
+	if registry == "" {
+		ginkgo.GinkgoLogr.Info("ALIBABA_OPERATOR_REGISTRY environment variable is not set; cannot list chart versions")
+		return
+	}
+
+	chartRef := fmt.Sprintf("%s/%s", registry, chartName)
+
+	// Probe chart major versions 108-112 (corresponding to Rancher 2.13-2.17)
+	for major := 112; major >= 108; major-- {
+		versionConstraint := fmt.Sprintf("~%d", major)
+		version := fetchOCIChartVersion(chartRef, versionConstraint)
+		if version != "" {
+			charts = append(charts, HelmChart{
+				Name:           chartName,
+				DerivedVersion: version,
+			})
+		}
+	}
+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Alibaba chart versions found: %v", charts))
 	return
 }
 
@@ -137,4 +180,65 @@ func VersionCompare(v, o string) int {
 	oldVer, err := semver.ParseTolerant(o)
 	Expect(err).To(BeNil())
 	return latestVer.Compare(oldVer)
+}
+
+// GetAlibabaChartVersionForRancher fetches the appropriate Alibaba chart version for the current Rancher version.
+// It queries the OCI registry for the chart version matching the Rancher minor version.
+// Chart versions follow the pattern: 108.x.x+up1.13.x (for Rancher 2.13), 109.x.x+up1.14.x (for Rancher 2.14), etc.
+// The chart major version = Rancher minor version + 95 (e.g., 2.13 → 108, 2.14 → 109).
+func GetAlibabaChartVersionForRancher() string {
+	registry := getAlibabaOCIRegistry()
+	if registry == "" {
+		ginkgo.GinkgoLogr.Info("ALIBABA_OPERATOR_REGISTRY environment variable is not set; cannot auto-detect chart version")
+		return ""
+	}
+
+	_, rancherVersion, rancherHeadVersion := GetRancherVersions(RancherFullVersion)
+
+	ver := rancherVersion
+	if rancherHeadVersion != "" {
+		ver = rancherHeadVersion
+	}
+
+	parsedVer, err := semver.ParseTolerant(ver)
+	if err != nil {
+		ginkgo.GinkgoLogr.Info(fmt.Sprintf("Unable to parse Rancher version %q: %v", ver, err))
+		return ""
+	}
+
+	// Calculate chart major version: Rancher minor + 95 (e.g., 2.13 → 108, 2.14 → 109)
+	chartMajor := int(parsedVer.Minor) + 95
+
+	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Rancher version: %s, chart major version: %d", ver, chartMajor))
+
+	chartRef := fmt.Sprintf("%s/rancher-ali-operator", registry)
+	versionConstraint := fmt.Sprintf("~%d", chartMajor)
+
+	version := fetchOCIChartVersion(chartRef, versionConstraint)
+	if version != "" {
+		ginkgo.GinkgoLogr.Info(fmt.Sprintf("Found matching chart version %s for Rancher %s", version, ver))
+	}
+	return version
+}
+
+// getAlibabaOCIRegistry returns the Alibaba OCI registry URL from the ALIBABA_OPERATOR_REGISTRY env var.
+func getAlibabaOCIRegistry() string {
+	return os.Getenv("ALIBABA_OPERATOR_REGISTRY")
+}
+
+// fetchOCIChartVersion runs helm show chart against an OCI reference with a version constraint
+// and returns the chart version, or empty string on failure.
+func fetchOCIChartVersion(chartRef, versionConstraint string) string {
+	cmd := exec.Command("helm", "show", "chart", chartRef, "--version", versionConstraint)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "version:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "version:"))
+		}
+	}
+	return ""
 }

--- a/hosted/helpers/helper_charts.go
+++ b/hosted/helpers/helper_charts.go
@@ -82,16 +82,15 @@ func WaitUntilOperatorChartInstallation(chartVersion, comparator string, compare
 
 // UpdateOperatorChartsVersion updates the operator charts to a given chart version and validates that the current version is same as provided
 func UpdateOperatorChartsVersion(updateChartVersion string) {
+	var chartReg = catalog.RancherChartRepo
+	if Provider == "alibaba" {
+		chartReg = getAlibabaOCIRegistry()
+		Expect(chartReg).ToNot(BeEmpty(), "ALIBABA_OPERATOR_REGISTRY environment variable is not set")
+	}
+
 	for _, chart := range ListOperatorChart() {
-		var chartSource string
-		if Provider == "alibaba" {
-			registry := getAlibabaOCIRegistry()
-			Expect(registry).ToNot(BeEmpty(), "ALIBABA_OPERATOR_REGISTRY environment variable is not set")
-			chartSource = fmt.Sprintf("%s/%s", registry, chart.Name)
-		} else {
-			chartSource = fmt.Sprintf("%s/%s", catalog.RancherChartRepo, chart.Name)
-		}
-		err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart.Name, chartSource, "--namespace", CattleSystemNS, "--version", updateChartVersion, "--wait")
+		err := kubectl.RunHelmBinaryWithCustomErr("upgrade", "--install", chart.Name, fmt.Sprintf("%s/%s", chartReg, chart.Name), "--namespace", CattleSystemNS, "--version", updateChartVersion, "--wait")
+
 		if err != nil {
 			Expect(err).To(BeNil(), "UpdateOperatorChartsVersion Failed")
 		}

--- a/hosted/helpers/helper_install.go
+++ b/hosted/helpers/helper_install.go
@@ -198,6 +198,7 @@ func InstallRancherManager(k *kubectl.Kubectl, rancherHostname, rancherChannel, 
 		extraEnvIndex++
 		extraFlags = append(extraFlags, alibabaFlags...)
 	}
+
 	err := rancherEle.DeployRancherManager(rancherHostname, rancherChannel, rancherVersion, rancherHeadVersion, "none", proxyEnabled, extraFlags)
 	Expect(err).To(Not(HaveOccurred()))
 
@@ -363,16 +364,23 @@ func RestartRancher(k *kubectl.Kubectl) {
 *
 Install Alibaba operator charts
   - @param k kubectl structure
-  - @param chartVersion version of the operator charts (optional, uses default if empty)
+  - @param chartVersion version of the operator charts (optional, auto-detects latest if empty)
   - @param chartRegistry OCI registry URL (optional, uses default if empty)
   - @returns Nothing, the function will fail through Ginkgo in case of issue
 */
 func InstallAlibabaOperatorCharts(k *kubectl.Kubectl, chartVersion, chartRegistry string) {
-	if chartVersion == "" {
-		chartVersion = "108.1.0+up1.13.1-rc.1"
-	}
 	if chartRegistry == "" {
-		chartRegistry = "oci://stgregistry.suse.com/rancher/charts"
+		chartRegistry = getAlibabaOCIRegistry()
+	}
+
+	Expect(chartRegistry).ToNot(BeEmpty(), "ALIBABA_OPERATOR_REGISTRY environment variable is not set and no registry was provided")
+
+	if chartVersion == "" {
+		By("Fetching appropriate Alibaba operator chart version for Rancher", func() {
+			chartVersion = GetAlibabaChartVersionForRancher()
+			Expect(chartVersion).ToNot(BeEmpty(), "Failed to auto-detect Alibaba chart version for Rancher %s; ensure ALIBABA_OPERATOR_REGISTRY is set or set ALIBABA_OPERATOR_VERSION explicitly", RancherFullVersion)
+			GinkgoLogr.Info(fmt.Sprintf("Auto-detected Alibaba chart version: %s", chartVersion))
+		})
 	}
 
 	GinkgoLogr.Info(fmt.Sprintf("Installing Alibaba operator charts version %s from %s", chartVersion, chartRegistry))
@@ -386,10 +394,17 @@ func InstallAlibabaOperatorCharts(k *kubectl.Kubectl, chartVersion, chartRegistr
 	})
 
 	By("Installing rancher-ali-operator chart", func() {
-		RunHelmCmdWithRetry("install", "rancher-ali-operator",
+		args := []string{"install", "rancher-ali-operator",
 			"-n", "cattle-system",
-			chartRegistry+"/rancher-ali-operator",
-			"--version", chartVersion)
+			chartRegistry + "/rancher-ali-operator",
+			"--version", chartVersion,
+		}
+		// Override the image registry when SYSTEM_DEFAULT_REGISTRY is set
+		// (e.g. when using a staging registry whose images may not yet be available on the production registry).
+		if systemDefaultRegistry := os.Getenv("SYSTEM_DEFAULT_REGISTRY"); systemDefaultRegistry != "" {
+			args = append(args, "--set", "global.cattle.systemDefaultRegistry="+systemDefaultRegistry)
+		}
+		RunHelmCmdWithRetry(args...)
 		GinkgoLogr.Info("rancher-ali-operator chart installed successfully")
 	})
 


### PR DESCRIPTION
### What does this PR do?

- Add k8s_chart_support and k8s_chart_support_upgrade test suites for Alibaba
- Add InstallAlibabaOperatorCharts to auto-detect the correct rancher-ali-operator
  chart version from the OCI staging registry based on the Rancher minor version
  (chart major = Rancher minor + 95, e.g., Rancher 2.14 → chart 109.x)
- Override global.cattle.systemDefaultRegistry to stgregistry.suse.com when
  installing from staging OCI registry to avoid ImagePullBackOff
- Fix workflow defaults: use head/devel/<minor> instead of prime/devel/<minor>
  for head/devel Rancher versions (prime channel only has released charts)
- Remove hardcoded chart_version fallback from alibaba.yaml workflow

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable)
- https://github.com/rancher/hosted-providers-e2e/actions/runs/25359132640
- https://github.com/rancher/hosted-providers-e2e/actions/runs/25357236331

### Special notes for your reviewer:
