### PR TITLE
Fix failure with AKS P1 Provisioning tests and add GCP runner labels for better identification

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -118,7 +118,8 @@ jobs:
           REGION=$(echo ${{ env.GCP_RUNNER_ZONE }} | sed 's/-[abcdef]$//')
           gcloud compute instances create ${{ steps.generator.outputs.runner }} \
             --zone ${{ env.GCP_RUNNER_ZONE }} \
-            --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }}
+            --source-instance-template projects/${{ env.GKE_PROJECT_ID }}/regions/${REGION}/instanceTemplates/${{ inputs.runner_template }} \
+            --labels=owner=${{ github.actor }},team=infracloud-qa,runner=${{ github.run_number }}
       - name: Allow traffic
         run: |
           gcloud compute instances add-tags ${{ steps.generator.outputs.runner }} \

--- a/hosted/aks/p1/p1_provisioning_test.go
+++ b/hosted/aks/p1/p1_provisioning_test.go
@@ -672,7 +672,7 @@ var _ = Describe("P1Provisioning", func() {
 		Eventually(func() bool {
 			cluster, err = ctx.RancherAdminClient.Management.Cluster.ByID(cluster.ID)
 			Expect(err).To(BeNil())
-			return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "Availability zone is not supported in region")
+			return cluster.Transitioning == "error" && strings.Contains(cluster.TransitioningMessage, "availability zones are not supported in region")
 		}, "2m", "2s").Should(BeTrue(), "Timed out while waiting for cluster to error out")
 	})
 


### PR DESCRIPTION
### What does this PR do?
1. Fix [failure](https://github.com/rancher/hosted-providers-e2e/actions/runs/27094003592/job/79962742267) with AKS P1 Provisioning test `P1Provisioning [It] should Create NP with AZ for region where AZ is not supported`
2. Add labels to GCP instances for better identification.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #

### Checklist:
- [ ] Squashed commits into logical changes
- [ ] Documentation
- [x] GitHub Actions (if applicable) - https://github.com/rancher/hosted-providers-e2e/actions/runs/27129313711/job/80066040215#step:18:123

### Special notes for your reviewer:
