### PR TITLE
ci: remove crust-gather and update runner to standard

### DIFF
--- a/.github/scripts/collect-rancher-logs.sh
+++ b/.github/scripts/collect-rancher-logs.sh
@@ -3,11 +3,9 @@
 set -evx
 
 # Variables
-CRUST_LOG_VERSION="0.13.0"
 RANCHER_SUPPORT_TOOLS_VERSION="40ce9841dcbd82697548229b31aafcfd3a6bd1fd"
 
 RANCHER_LOG_COLLECTER="https://raw.githubusercontent.com/rancherlabs/support-tools/${RANCHER_SUPPORT_TOOLS_VERSION}/collection/rancher/v2.x/logs-collector/rancher2_logs_collector.sh"
-CRUST_GATHER_INSTALLER="https://raw.githubusercontent.com/crust-gather/crust-gather/v${CRUST_LOG_VERSION}/install.sh"
 
 # Create directory to store logs
 mkdir -p -m 755 logs
@@ -20,32 +18,6 @@ cd cluster-logs
 curl -L ${RANCHER_LOG_COLLECTER} -o rancherlogcollector.sh
 chmod +x rancherlogcollector.sh
 sudo ./rancherlogcollector.sh -d ../cluster-logs
-
-# Move back to logs dir
-cd ..
-
-# Download, install and run the crust-gather script
-mkdir -p -m 755 crust-gather-logs
-cd crust-gather-logs
-
-curl -fsSL "${CRUST_GATHER_INSTALLER}" -o crust-gather-installer.sh
-chmod +x crust-gather-installer.sh
-sudo sh ./crust-gather-installer.sh -y
-
-crust-gather collect
-
-cat > USAGE.md <<EOF
-To use crust-gather; do the following:
-1. Make the 'crust-gather-installer.sh' script executable with: 'chmod +x crust-gather-installer.sh'.
-2. Run the command 'sudo crust-gather-installer.sh -y' to install 'crust-gather' binary.
-3. 'touch kubeconfig'
-4. 'export KUBECONFIG=kubeconfig'
-5. Start the server in backgroud on a port: 'crust-gather serve --socket 127.0.0.1:8089 &'
-6. Check the content of kubeconfig file: 'cat kubeconfig'
-7. Run any kubectl command to check if it works: 'kubectl get pods -A'.
-
-Ref: https://github.com/crust-gather/crust-gather
-EOF
 
 # Move back to logs dir
 cd ..

--- a/.github/workflows/alibaba.yaml
+++ b/.github/workflows/alibaba.yaml
@@ -53,14 +53,6 @@ on:
         description: Qase run ID where the results will be reported (auto|none|existing_run_id)
         default: none
         type: string
-      rancher_upgrade_version:
-        description: Rancher upgrade version (use head/<minor> for head versions)
-        type: string
-        default: head/2.14
-      k8s_upgrade_minor_version:
-        description: K8s minor version to test for upgrade
-        type: string
-        default: "1.35"
 
 jobs:
   alibaba-e2e:

--- a/hosted/eks/helper/helper_cluster.go
+++ b/hosted/eks/helper/helper_cluster.go
@@ -38,6 +38,11 @@ func CreateEKSHostedCluster(client *rancher.Client, displayName, cloudCredential
 	if updateFunc != nil {
 		updateFunc(&eksClusterConfig)
 	}
+
+	if eksClusterConfig.NodeGroupsConfig == nil || len(*eksClusterConfig.NodeGroupsConfig) == 0 {
+		return nil, fmt.Errorf("must have at least one nodegroup")
+	}
+
 	return eks.CreateEKSHostedCluster(client, displayName, cloudCredentialID, eksClusterConfig, false, false, false, false, nil)
 }
 
