### PR TITLE
change janitor scheduled time from 3 to 6 UTC

### DIFF
--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 on:
   schedule:
-    - cron: "0 3 * * 0,1,4" # Every Sunday, Monday, and Thursday at 03:00 UTC
+    - cron: "0 6 * * 0,1,4" # Every Sunday, Monday, and Thursday at 06:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### What does this PR do?
Changes the janitor scheduled time from 3 UTC to 6 UTC. 
As of now Janitor runs while the P1 checks are still running, resulting in abrupt deletion of resources and failure in tests.
Hence, updating the Janitor scheduled time 3 hours later.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [X] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