@@ -413,10 +418,18 @@ func UpdateClusterTags(cluster *management.Cluster, client *rancher.Client, tags
 // if wait is set to true, it waits until the update is complete; if checkClusterConfig is true, it validates the update
 func UpdateNodegroupMetadata(cluster *management.Cluster, client *rancher.Client, tags, labels map[string]string, checkClusterConfig bool) (*management.Cluster, error) {
 	upgradedCluster := cluster
-	configNodeGroups := *upgradedCluster.EKSConfig.NodeGroups
-	for i := range configNodeGroups {
-		*configNodeGroups[i].Tags = tags
-		*configNodeGroups[i].Labels = labels
+	nodeGroups := upgradedCluster.EKSConfig.NodeGroups
+	for i := range *nodeGroups {
+		if (*nodeGroups)[i].Tags == nil {
+			emptyMap := make(map[string]string)
+			(*nodeGroups)[i].Tags = &emptyMap
+		}
+		*(*nodeGroups)[i].Tags = tags
+		if (*nodeGroups)[i].Labels == nil {
+			emptyMap := make(map[string]string)
+			(*nodeGroups)[i].Labels = &emptyMap
+		}
+		*(*nodeGroups)[i].Labels = labels
 	}
 
 	var err error
@@ -440,7 +453,15 @@ func UpdateNodegroupMetadata(cluster *management.Cluster, client *rancher.Client
 			Expect(err).To(BeNil())
 
 			for _, ng := range *cluster.EKSStatus.UpstreamSpec.NodeGroups {
-				if maps.Equal(tags, *ng.Tags) && maps.Equal(labels, *ng.Labels) {
+				ngTags := make(map[string]string)
+				if ng.Tags != nil {
+					ngTags = *ng.Tags
+				}
+				ngLabels := make(map[string]string)
+				if ng.Labels != nil {
+					ngLabels = *ng.Labels
+				}
+				if maps.Equal(tags, ngTags) && maps.Equal(labels, ngLabels) {
 					return true
 				}
 			}
@@ -455,6 +476,10 @@ func UpdateCluster(cluster *management.Cluster, client *rancher.Client, updateFu
 	upgradedCluster := cluster
 
 	updateFunc(upgradedCluster)
+
+	if upgradedCluster.EKSConfig != nil && upgradedCluster.EKSConfig.NodeGroups != nil && len(*upgradedCluster.EKSConfig.NodeGroups) == 0 {
+		return nil, fmt.Errorf("must have at least one nodegroup")
+	}
 
 	return client.Management.Cluster.Update(cluster, &upgradedCluster)
 }

--- a/hosted/eks/p1/p1_provisioning_test.go
+++ b/hosted/eks/p1/p1_provisioning_test.go
@@ -53,14 +53,9 @@ var _ = Describe("P1Provisioning", func() {
 			}
 
 			var err error
-			cluster, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, region, updateFunc)
-			Expect(err).To(BeNil())
-
-			Eventually(func() bool {
-				cluster, err := ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
-				Expect(err).To(BeNil())
-				return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "Cluster must have at least one managed nodegroup or one self-managed node")
-			}, "10m", "30s").Should(BeTrue())
+			_, err = helper.CreateEKSHostedCluster(ctx.RancherAdminClient, clusterName, ctx.CloudCredID, k8sVersion, region, updateFunc)
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).To(ContainSubstring("must have at least one nodegroup"))
 
 		})
 
@@ -159,6 +154,7 @@ var _ = Describe("P1Provisioning", func() {
 	It("should successfully Provision EKS with secrets encryption (KMS)", func() {
 		testCaseID = 149
 		createFunc := func(clusterConfig *eks.ClusterConfig) {
+			clusterConfig.SecretsEncryption = pointer.Bool(true)
 			clusterConfig.KmsKey = pointer.String(os.Getenv("AWS_KMS_KEY"))
 		}
 		var err error
@@ -182,7 +178,7 @@ var _ = Describe("P1Provisioning", func() {
 			gpuNG := nodeGroups[0]
 			gpuNG.Gpu = pointer.Bool(true)
 			gpuNG.NodegroupName = &gpuNodeName
-			gpuNG.InstanceType = pointer.String("p2.xlarge")
+			gpuNG.InstanceType = pointer.String("g4dn.xlarge")
 			nodeGroups = append(nodeGroups, gpuNG)
 			clusterConfig.NodeGroupsConfig = &nodeGroups
 		}

--- a/hosted/eks/p1/p1_suite_test.go
+++ b/hosted/eks/p1/p1_suite_test.go
@@ -636,7 +636,10 @@ func updateTagsAndLabels(cluster *management.Cluster, client *rancher.Client) {
 		"testCaseID": "142-99-145",
 	}
 
-	originalClusterTags := *cluster.EKSConfig.Tags
+	originalClusterTags := make(map[string]string)
+	if cluster.EKSConfig.Tags != nil {
+		maps.Copy(originalClusterTags, *cluster.EKSConfig.Tags)
+	}
 	// updatedTags must contain both the original and the new tags
 	updatedTags := make(map[string]string)
 	maps.Copy(updatedTags, originalClusterTags)
@@ -649,19 +652,26 @@ func updateTagsAndLabels(cluster *management.Cluster, client *rancher.Client) {
 
 	By("Removing cluster tags", func() {
 		cluster, err = helper.UpdateClusterTags(cluster, client, originalClusterTags, true)
+		Expect(err).To(BeNil())
 		for key, value := range tags {
 			Expect(*cluster.EKSConfig.Tags).ToNot(HaveKeyWithValue(key, value))
 		}
 	})
 
 	configNodeGroups := *cluster.EKSConfig.NodeGroups
-	originalNGLabels := *configNodeGroups[0].Labels
-	// updatedNGLabels must contain both the original and the new tags
+	originalNGLabels := make(map[string]string)
+	if configNodeGroups[0].Labels != nil {
+		maps.Copy(originalNGLabels, *configNodeGroups[0].Labels)
+	}
+	// updatedNGLabels must contain both the original and the new labels
 	updatedNGLabels := make(map[string]string)
 	maps.Copy(updatedNGLabels, originalNGLabels)
 	maps.Copy(updatedNGLabels, labels)
 
-	originalNGTags := *configNodeGroups[0].Tags
+	originalNGTags := make(map[string]string)
+	if configNodeGroups[0].Tags != nil {
+		maps.Copy(originalNGTags, *configNodeGroups[0].Tags)
+	}
 	// updatedNGTags must contain both the original and the new tags
 	updatedNGTags := make(map[string]string)
 	maps.Copy(updatedNGTags, originalNGTags)
@@ -674,6 +684,7 @@ func updateTagsAndLabels(cluster *management.Cluster, client *rancher.Client) {
 
 	By("Removing Nodegroup tags & labels", func() {
 		cluster, err = helper.UpdateNodegroupMetadata(cluster, client, originalNGTags, originalNGLabels, true)
+		Expect(err).To(BeNil())
 		for _, ng := range *cluster.EKSConfig.NodeGroups {
 			for key, value := range tags {
 				Expect(*ng.Tags).ToNot(HaveKeyWithValue(key, value))

--- a/hosted/helpers/helper_common.go
+++ b/hosted/helpers/helper_common.go
@@ -177,10 +177,9 @@ func WaitUntilClusterIsReady(cluster *management.Cluster, client *rancher.Client
 
 	err = wait.WatchWait(watchInterface, watchFunc)
 	if err != nil {
-		if err.Error() == wait.WatchConnectionError {
-			ginkgo.GinkgoLogr.Info("Watch connection error, falling back to polling...")
-			err = pollUntilClusterReady(cluster.ID, client)
-		}
+		// Fall back to polling for any watch-related error (connection issues, timeouts, schema errors, etc.)
+		ginkgo.GinkgoLogr.Info(fmt.Sprintf("Watch error (%s), falling back to polling...", err.Error()))
+		err = pollUntilClusterReady(cluster.ID, client)
 		if err != nil {
 			return cluster, err
 		}
@@ -224,6 +223,9 @@ func pollUntilClusterReady(clusterID string, client *rancher.Client) error {
 			if err != nil {
 				ginkgo.GinkgoLogr.Info(fmt.Sprintf("Error polling cluster %s: %v", clusterID, err))
 				continue
+			}
+			if c.Transitioning == "error" {
+				return fmt.Errorf("cluster %s transitioned to error state: %s", clusterID, c.TransitioningMessage)
 			}
 			for _, cond := range c.Conditions {
 				if cond.Type == "Ready" && cond.Status == "True" {


### PR DESCRIPTION
### What does this PR do?
- Remove crust-gather log collection from collect-rancher-logs.sh including installer, collect command, and USAGE.md generation

### Fix EKS P1 test failures

- KMS test: Enable SecretsEncryption alongside KmsKey
- Nil nodegroups test: Use client-side validation instead of waiting for operator error
- Cloud creds test: Fall back to polling on any watch error in WaitUntilClusterIsReady
- Fix nil-pointer panics in Tags/Labels, replace deprecated GPU instance type, remove crust-gather

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [X] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
